### PR TITLE
Replace hard-coded filter content with YAML

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,7 +14,15 @@ def create_app(config_name):
     config[config_name].init_app(application)
     questions = QuestionsLoader(
         "app/helpers/content_manifest.yml",
-        "bower_components/digital-marketplace-ssp-content/g6/"
+        "bower_components/digital-marketplace-ssp-content/g6/",
+        [
+            'requirements',
+            'hint',
+            'assuranceApproach',
+            'filters',
+            'mockAnswer',
+            'validations'
+        ]
     )
 
     bootstrap.init_app(application)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask.ext.bootstrap import Bootstrap
 from config import config
+from .helpers.questions import QuestionsLoader
 
 
 bootstrap = Bootstrap()
@@ -11,6 +12,10 @@ def create_app(config_name):
     application = Flask(__name__)
     application.config.from_object(config[config_name])
     config[config_name].init_app(application)
+    questions = QuestionsLoader(
+        "app/helpers/content_manifest.yml",
+        "bower_components/digital-marketplace-ssp-content/g6/"
+    )
 
     bootstrap.init_app(application)
 
@@ -24,43 +29,7 @@ def create_app(config_name):
             'SaaS': 'Software as a Service',
             'SCS': 'Specialist Cloud Services'
         },
-        'SEARCH_FILTERS': [
-            {
-                'legend': 'Service features and management',
-                'filters': [
-                    {
-                        'label': 'Self-service provisioning supported',
-                        'name': 'selfserviceprovisioning',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Offline working and syncing supported',
-                        'name': 'offlineWorking',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Real-time management information available',
-                        'name': 'analyticsAvailable',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Elastic cloud approach supported',
-                        'name': 'elasticCloud',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Guaranteed resources defined',
-                        'name': 'guaranteedResources',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Persistent storage supported',
-                        'name': 'persistentStorage',
-                        'isBoolean': True
-                    }
-                ]
-            }
-        ]
+        'SEARCH_FILTERS': questions.sections
     }
 
     return application

--- a/app/helpers/content_manifest.yml
+++ b/app/helpers/content_manifest.yml
@@ -1,4 +1,9 @@
 -
-  name: Service attributes
+  name: Service features and management
   questions:
+    - selfServiceProvisioning
+    - offlineWorking
+    - analyticsAvailable
     - elasticCloud
+    - guaranteedResources
+    - persistentStorage

--- a/app/helpers/questions.py
+++ b/app/helpers/questions.py
@@ -55,7 +55,6 @@ class QuestionsLoader(object):
 
     def __remove_unused_keys__(self, question):
         keys = [
-            'filterLabel',
             'requirements',
             'hint',
             'assuranceApproach',

--- a/app/helpers/questions.py
+++ b/app/helpers/questions.py
@@ -10,13 +10,14 @@ class QuestionsLoader(object):
     """Interface to the question data from
        https://github.com/alphagov/digital-marketplace-ssp-content/g6"""
 
-    def __init__(self, manifest, content_directory):
+    def __init__(self, manifest, content_directory, unused_keys=[]):
 
         with open(manifest, "r") as file:
             section_order = yaml.load(file)
 
         self._directory = content_directory
         self._question_cache = {}
+        self._unused_keys = unused_keys
         self.sections = [
             self.__populate_section__(s) for s in section_order
         ]
@@ -54,15 +55,7 @@ class QuestionsLoader(object):
         return self._question_cache[question]
 
     def __remove_unused_keys__(self, question):
-        keys = [
-            'requirements',
-            'hint',
-            'assuranceApproach',
-            'filters',
-            'mockAnswer',
-            'validations'
-        ]
-        for key in keys:
+        for key in self._unused_keys:
             if key in question:
                 del question[key]
         return question

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -30,9 +30,8 @@ class SearchFilters(object):
 
     def __set_filter_states(self):
         """Sets a flag on each filter to mark it as set or not"""
-
-        for filter_group in self.filter_groups:
-            for filter in filter_group['filters']:
-                filter['isSet'] = False
-                if filter['name'] in self.request_filters:
-                    filter['isSet'] = True
+        for g_index, filter_group in enumerate(self.filter_groups):
+            for q_index, question in enumerate(filter_group['questions']):
+                self.filter_groups[g_index]['questions'][q_index]['isSet'] = (
+                    question['id'] in self.request_filters
+                )

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -9,7 +9,7 @@
 {% for filter_group in filter_groups %}
 <div class="filter checkbox-filter js-openable-filter closed">
   <div class="head">
-    <span class="legend">{{ filter_group.legend }}</span>
+    <span class="legend">{{ filter_group.name }}</span>
     <div class="controls">
       <a class="clear-selected js-hidden">clear</a>
       <div class="toggle"></div>
@@ -17,12 +17,10 @@
   </div>
   <div class="checkbox-container">
     <div class='js-auto-height-inner'>
-      {% for filter in filter_group.filters %}
+      {% for filter in filter_group.questions %}
       <label for='{{ filter.id }}'>
-        {% if filter.isBoolean %}
-        <input type="checkbox" name="{{ filter.name }}" id="{{ filter.id }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
-        {% endif %}
-        {{ filter.label }}
+        <input type="checkbox" name="{{ filter.id }}" id="{{ filter.id }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
+        {{ filter.filterLabel }}
       </label>
       {% endfor %}
     </div>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [pep8]
-exclude = ./venv,./bower_components,./digital_marketplace_frontend_toolkit
+exclude = ./venv,./bower_components,./node_modules


### PR DESCRIPTION
This does not change which filters we show. It just moves the _definition_ of which filters we show:
- from being hard-coded in the app
- to a YAML manifest which the content loader helper can use to pull in the labels from the content repo

This means changing the keys used in the template to those used by the content repo.

This also fixes the bug that @robyoung noticed where filter state was persisting when it shouldn't.

_N.B. This pull request is against @tombye's branch, not master_