### PR TITLE
Add static filter data

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,8 @@ from dmutils import logging
 
 from .main import main as main_blueprint
 from .status import status as status_blueprint
+from .helpers.questions import QuestionsLoader
+from .presenters.search_presenters import SearchFilters
 
 
 bootstrap = Bootstrap()
@@ -15,6 +17,13 @@ def create_app(config_name):
     application = Flask(__name__)
     application.config.from_object(config[config_name])
     config[config_name].init_app(application)
+    g6_questions = QuestionsLoader(
+        manifest="app/helpers/questions_manifest.yml",
+        questions_dir="bower_components/digital-marketplace-ssp-content/g6/"
+    )
+    filter_groups = SearchFilters.get_filter_groups_from_questions(
+        g6_questions.sections
+    )
 
     bootstrap.init_app(application)
     logging.init_app(application)
@@ -29,43 +38,7 @@ def create_app(config_name):
             'SaaS': 'Software as a Service',
             'SCS': 'Specialist Cloud Services'
         },
-        'SEARCH_FILTERS': [
-            {
-                'legend': 'Service features and management',
-                'filters': [
-                    {
-                        'label': 'Self-service provisioning supported',
-                        'name': 'selfserviceprovisioning',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Offline working and syncing supported',
-                        'name': 'offlineWorking',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Real-time management information available',
-                        'name': 'analyticsAvailable',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Elastic cloud approach supported',
-                        'name': 'elasticCloud',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Guaranteed resources defined',
-                        'name': 'guaranteedResources',
-                        'isBoolean': True
-                    },
-                    {
-                        'label': 'Persistent storage supported',
-                        'name': 'persistentStorage',
-                        'isBoolean': True
-                    }
-                ]
-            }
-        ]
+        'FILTER_GROUPS': filter_groups
     }
 
     return application

--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -1,0 +1,19 @@
+.search-page-filters {
+
+  .govuk-option-select {
+    margin-bottom: 30px;
+  }
+
+  .option-select-label {
+    display: block;
+  }
+
+  .filter-field-text {
+    @include core-16;
+    @include box-sizing(border-box);
+    width: 100%;
+    padding: 5px;
+    border: 1px solid $border-colour;
+  }
+
+}

