### PR TITLE
Do not activate venv if already in a venv

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-source ./venv/bin/activate 2>/dev/null && echo "Virtual environment activated."
+if [ -n "$VIRTUAL_ENV" ]; then
+  echo "Already in virtual environment $VIRTUAL_ENV"
+else
+  source ./venv/bin/activate 2>/dev/null && echo "Virtual environment activated."
+fi
 
 # Use default environment vars for localhost if not already set
 export DM_API_URL=${DM_API_URL:=http://localhost:5000}


### PR DESCRIPTION
The environment variable is set in the activate script https://github.com/pypa/virtualenv/blob/92fe07a9374222caf81d1c12802311506173fd5c/virtualenv_embedded/activate.sh#L43