### PR TITLE
Bump DM toolkit to 1.1.1 & fix $path variable

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -3,7 +3,7 @@
 @import "_typography.scss";
 
 // Path to assets for use with file-url()
-$path: "/static/";
+$path: "/static/images/";
 
 #wrapper {
   @extend %site-width-container;

--- a/scripts/install_frontend_dependencies.py
+++ b/scripts/install_frontend_dependencies.py
@@ -7,7 +7,7 @@ class DependenciesHandler(object):
 
     dependencies = {
         "govuk_template": "0.12.0",
-        "digital_marketplace_frontend_toolkit": "1.1.0"
+        "digital_marketplace_frontend_toolkit": "1.1.1"
     }
 
     # public methods


### PR DESCRIPTION
Brings in a fix for the paths used in different toolkit modules not working in a consistent way.

(The fix was added in https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/37.)

Previously the paths in `digital-marketplace-frontend-toolkit/toolkit/scss/forms/_multi-select.scss` didn't match those in `digital-marketplace-frontend-toolkit/toolkit/scss/_search-result.scss`.