--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -1,7 +1,18 @@
 .search-page-filters {
+  .lot-filters {
+    h3 {
+      @include bold-19;
+    }
+
+    ul {
+      list-style: none;
+      padding-left: 0;
+      margin: 5px 0 $gutter;
+    }
+  }
 
   .govuk-option-select {
-    margin-bottom: 30px;
+    margin-bottom: $gutter;
   }
 
   .option-select-label {
@@ -15,5 +26,4 @@
     padding: 5px;
     border: 1px solid $border-colour;
   }
-
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -23,13 +23,7 @@ $path: "/static/images/";
 
 @import "_service-page.scss";
 @import "_index-page.scss";
-
-.filter-field-text {
-  @include core-16;
-  @include box-sizing(border-box);
-  width: 100%;
-  padding: 5px;
-}
+@import "_search-result.scss";
 
 .return-to-top {
   display: block;

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -23,7 +23,7 @@ $path: "/static/images/";
 
 @import "_service-page.scss";
 @import "_index-page.scss";
-@import "_search-result.scss";
+@import "_search-page.scss";
 
 .return-to-top {
   display: block;

--- a/app/helpers/questions.py
+++ b/app/helpers/questions.py
@@ -1,0 +1,78 @@
+import yaml
+import inflection
+import re
+import os
+
+from collections import OrderedDict
+
+
+class QuestionsLoader(object):
+
+
+    def __init__(self,
+                 manifest='questions_manifest.yml',
+                 questions_dir=''):
+
+        with open(manifest, "r") as file:
+            section_order = yaml.load(file)
+
+        self._directory = questions_dir 
+        self._question_cache = {}
+        self.sections = [
+            self.__populate_section__(s) for s in section_order
+        ]
+
+    def get_section(self, requested_section):
+
+        for section in self.sections:
+            if section["id"] == requested_section:
+                return section
+
+    def get_question(self, question):
+
+        if question not in self._question_cache:
+
+            question_file = self._directory + question + ".yml"
+
+            if not os.path.isfile(question_file):
+                self._question_cache[question] = {}
+                return {}
+
+            with open(question_file, "r") as file:
+                question_content = yaml.load(file)
+
+            question_content["id"] = question
+
+            # wrong way to do it? question should be shown by default.
+            question_content["depends_on_lots"] = (
+                self.__get_dependent_lots__(question_content["dependsOnLots"])
+            ) if "dependsOnLots" in question_content else (
+                ["saas", "paas", "iaas", "scs"]
+            )
+
+            self._question_cache[question] = question_content
+
+        return self._question_cache[question]
+
+    def __populate_section__(self, section):
+        section["questions"] = [
+            self.get_question(q) for q in section["questions"]
+        ]
+        all_dependencies = [
+            q["depends_on_lots"] for q in section["questions"]
+        ]
+        section["depends_on_lots"] = [
+            y for x in all_dependencies for y in x  # flatten array
+        ]
+        section["id"] = self.__make_id__(section["name"])
+        return section
+
+    def __make_id__(self, name):
+        return inflection.underscore(
+            re.sub("\s", "_", name)
+        )
+
+    def __get_dependent_lots__(self, dependent_lots_as_string):
+        return [
+            x.strip() for x in dependent_lots_as_string.lower().split(",")
+        ]

--- a/app/helpers/questions.py
+++ b/app/helpers/questions.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 
 class QuestionsLoader(object):
 
-
     def __init__(self,
                  manifest='questions_manifest.yml',
                  questions_dir=''):
@@ -16,7 +15,7 @@ class QuestionsLoader(object):
         with open(manifest, "r") as file:
             section_order = yaml.load(file)
 
-        self._directory = questions_dir 
+        self._directory = questions_dir
         self._question_cache = {}
         self.sections = [
             self.__populate_section__(s) for s in section_order

--- a/app/helpers/questions_manifest.yml
+++ b/app/helpers/questions_manifest.yml
@@ -3,6 +3,8 @@
   questions:
     - freeOption
     - trialOption
+    - educationPricing
+    - terminationCost
 -
   name: Minimum contract period
   questions:
@@ -10,18 +12,11 @@
 -
   name: Service management
   questions:
-    - serviceOnboarding
-    - serviceOffboarding
     - dataExtractionRemoval
     - datacentresEUCode
     - dataBackupRecovery
     - selfServiceProvisioning
-    - provisioningTime
     - supportForThirdParties
--
-  name: Data centre tier
-  questions:
-    - datacentreTier
 -
   name: Networks the service is directly connected to
   questions:
@@ -32,3 +27,9 @@
     - apiAccess
     - openStandardsSupported
     - openSource
+-
+  name: Cloud features 
+  questions:
+    - persistentStorage
+    - guaranteedResources
+    - elasticCloud

--- a/app/helpers/questions_manifest.yml
+++ b/app/helpers/questions_manifest.yml
@@ -1,0 +1,34 @@
+-
+  name: Pricing
+  questions:
+    - freeOption
+    - trialOption
+-
+  name: Minimum contract period
+  questions:
+    - minimumContractPeriod
+-
+  name: Service management
+  questions:
+    - serviceOnboarding
+    - serviceOffboarding
+    - dataExtractionRemoval
+    - datacentresEUCode
+    - dataBackupRecovery
+    - selfServiceProvisioning
+    - provisioningTime
+    - supportForThirdParties
+-
+  name: Data centre tier
+  questions:
+    - datacentreTier
+-
+  name: Networks the service is directly connected to
+  questions:
+    - networksConnected
+-
+  name: Interoperability
+  questions:
+    - apiAccess
+    - openStandardsSupported
+    - openSource

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -66,6 +66,7 @@ def search():
     search_results_json = response
     template_data = get_template_data(main, {
         'title': 'Search results',
+        'current_lot': SearchFilters.get_current_lot(request),
         'lots': search_filters_obj.lot_filters,
         'search_keywords': search_keywords,
         'filter_groups': search_filters_obj.filter_groups,

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,17 +1,19 @@
 # coding=utf-8
 
+import os
+import re
 import json
+
 from . import main
 from app import models
 from flask import abort, render_template, request, Response
 from ..presenters.search_presenters import SearchFilters
+from ..presenters.service_presenters import Service
 from ..helpers.search_helpers import (
     get_keywords_from_request, get_template_data
 )
-from ..exceptions import AuthException
 from ..helpers.service_helpers import get_lot_name_from_acronym
-import json
-from ..presenters.service_presenters import Service
+from ..exceptions import AuthException
 
 
 @main.route('/')
@@ -59,13 +61,25 @@ def search():
     search_filters_obj = SearchFilters(blueprint=main, request=request)
     response = models.search_for_services(
         query=search_keywords,
-        filters=search_filters_obj.get_request_filters()
+        filters=search_filters_obj.request_filters
     )
-    search_results_json = json.loads(response)
+    search_results_json = response
     template_data = get_template_data(main, {
         'title': 'Search results',
         'search_keywords': search_keywords,
-        'filter_groups': search_filters_obj.get_filter_groups(),
+        'filter_groups': search_filters_obj.filter_groups,
         'services': search_results_json['services']
     })
     return render_template('search.html', **template_data)
+
+
+def _get_questions():
+    question_sections_manifest = os.path.abspath(os.path.join(
+        os.path.dirname(__file__),
+        "../helpers/question_sections_manifest.yml"
+    ))
+    questions_directory = os.path.abspath(os.path.join(
+        os.path.dirname(__file__),
+        "../../bower_components/digital-marketplace-ssp-content/g6"
+    ))
+    return QuestionsLoader(question_sections_manifest, questions_directory)

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -66,6 +66,7 @@ def search():
     search_results_json = response
     template_data = get_template_data(main, {
         'title': 'Search results',
+        'lots': search_filters_obj.lot_filters,
         'search_keywords': search_keywords,
         'filter_groups': search_filters_obj.filter_groups,
         'services': search_results_json['search']['services']

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -68,7 +68,7 @@ def search():
         'title': 'Search results',
         'search_keywords': search_keywords,
         'filter_groups': search_filters_obj.filter_groups,
-        'services': search_results_json['services']
+        'services': search_results_json['search']['services']
     })
     return render_template('search.html', **template_data)
 

--- a/app/models.py
+++ b/app/models.py
@@ -48,7 +48,7 @@ def get_service(service_id):
 
 def search_for_services(query="", filters={}):
     payload = {'q': query}
-    for k, v in filters.iteritems():
+    for k, v in filters.items():
         payload[k] = v
     response = requests.get(
         search_url,
@@ -57,4 +57,4 @@ def search_for_services(query="", filters={}):
             "authorization": "Bearer {}".format(search_access_token)
         }
     )
-    return response.content
+    return response.json()

--- a/app/models.py
+++ b/app/models.py
@@ -1,12 +1,16 @@
 import requests
 import os
+import urlparse
 from flask import json
 from .exceptions import AuthException
 
 
 api_url = os.getenv('DM_API_URL')
 api_access_token = os.getenv('DM_BUYER_FRONTEND_API_AUTH_TOKEN')
-search_url = os.getenv('DM_SEARCH_API_URL') + "/search"
+search_url = urlparse.urljoin(
+    os.getenv('DM_SEARCH_API_URL'),
+    'g-cloud/services/search'
+)
 search_access_token = os.getenv('DM_BUYER_FRONTEND_SEARCH_API_AUTH_TOKEN')
 
 if api_access_token is None:
@@ -50,6 +54,7 @@ def search_for_services(query="", filters={}):
     payload = {'q': query}
     for k, v in filters.items():
         payload[k] = v
+    '''
     response = requests.get(
         search_url,
         params=payload,
@@ -58,3 +63,15 @@ def search_for_services(query="", filters={}):
         }
     )
     return response.json()
+    '''
+
+    search_results_stub_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..", 
+            "tests", 
+            "fixtures",
+            "search_results.json"
+        )
+    )
+    return json.load(open(search_results_stub_path))

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,9 @@
 import requests
 import os
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    from urllib import parse as urlparse
 from flask import json
 from .exceptions import AuthException
 

--- a/app/models.py
+++ b/app/models.py
@@ -68,8 +68,8 @@ def search_for_services(query="", filters={}):
     search_results_stub_path = os.path.abspath(
         os.path.join(
             os.path.dirname(__file__),
-            "..", 
-            "tests", 
+            "..",
+            "tests",
             "fixtures",
             "search_results.json"
         )

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -3,7 +3,7 @@ class SearchFilters(object):
     """
 
     @staticmethod
-    def get_filters_from_boolean_question(question):
+    def get_filters_from_default_question(question):
         # boolean questions have no options as 'Yes' or 'No' is
         # implied
         return {
@@ -33,7 +33,9 @@ class SearchFilters(object):
     def get_filter_groups_from_questions(question_sections):
         filter_groups = []
         get_filter_for = {
-            'boolean': SearchFilters.get_filters_from_boolean_question,
+            'boolean': SearchFilters.get_filters_from_default_question,
+            'text': SearchFilters.get_filters_from_default_question,
+            'pricing': SearchFilters.get_filters_from_default_question,
             'options': SearchFilters.get_filters_from_question_with_options
         }
         for section in question_sections:
@@ -44,8 +46,16 @@ class SearchFilters(object):
             }
             for question in section['questions']:
                 questionType = question['type']
-                if (questionType == 'boolean') or (questionType == 'text'):
+                if questionType == 'boolean':
                     filter_group['filters'].append(get_filter_for['boolean'](
+                        question
+                    ))
+                elif questionType == 'text':
+                    filter_group['filters'].append(get_filter_for['text'](
+                        question
+                    ))
+                elif questionType == 'pricing':
+                    filter_group['filters'].append(get_filter_for['pricing'](
                         question
                     ))
                 else:

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -82,7 +82,7 @@ class SearchFilters(object):
                 if (lot == 'all'):
                     if _filter_is_in_all_lots(filter):
                         sifted_group['filters'].append(filter)
-                else: # lot is singular
+                else:  # lot is singular
                     if lot in filter['lots']:
                         sifted_group['filters'].append(filter)
             if len(sifted_group['filters']) > 0:
@@ -133,7 +133,7 @@ class SearchFilters(object):
                 'url': _get_url(keywords=keywords, lot='scs')
             }
         ]
-        if current_lot != None:
+        if current_lot is not None:
             lot_filters[lot_names.index(current_lot)]['isActive'] = True
         return lot_filters
 
@@ -145,7 +145,7 @@ class SearchFilters(object):
         for key in request.args:
             if key != 'q':
                 arg_value = request.args.get(key, None)
-                if arg_value != None:
+                if arg_value is not None:
                     filters[key] = arg_value
         return filters
 

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -55,7 +55,56 @@ class SearchFilters(object):
     def __init__(self, blueprint=False, request={}):
         self.filter_groups = blueprint.config['FILTER_GROUPS']
         self.request_filters = self.__get_filters_from_request(request)
+        self.lot_filters = self.__get_lot_filters_from_request(request)
         self.__set_filter_states()
+
+    def __get_lot_filters_from_request(self, request):
+        """Returns data to construct lot filters from"""
+
+        def _get_url(keywords=None, lot=None):
+            params = []
+            if keywords is not None:
+                params.append('q=' + keywords)
+            if lot is not None:
+                params.append('lot=' + lot)
+            if len(params) == 0:
+                return '/search'
+            else:
+                return '/search?' + '&'.join(params)
+
+        lot_names = ['all', 'saas', 'paas', 'iaas', 'scs']
+        current_lot = request.args.get('lot', 'all')
+        keywords = request.args.get('q', None)
+        lot_filters = [
+            {
+                'isActive': False,
+                'label': u'All categories',
+                'url': _get_url(keywords=keywords)
+            },
+            {
+                'isActive': False,
+                'label': u'Software as a Service',
+                'url': _get_url(keywords=keywords, lot='saas')
+            },
+            {
+                'isActive': False,
+                'label': u'Platform as a Service',
+                'url': _get_url(keywords=keywords, lot='paas')
+            },
+            {
+                'isActive': False,
+                'label': u'Infrastructure as a Service',
+                'url': _get_url(keywords=keywords, lot='iaas')
+            },
+            {
+                'isActive': False,
+                'label': u'Specialist Cloud Services',
+                'url': _get_url(keywords=keywords, lot='scs')
+            }
+        ]
+        if current_lot != None:
+            lot_filters[lot_names.index(current_lot)]['isActive'] = True
+        return lot_filters
 
     def __get_filters_from_request(self, request):
         """Returns the filters applied to a search from the request object"""
@@ -64,7 +113,9 @@ class SearchFilters(object):
         filters = {}
         for key in request.args:
             if key != 'q':
-                filters[key] = request.args[key]
+                arg_value = request.args.get(key, None)
+                if arg_value != None:
+                    filters[key] = arg_value
         return filters
 
     def __set_filter_states(self):

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -3,6 +3,14 @@ class SearchFilters(object):
     """
 
     @staticmethod
+    def get_current_lot(request):
+        current_lot = request.args.get('lot', None)
+        if current_lot is not None:
+            return current_lot
+        else:
+            return False
+
+    @staticmethod
     def get_filters_from_default_question(question):
         # boolean questions have no options as 'Yes' or 'No' is
         # implied

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -1,4 +1,4 @@
-{% from 'macros/_filter_options.html' import radio, checkbox %}
+{% from 'macros/_filters.html' import checkbox %}
 <div class="govuk-option-select">
   <div class="container-head">
     <label class="option-select-label" for="keywords">
@@ -10,28 +10,12 @@
 {% for filter_group in filter_groups %}
 <div class="govuk-option-select">
   <div class="container-head js-container-head">
-    <div class="option-select-label">{{ filter_group.name }}</div>
+    <div class="option-select-label">{{ filter_group.label }}</div>
   </div>
   <div class="options-container">
     <div class='js-auto-height-inner'>
-      {% for filter in filter_group.questions %}
-        {% if filter['type'] == 'boolean' %}
-          {{ checkbox(filter.filterLabel, filter.id, filter.id, filter.isSet, 'js-search-results.info') }}
-        {% endif %}
-        {% if filter['type'] == 'checkboxes' or filter['type'] == 'checkboxes' %}
-          {% for option in filter.options %}
-            {% if option.filterLabel %}
-              {{ checkbox(option.filterLabel, '%s--%s' % (filter.id, loop.index), '%s--%s' % (filter.id, loop.index), filter.isSet, 'js-search-results.info') }}
-            {% endif %}
-          {% endfor %}
-        {% endif %}
-        {% if filter['type'] == 'radio' or filter['type'] == 'radios' %}
-          {% for option in filter.options %}
-            {% if option.filterLabel %}
-              {{ radio(option.filterLabel, '%s--%s' % (filter.id, loop.index), '%s--%s' % (filter.id, loop.index), filter.isSet, 'js-search-results.info') }}
-            {% endif %}
-          {% endfor %}
-        {% endif %}
+      {% for filter in filter_group.filters %}
+        {{ checkbox(filter.label, filter.name, filter.id, filter.isSet, 'js-search-results.info') }}
       {% endfor %}
     </div>
   </div>

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -1,4 +1,13 @@
-{% from 'macros/_filters.html' import checkbox %}
+{% from 'macros/_filters.html' import checkbox, lot_filters %}
+<ul>
+{% for lot in lots %}
+  {% if lot.isActive %}
+    <li>{{ lot.label }}</li>
+  {% else %}
+    <li><a href="{{ lot.url }}">{{ lot.label }}</a></li>
+  {% endif %}
+{% endfor %}
+</ul>
 <div class="govuk-option-select">
   <div class="container-head">
     <label class="option-select-label" for="keywords">

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -1,21 +1,17 @@
-<div class="filter checkbox-filter">
-  <div class="head">
-    <label class="legend" for="keywords">
+<div class="govuk-option-select">
+  <div class="container-head">
+    <label class="option-select-label" for="keywords">
       Keywords
     </label>
   </div>
   <input class="filter-field-text" type="text" name="q" id="keywords" value="{{ search_keywords }}">
 </div>
 {% for filter_group in filter_groups %}
-<div class="filter checkbox-filter js-openable-filter closed">
-  <div class="head">
-    <span class="legend">{{ filter_group.name }}</span>
-    <div class="controls">
-      <a class="clear-selected js-hidden">clear</a>
-      <div class="toggle"></div>
-    </div>
+<div class="govuk-option-select">
+  <div class="container-head js-container-head">
+    <div class="option-select-label">{{ filter_group.name }}</div>
   </div>
-  <div class="checkbox-container">
+  <div class="options-container">
     <div class='js-auto-height-inner'>
       {% for filter in filter_group.questions %}
         {% if filter['type'] == 'boolean' %}

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -16,6 +16,9 @@
   </div>
   <input class="filter-field-text" type="text" name="q" id="keywords" value="{{ search_keywords }}">
 </div>
+{% if current_lot %}
+<input type="hidden" name="lot" value="{{ current_lot }}" />
+{% endif %}
 {% for filter_group in filter_groups %}
 <div class="govuk-option-select">
   <div class="container-head js-container-head">

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -9,7 +9,7 @@
 {% for filter_group in filter_groups %}
 <div class="filter checkbox-filter js-openable-filter closed">
   <div class="head">
-    <span class="legend">{{ filter_group.legend }}</span>
+    <span class="legend">{{ filter_group.name }}</span>
     <div class="controls">
       <a class="clear-selected js-hidden">clear</a>
       <div class="toggle"></div>
@@ -17,16 +17,14 @@
   </div>
   <div class="checkbox-container">
     <div class='js-auto-height-inner'>
-      {% for filter in filter_group.filters %}
+      {% for filter in filter_group.questions %}
       <label for='{{ filter.id }}'>
-        {% if filter.isBoolean %}
-        <input type="checkbox" name="{{ filter.name }}" id="{{ filter.id }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
-        {% endif %}
-        {{ filter.label }}
+        <input type="checkbox" name="{{ filter.id }}" id="{{ filter.id }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
+        {{ filter.filterLabel }}
       </label>
       {% endfor %}
     </div>
   </div>
-{% endfor %}
 </div>
+{% endfor %}
 <button class="button-save" type="submit">Filter</button>

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -1,3 +1,4 @@
+{% from 'macros/_filter_options.html' import radio, checkbox %}
 <div class="govuk-option-select">
   <div class="container-head">
     <label class="option-select-label" for="keywords">
@@ -15,28 +16,19 @@
     <div class='js-auto-height-inner'>
       {% for filter in filter_group.questions %}
         {% if filter['type'] == 'boolean' %}
-          <label for='{{ filter.id }}'>
-            <input type="checkbox" name="{{ filter.id }}" id="{{ filter.id }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
-            {{ filter.filterLabel }}
-          </label>
+          {{ checkbox(filter.filterLabel, filter.id, filter.id, filter.isSet, 'js-search-results.info') }}
         {% endif %}
         {% if filter['type'] == 'checkboxes' or filter['type'] == 'checkboxes' %}
           {% for option in filter.options %}
             {% if option.filterLabel %}
-              <label for='{{ filter.id }}-{{ loop.index }}'>
-                <input type="checkbox" name="{{ filter.id }}" id="{{ filter.id }}-{{ loop.index }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
-                {{ option.filterLabel }}
-              </label>
+              {{ checkbox(option.filterLabel, '%s--%s' % (filter.id, loop.index), '%s--%s' % (filter.id, loop.index), filter.isSet, 'js-search-results.info') }}
             {% endif %}
           {% endfor %}
         {% endif %}
         {% if filter['type'] == 'radio' or filter['type'] == 'radios' %}
           {% for option in filter.options %}
             {% if option.filterLabel %}
-              <label for='{{ filter.id }}-{{ loop.index }}'>
-                <input type="checkbox" name="{{ filter.id }}" id="{{ filter.id }}-{{ loop.index }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
-                {{ option.filterLabel }}
-              </label>
+              {{ radio(option.filterLabel, '%s--%s' % (filter.id, loop.index), '%s--%s' % (filter.id, loop.index), filter.isSet, 'js-search-results.info') }}
             {% endif %}
           {% endfor %}
         {% endif %}

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -18,10 +18,32 @@
   <div class="checkbox-container">
     <div class='js-auto-height-inner'>
       {% for filter in filter_group.questions %}
-      <label for='{{ filter.id }}'>
-        <input type="checkbox" name="{{ filter.id }}" id="{{ filter.id }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
-        {{ filter.filterLabel }}
-      </label>
+        {% if filter['type'] == 'boolean' %}
+          <label for='{{ filter.id }}'>
+            <input type="checkbox" name="{{ filter.id }}" id="{{ filter.id }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
+            {{ filter.filterLabel }}
+          </label>
+        {% endif %}
+        {% if filter['type'] == 'checkboxes' or filter['type'] == 'checkboxes' %}
+          {% for option in filter.options %}
+            {% if option.filterLabel %}
+              <label for='{{ filter.id }}-{{ loop.index }}'>
+                <input type="checkbox" name="{{ filter.id }}" id="{{ filter.id }}-{{ loop.index }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
+                {{ option.filterLabel }}
+              </label>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% if filter['type'] == 'radio' or filter['type'] == 'radios' %}
+          {% for option in filter.options %}
+            {% if option.filterLabel %}
+              <label for='{{ filter.id }}-{{ loop.index }}'>
+                <input type="checkbox" name="{{ filter.id }}" id="{{ filter.id }}-{{ loop.index }}" value="True" aria-controls="js-search-results-info" {% if filter.isSet %}checked="checked"{% endif %} />
+                {{ option.filterLabel }}
+              </label>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -1,13 +1,16 @@
-{% from 'macros/_filters.html' import checkbox, lot_filters %}
-<ul>
-{% for lot in lots %}
-  {% if lot.isActive %}
-    <li>{{ lot.label }}</li>
-  {% else %}
-    <li><a href="{{ lot.url }}">{{ lot.label }}</a></li>
-  {% endif %}
-{% endfor %}
-</ul>
+<div class="lot-filters">
+  <h3>Choose a category</h3>
+  {% from 'macros/_filters.html' import checkbox, lot_filters %}
+  <ul>
+  {% for lot in lots %}
+    {% if lot.isActive %}
+      <li>{{ lot.label }}</li>
+    {% else %}
+      <li><a href="{{ lot.url }}">{{ lot.label }}</a></li>
+    {% endif %}
+  {% endfor %}
+  </ul>
+</div>
 <div class="govuk-option-select">
   <div class="container-head">
     <label class="option-select-label" for="keywords">

--- a/app/templates/macros/_filters.html
+++ b/app/templates/macros/_filters.html
@@ -1,10 +1,3 @@
-{% macro radio(label, name, id, checked, results_container_id) -%}
-<label for='{{ id }}'>
-  <input type="radio" name="{{ id }}" id="{{ id }}" value="True" aria-controls="{{ results_container_id }}" {% if isSet %}checked="checked"{% endif %} />
-  {{ label }}
-</label>
-{%- endmacro %}
-
 {% macro checkbox(label, name, id, checked, results_container_id) -%}
 <label for='{{ id }}'>
   <input type="checkbox" name="{{ id }}" id="{{ id }}" value="True" aria-controls="{{ results_container_id }}" {% if isSet %}checked="checked"{% endif %} />

--- a/app/templates/macros/_filters.html
+++ b/app/templates/macros/_filters.html
@@ -1,0 +1,13 @@
+{% macro radio(label, name, id, checked, results_container_id) -%}
+<label for='{{ id }}'>
+  <input type="radio" name="{{ id }}" id="{{ id }}" value="True" aria-controls="{{ results_container_id }}" {% if isSet %}checked="checked"{% endif %} />
+  {{ label }}
+</label>
+{%- endmacro %}
+
+{% macro checkbox(label, name, id, checked, results_container_id) -%}
+<label for='{{ id }}'>
+  <input type="checkbox" name="{{ id }}" id="{{ id }}" value="True" aria-controls="{{ results_container_id }}" {% if isSet %}checked="checked"{% endif %} />
+  {{ label }}
+</label>
+{%- endmacro %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -6,7 +6,7 @@
 </header>
 <form action="/search" method="get">
   <div class="grid-row">
-    <div class="column-one-third">
+    <div class="column-one-third search-page-filters">
     {% include '_search_filters.html' %}
     </div>
     <div class="column-two-thirds">

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "jquery": "1.11.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace_frontend_toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v2.0.2",
-    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz"
+    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#da2a7defe28bd7d9154a2e20769c50b41414b485"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var jsVendorFiles = [
   bowerRoot + '/jquery-details/jquery.details.js'
 ];
 var jsSourceFiles = [
-  dmToolkitRoot + '/javascripts/multi-selects.js',
+  dmToolkitRoot + '/javascripts/option-select.js',
   assetsFolder + '/javascripts/_onready.js'
 ];
 var jsDistributionFolder = staticFolder + '/javascripts';
@@ -113,7 +113,7 @@ gulp.task('js', function () {
   var stream = gulp.src(jsFiles)
     .pipe(filelog('Compressing JavaScript files'))
     .pipe(uglify(
-      jsDistributionFile, 
+      jsDistributionFile,
       uglifyOptions[environment]
     ))
     .pipe(gulp.dest(jsDistributionFolder));
@@ -195,8 +195,8 @@ gulp.task('watch', ['build:development'], function () {
     console.log('File ' + event.path + ' was ' + event.type + ' running tasks...');
   }
 
-  cssWatcher.on('change', notice); 
-  jsWatcher.on('change', notice); 
+  cssWatcher.on('change', notice);
+  jsWatcher.on('change', notice);
 });
 
 gulp.task('set_environment_to_development', function (cb) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ Flask==0.10.1
 Flask-Bootstrap==3.3.0.1
 Flask-Script==2.0.5
 requests==2.5.1
+inflection==0.2.1
+pyyaml==3.11
 -e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.2.0#egg=digitalmarketplace-utils
 
 # Required for SNI to work in requests

--- a/tests/fixtures/search_results.json
+++ b/tests/fixtures/search_results.json
@@ -1,0 +1,140 @@
+{
+    "search": {
+        "services": [{
+            "serviceSummary": "The Vodafone Secure Mail service is a business-class email system based on Microsoft Exchange\u2122. It provides a secure and robust email service, and includes an inbox, calendar, contacts, tasks and folders",
+            "serviceName": "Secure Email",
+            "serviceTypes": ["Collaboration"],
+            "lot": "SaaS",
+            "highlight": {
+                "serviceSummary": ["The Vodafone Secure Mail service is a business-class <em>email</em> system based on Microsoft Exchange\u2122. It", " provides a secure and robust <em>email</em> service, and includes an inbox, calendar, contacts, tasks and folders"],
+                "serviceFeatures": ["Exchange-based secure <em>email</em> service", "Support for migration from other <em>email</em> available"],
+                "serviceName": ["Secure <em>Email</em>"]
+            },
+            "serviceFeatures": ["Exchange-based secure email service", "Support for migration from other email available", "Supports Official and Official Sensitive Data ", "Remote and Mobile access"],
+            "supplierName": "supplier",
+            "serviceBenefits": ["Secure, managed service ", "Fully resilient service ", "UK based"]
+        }, {
+            "serviceSummary": "Integration of email to enable documents to be emailed from the Store.",
+            "serviceName": "Manage Email",
+            "serviceTypes": ["Implementation", "Ongoing support", "Planning", "Testing", "Training"],
+            "lot": "SCS",
+            "highlight": {
+                "serviceSummary": ["Integration of <em>email</em> to enable documents to be emailed from the Store."],
+                "serviceFeatures": ["Integration of user's <em>email</em>"],
+                "serviceName": ["Manage <em>Email</em>"],
+                "serviceBenefits": ["Intergrated <em>email</em> support"]
+            },
+            "serviceFeatures": ["Integration of user's email", "Notification emails"],
+            "supplierName": "supplier.name",
+            "serviceBenefits": ["User messaging options", "Intergrated email support"]
+        }, {
+            "serviceSummary": "twentysix run email marketing and loyalty programmes for many clients.  We offer the full range of services from email design and build, targeting and data segmentation through to distribution, testing, deployment and reporting.  Our experience includes working with renown brands on multilingual Pan-European and Global eCRM campaigns.",
+            "serviceName": "Email Marketing",
+            "serviceTypes": ["Implementation", "Ongoing support", "Planning", "Testing", "Training"],
+            "lot": "SCS",
+            "highlight": {
+                "serviceSummary": ["twentysix run <em>email</em> marketing and loyalty programmes for many clients.  We offer the full range of", " services from <em>email</em> design and build, targeting and data segmentation through to distribution"],
+                "serviceFeatures": ["<em>Email</em> Design", "<em>Email</em> Copywriting", "<em>Email</em> Build"],
+                "serviceName": ["<em>Email</em> Marketing"]
+            },
+            "serviceFeatures": ["Targeting and Data Segmentation", "Email Design", "Email Copywriting", "Email Build", "Split Testing", "Tracking", "Management of deployment platforms", "Analysis and Reporting", "eCRM Programme Development", "Content Calendar Planning"],
+            "supplierName": "supplier",
+            "serviceBenefits": ["Creativity to achieve cut-through", "Advanced Targeting and Segmentation", "Integration with wider marketing mix", "Measurement and Analysis"]
+        }, {
+            "serviceSummary": "Increase email delivery rates and the ROI of your marketing campaigns by checking addresses as they\u2019re typed, or in bulk.\r\nOur cloud-based technology uses self-learning algorithms so that it constantly evolves to deliver the most accurate results without requiring you to make any updates.",
+            "serviceName": "Email Verification",
+            "serviceTypes": ["Data management"],
+            "lot": "SaaS",
+            "highlight": {
+                "serviceSummary": ["Increase <em>email</em> delivery rates and the ROI of your marketing campaigns by checking addresses as"],
+                "serviceFeatures": ["Verify <em>email</em> addresses at the point of entry", "Validate <em>email</em> address format", "Live <em>email</em> account", "Safe to <em>email</em>"],
+                "serviceName": ["<em>Email</em> Verification"],
+                "serviceBenefits": ["Increase <em>email</em> deliverability"]
+            },
+            "serviceFeatures": ["Verify email addresses at the point of entry", "Validate email address format", "Live email account", "Safe to email", "Untraceable ping of the account"],
+            "supplierName": "supplier",
+            "serviceBenefits": ["Increase email deliverability", "Reduce bogus registrations", "Protect your reputation", "Prevent fraud", "Reduce bounce rates", "Improve customer mailing"]
+        }, {
+            "serviceSummary": "Dyn Email Delivery is a cloud-based email delivery engine, designed for both transactional and bulk/marketing campaign email. Along with sending email generated by an application, Dyn\u2019s email solution is integrated with the leading marketing automation and email template/management solutions.",
+            "serviceName": "Dyn Email Delivery",
+            "serviceTypes": ["Business intelligence and analytics", "Customer relationship management (CRM)", "IT management", "Marketing", "Operations management", "Security"],
+            "lot": "SaaS",
+            "highlight": {
+                "serviceSummary": ["Dyn <em>Email</em> Delivery is a cloud-based <em>email</em> delivery engine, designed for both transactional and bulk", "/marketing campaign <em>email</em>. Along with sending <em>email</em> generated by an application, Dyn\u2019s <em>email</em>", " solution is integrated with the leading marketing automation and <em>email</em> template/management solutions."],
+                "serviceName": ["Dyn <em>Email</em> Delivery"]
+            },
+            "serviceFeatures": ["API integration", "Postback service", "Deliverability support and ISP/Mailbox provider remediation", "Advanced reporting"],
+            "supplierName": "supplier",
+            "serviceBenefits": ["Inbox success", "IP pool flexibility", "Advanced tagging and segmenting"]
+        }, {
+            "serviceSummary": "Mimecast Email Archive is a secure, scalable, cloud-based archive that can significantly reduce the complexity of your email infrastructure. Unrivalled integration with Microsoft Outlook gives users a bottomless mailbox, while superior mailbox management capability helps reduce the load on Exchange. Compliance officers benefit from near real time searches.",
+            "serviceName": "Mimecast Email Archiving",
+            "serviceTypes": ["Data management"],
+            "lot": "SaaS",
+            "highlight": {
+                "serviceSummary": ["Mimecast <em>Email</em> Archive is a secure, scalable, cloud-based archive that can significantly reduce the", " complexity of your <em>email</em> infrastructure. Unrivalled integration with Microsoft Outlook gives users"],
+                "serviceFeatures": ["Highly secure, resilient, bottomless <em>email</em> storage"],
+                "serviceName": ["Mimecast <em>Email</em> Archiving"],
+                "serviceBenefits": ["Export <em>email</em> to Outlook from a Personal archive"]
+            },
+            "serviceFeatures": ["Highly secure, resilient, bottomless email storage", "All stored data is encrypted", "Data stored in defined, appropriate jurisdictions", "Unrivalled integration with Microsoft Outlook", "Mobile search app available for all major mobile devices", "Near real-time organization-wide search", "Granular litigation hold functionality", "100% service availability SLA", "Sub 7 second archive search SLA", "No additional on-premises hardware required"],
+            "supplierName": "supplier",
+            "serviceBenefits": ["Bottomless user mailboxes", "Personal archive access from Outlook, MAC, tablet and mobile devices", "ediscovery and case management easily accomplished", "archive retention and message purge tools", "Near real-time search", "Familiar Personal folder structures presented in Mimecast Personal Portal", "Smart Tagged Message folders and search for collaboration", "View recent and saved archive searches in Outlook", "Export email to Outlook from a Personal archive", "ediscovery exports in ZIP, PST or EDRM XML"]
+        }, {
+            "serviceSummary": "All archived mail is encrypted. Set policy levels, what mail requires archiving and who has access to the archive. Mail is stored in multiple geographically diverse locations within the UK. Archive all mail to or from a domain, individual users or groups of users with retention periods from one year. ",
+            "serviceName": "Secure Email Archiving",
+            "serviceTypes": ["Ongoing support"],
+            "lot": "SCS",
+            "highlight": {
+                "serviceName": ["Secure <em>Email</em> Archiving"],
+                "serviceBenefits": ["Reduce the total cost of ownership of <em>email</em> "]
+            },
+            "serviceFeatures": ["Import of legacy data ", "Tamper proof archive for eDiscovery and legal compliance ", "Unlimited archive storage ", "Global search across all mail ", "Recover and download multiple emails for legal or HR purposes ", "Granular access to individual\u2019s archive if required ", "Full LDAP integration ", "Archive of external and internal emails ", "Complete policy flexibility "],
+            "supplierName": "supplier",
+            "serviceBenefits": ["Unlimited Storage as standard ", "Achieve Legal and Compliance targets", "Granular and flexible retention policies ", "Reduce the total cost of ownership of email ", "Fault tolerant and scalable platform ", "Guaranteed 100% availability on all infrastructure (power, cooling and network) "]
+        }, {
+            "serviceSummary": "As professionals you\u2019re under pressure to cut costs, become more productive, whilst making yourself more available to clients and colleagues. So when the time comes to move to a Hosted Exchange platform, make sure you choose a platform that guarantees you peace of mind from a provider you can trust. ",
+            "serviceName": "Microsoft Exchange Email Services",
+            "serviceTypes": ["Collaboration"],
+            "lot": "SaaS",
+            "highlight": {
+                "serviceFeatures": ["Mobile <em>email</em> \u2018push\u2019 technology"],
+                "serviceName": ["Microsoft Exchange <em>Email</em> Services"]
+            },
+            "serviceFeatures": ["Microsoft Exchange features", "Instant deployment", "Massive 50GB per mailbox", "Mobile email \u2018push\u2019 technology", "Shared calendars and contacts", "Redundant networks", "Award-winning Anti-Spam", "Advance security options available "],
+            "supplierName": "supplier",
+            "serviceBenefits": ["Reduced IT infrastructure costs", "Enhanced security", "No upgrades or repairs", "Easy mailbox control", "Instant scalability", "Workforce mobility"]
+        }, {
+            "serviceSummary": "Our migration service covers on-premise, third-party hosted or public cloud Exchange-based email processes, and supports migration from earlier versions of Exchange/Lotus Domino/Notes to the latest version of Microsoft Exchange. Experience of 10M+ mailboxes, in highly regulated markets. Partnerships with VMware, RSA and Microsoft ensure highly scalable, secure and flexible deployments.",
+            "serviceName": "Email Migration and Modernisation",
+            "serviceTypes": ["Implementation", "Planning"],
+            "lot": "SCS",
+            "highlight": {
+                "serviceSummary": ["Our migration service covers on-premise, third-party hosted or public cloud Exchange-based <em>email</em>"],
+                "serviceName": ["<em>Email</em> Migration and Modernisation"]
+            },
+            "serviceFeatures": ["Highly experienced professional consultants", "Proven Assured Performance tool and dedicated 24hr migration factory ", "Accelerated timescales, lower project risk and project cost savings", "Work package:  Requirements gathering ", "Work package:  Designing platform architecture ", "Work package:  Construction ", "Work package:  Migration and deployment "],
+            "supplierName": "supplier",
+            "serviceBenefits": ["Ensures predictable outcomes, minimised risk, maximised productivity during technology change", "Accelerated ability to use enhanced capabilities of Microsoft Exchange ", "Greater scaling power and performance per user/server", "Improved protection and reliability", "Lower management cost", "Improved unified messaging and collaboration", "Improved operations and regulatory compliance", "Enhanced mobility features", "Accelerated timescales", "Lower project risk, release of project cost savings"]
+        }, {
+            "serviceSummary": "Mimecast Email Security is a comprehensive cloud-based email security and compliance solution on the market today. Mimecast\u2019s massively scalable mail transfer agent with multiple layers of malware and spam protection acts as your email bridgehead, stopping known and emerging email borne threats before they reach your network.",
+            "serviceName": "Mimecast Email Security",
+            "serviceTypes": ["Data management", "IT management", "Legal", "Security"],
+            "lot": "SaaS",
+            "highlight": {
+                "serviceSummary": ["Mimecast <em>Email</em> Security is a comprehensive cloud-based <em>email</em> security and compliance solution on", " and spam protection acts as your <em>email</em> bridgehead, stopping known and emerging <em>email</em> borne threats before they reach your network."],
+                "serviceFeatures": ["Secure Messaging for secure <em>email</em> sending ", "Real-time monitoring with <em>email</em> & SMS alerting for  issues"],
+                "serviceName": ["Mimecast <em>Email</em> Security"],
+                "serviceBenefits": ["Stop malicious or unwanted <em>email</em> from ever reaching your ", "Early alert/notification of possible <em>email</em> communication problems"]
+            },
+            "serviceFeatures": ["Always-on cloud-based security service", "Real-time online track & trace", "Stops 99% of spam and 100% malware in the cloud", "Granular content examination engine for DLP policy application", "AD synchronization enables group policy setting", "Document metadata stripping", " Secure message delivery via TLS and Pull Based encryption ", "Secure Messaging for secure email sending ", "Real-time monitoring with email & SMS alerting for  issues"],
+            "supplierName": "supplier",
+            "serviceBenefits": ["Stop malicious or unwanted email from ever reaching your ", "Prevents malicious URLs in emails from affecting end users", "Interactive digests enable users to manage their own quarantine", "Support requirements using our granular policy engine", "Personal block and permit lists reflect user preferences", "user or policy invoked secure communication", "Early alert/notification of possible email communication problems", "Send large files through Outlook, securly, upto 2GB", "Centralise disclaimer and stationery management"]
+        }],
+        "query": {
+            "q": "email"
+        },
+        "total": 634,
+        "took": 4352
+    }
+}


### PR DESCRIPTION
This adds filtering to the search page based on fields shared between G4, G5 and G6 services.

The shared fields were determined by comparing a record of all the G4 and G5 services, formatted to match G6, with the fields defined in the [JSON schemas](https://github.com/alphagov/digitalmarketplace-api/tree/master/json_schemas) used by the content API.

The filters are derived from these fields with their in-page copy taken from the [SSP content repo](https://github.com/alphagov/digital-marketplace-ssp-content).

https://www.pivotaltracker.com/story/show/89414742

The following is left out of this story:

- integration with the search API (which will be done by the search utils)
- categories (due to requiring changes to the SSP Content repo)
- uniform URLs for clearer analytics data

The full page, filtered by the SaaS lot:

![buyers-app-search-filters](https://cloud.githubusercontent.com/assets/87140/7394304/93da0b18-ee8a-11e4-9bbf-4fdd781ddf8f.png)