### PR TITLE
`/_status` endpoint includes information about dependent APIs

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,13 +1,12 @@
 from flask import Flask
 from flask.ext.bootstrap import Bootstrap
 from config import config
-from dmutils import logging
-
-from .main import main as main_blueprint
-from .status import status as status_blueprint
+from dmutils import apiclient, logging
 
 
 bootstrap = Bootstrap()
+data_api_client = apiclient.DataAPIClient()
+search_api_client = apiclient.SearchAPIClient()
 
 
 def create_app(config_name):
@@ -18,6 +17,11 @@ def create_app(config_name):
 
     bootstrap.init_app(application)
     logging.init_app(application)
+    data_api_client.init_app(application)
+    search_api_client.init_app(application)
+
+    from .main import main as main_blueprint
+    from .status import status as status_blueprint
 
     application.register_blueprint(status_blueprint)
     application.register_blueprint(main_blueprint)

--- a/app/models.py
+++ b/app/models.py
@@ -34,19 +34,6 @@ def strip_services_wrapper(content):
     return content_json["services"]
 
 
-def get_api_status():
-    return requests.get(
-        api_url + '/_status',
-    )
-
-
-def get_search_api_status():
-    # Might be the wrong url - os.getenv('DM_SEARCH_API_URL') + "/search"
-    return requests.get(
-        search_api_url + '/_status',
-    )
-
-
 def get_service(service_id):
     url = api_url + "/services/" + service_id
     response = requests.get(

--- a/app/models.py
+++ b/app/models.py
@@ -34,7 +34,7 @@ def strip_services_wrapper(content):
     return content_json["services"]
 
 
-def get_data_api_status():
+def get_api_status():
     return requests.get(
         api_url + '/_status',
     )

--- a/app/models.py
+++ b/app/models.py
@@ -6,7 +6,8 @@ from .exceptions import AuthException
 
 api_url = os.getenv('DM_API_URL')
 api_access_token = os.getenv('DM_BUYER_FRONTEND_API_AUTH_TOKEN')
-search_url = os.getenv('DM_SEARCH_API_URL') + "/search"
+search_api_url = os.getenv('DM_SEARCH_API_URL')
+search_url = search_api_url + "/search"
 search_access_token = os.getenv('DM_BUYER_FRONTEND_SEARCH_API_AUTH_TOKEN')
 
 if api_access_token is None:
@@ -31,6 +32,19 @@ def handle_api_errors(response):
 def strip_services_wrapper(content):
     content_json = json.loads(content)
     return content_json["services"]
+
+
+def get_data_api_status():
+    return requests.get(
+        api_url + '/_status',
+    )
+
+
+def get_search_api_status():
+    # Might be the wrong url - os.getenv('DM_SEARCH_API_URL') + "/search"
+    return requests.get(
+        search_api_url + '/_status',
+    )
 
 
 def get_service(service_id):

--- a/app/status/utils.py
+++ b/app/status/utils.py
@@ -1,5 +1,4 @@
 import os
-import json
 from requests.exceptions import ConnectionError
 
 
@@ -25,4 +24,4 @@ def return_response_from_api_status_call(api_status_call):
 
 
 def return_json_or_none(response):
-    return None if response is None else json.loads(response.get_data())
+    return None if response is None else response.json()

--- a/app/status/utils.py
+++ b/app/status/utils.py
@@ -12,17 +12,12 @@ def get_version_label():
         return None
 
 
-def return_result_of_api_status_call(function_call):
-
-    api_status = "error"
+def return_response_from_api_status_call(api_status_call):
 
     try:
-        api_status_response = function_call()
-
-        if api_status_response.status_code is 200:
-            api_status = "ok"
+        return api_status_call()
 
     except ConnectionError:
         pass
 
-    return api_status
+    return None

--- a/app/status/utils.py
+++ b/app/status/utils.py
@@ -1,5 +1,5 @@
 import os
-from requests.exceptions import ConnectionError
+from dmutils.apiclient import ConnectionError
 
 
 def get_version_label():

--- a/app/status/utils.py
+++ b/app/status/utils.py
@@ -1,4 +1,5 @@
 import os
+import json
 from requests.exceptions import ConnectionError
 
 
@@ -21,3 +22,7 @@ def return_response_from_api_status_call(api_status_call):
         pass
 
     return None
+
+
+def return_json_or_none(response):
+    return None if response is None else json.loads(response.get_data())

--- a/app/status/utils.py
+++ b/app/status/utils.py
@@ -1,4 +1,5 @@
 import os
+from requests.exceptions import ConnectionError
 
 
 def get_version_label():
@@ -9,3 +10,19 @@ def get_version_label():
             return f.read().strip()
     except IOError:
         return None
+
+
+def return_result_of_api_status_call(function_call):
+
+    api_status = "error"
+
+    try:
+        api_status_response = function_call()
+
+        if api_status_response.status_code is 200:
+            api_status = "ok"
+
+    except ConnectionError:
+        pass
+
+    return api_status

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,9 +1,48 @@
-from flask import jsonify
+from flask import jsonify, current_app
 
 from . import status
 from . import utils
+from .. import models
 
 
 @status.route('/_status')
 def status():
-    return jsonify(status="ok", version=utils.get_version_label())
+
+    data_api_status = utils.return_result_of_api_status_call(
+        models.get_data_api_status
+    )
+
+    search_api_status = utils.return_result_of_api_status_call(
+        models.get_search_api_status
+    )
+
+    if data_api_status is "ok" and search_api_status is "ok":
+
+        return jsonify(
+            status="ok",
+            version=utils.get_version_label(),
+            data_api_status=data_api_status,
+            search_api_status=search_api_status
+            )
+
+    apis_wot_got_errors = []
+
+    if data_api_status is not "ok":
+        apis_wot_got_errors.append("Data API")
+
+    if search_api_status is not "ok":
+        apis_wot_got_errors.append("Search API")
+
+    # logic breaks down once we hit 3 APIs.
+    message = "Error connecting to the " \
+              + (" and the ".join(apis_wot_got_errors)) \
+              + "."
+
+    current_app.logger.error(message)
+    return jsonify(
+        status="error",
+        app_version=utils.get_version_label(),
+        data_api_status=data_api_status,
+        search_api_status=search_api_status,
+        message=message,
+    ), 500

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -31,8 +31,8 @@ def status():
         return jsonify(
             status="ok",
             version=utils.get_version_label(),
-            api_status=json.loads(api_response.get_data()),
-            search_api_status=json.loads(api_response.get_data())
+            api_status=api_response.json(),
+            search_api_status=search_api_response.json()
         )
 
     message = "Error connecting to the " \

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -8,41 +8,41 @@ from .. import models
 @status.route('/_status')
 def status():
 
-    data_api_status = utils.return_result_of_api_status_call(
-        models.get_data_api_status
+    api_response = utils.return_response_from_api_status_call(
+        models.get_api_status
     )
 
-    search_api_status = utils.return_result_of_api_status_call(
+    search_api_response = utils.return_response_from_api_status_call(
         models.get_search_api_status
     )
 
-    if data_api_status is "ok" and search_api_status is "ok":
+    apis_wot_got_errors = []
 
+    if api_response is None or api_response.status_code is not 200:
+        apis_wot_got_errors.append("(Data) API")
+
+    if search_api_response is None or search_api_response.status_code is not 200:
+        apis_wot_got_errors.append("Search API")
+
+    # if no errors found, return everything
+    if not apis_wot_got_errors:
         return jsonify(
             status="ok",
             version=utils.get_version_label(),
-            data_api_status=data_api_status,
-            search_api_status=search_api_status
-            )
+            api_status=api_response.json(),
+            search_api_status=search_api_response.json(),
+        )
 
-    apis_wot_got_errors = []
-
-    if data_api_status is not "ok":
-        apis_wot_got_errors.append("Data API")
-
-    if search_api_status is not "ok":
-        apis_wot_got_errors.append("Search API")
-
-    # logic breaks down once we hit 3 APIs.
     message = "Error connecting to the " \
               + (" and the ".join(apis_wot_got_errors)) \
               + "."
 
     current_app.logger.error(message)
+
     return jsonify(
         status="error",
-        app_version=utils.get_version_label(),
-        data_api_status=data_api_status,
-        search_api_status=search_api_status,
+        version=utils.get_version_label(),
+        api_status=None if api_response is None else api_response.json(),
+        search_api_status=None if search_api_response is None else search_api_response.json(),
         message=message,
     ), 500

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,20 +1,19 @@
 from flask import jsonify, current_app
-import json
 
 from . import status
 from . import utils
-from .. import models
+from .. import data_api_client, search_api_client
 
 
 @status.route('/_status')
 def status():
 
     api_response = utils.return_response_from_api_status_call(
-        models.get_api_status
+        data_api_client.get_status
     )
 
     search_api_response = utils.return_response_from_api_status_call(
-        models.get_search_api_status
+        search_api_client.get_status
     )
 
     apis_with_errors = []
@@ -35,9 +34,9 @@ def status():
             search_api_status=search_api_response.json()
         )
 
-    message = "Error connecting to the " \
-              + (" and the ".join(apis_with_errors)) \
-              + "."
+    message = "Error connecting to the {}.".format(
+        " and the ".join(apis_with_errors)
+    )
 
     current_app.logger.error(message)
 

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,4 +1,5 @@
 from flask import jsonify, current_app
+import json
 
 from . import status
 from . import utils
@@ -21,7 +22,8 @@ def status():
     if api_response is None or api_response.status_code is not 200:
         apis_wot_got_errors.append("(Data) API")
 
-    if search_api_response is None or search_api_response.status_code is not 200:
+    if search_api_response is None \
+            or search_api_response.status_code is not 200:
         apis_wot_got_errors.append("Search API")
 
     # if no errors found, return everything
@@ -29,8 +31,8 @@ def status():
         return jsonify(
             status="ok",
             version=utils.get_version_label(),
-            api_status=api_response.json(),
-            search_api_status=search_api_response.json(),
+            api_status=json.loads(api_response.get_data()),
+            search_api_status=json.loads(api_response.get_data())
         )
 
     message = "Error connecting to the " \
@@ -42,7 +44,7 @@ def status():
     return jsonify(
         status="error",
         version=utils.get_version_label(),
-        api_status=None if api_response is None else api_response.json(),
-        search_api_status=None if search_api_response is None else search_api_response.json(),
+        api_status=utils.return_json_or_none(api_response),
+        search_api_status=utils.return_json_or_none(search_api_response),
         message=message,
     ), 500

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -17,17 +17,17 @@ def status():
         models.get_search_api_status
     )
 
-    apis_wot_got_errors = []
+    apis_with_errors = []
 
-    if api_response is None or api_response.status_code is not 200:
-        apis_wot_got_errors.append("(Data) API")
+    if api_response is None or api_response.status_code != 200:
+        apis_with_errors.append("(Data) API")
 
     if search_api_response is None \
-            or search_api_response.status_code is not 200:
-        apis_wot_got_errors.append("Search API")
+            or search_api_response.status_code != 200:
+        apis_with_errors.append("Search API")
 
     # if no errors found, return everything
-    if not apis_wot_got_errors:
+    if not apis_with_errors:
         return jsonify(
             status="ok",
             version=utils.get_version_label(),
@@ -36,7 +36,7 @@ def status():
         )
 
     message = "Error connecting to the " \
-              + (" and the ".join(apis_wot_got_errors)) \
+              + (" and the ".join(apis_with_errors)) \
               + "."
 
     current_app.logger.error(message)

--- a/config.py
+++ b/config.py
@@ -10,6 +10,14 @@ class Config(object):
         'asset_path': '/static/',
         'header_class': 'with-proposition'
     }
+    DM_DATA_API_URL = os.getenv('DM_API_URL')
+    DM_DATA_API_AUTH_TOKEN = os.getenv('DM_BUYER_FRONTEND_API_AUTH_TOKEN')
+    DM_SEARCH_API_URL = os.getenv('DM_SEARCH_API_URL')
+    DM_SEARCH_API_AUTH_TOKEN = os.getenv(
+        'DM_BUYER_FRONTEND_SEARCH_API_AUTH_TOKEN'
+    )
+    # This is just a placeholder
+    ES_ENABLED = None
 
     # Logging
     DM_LOG_LEVEL = 'DEBUG'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pyasn1==0.1.7
 #Required for testing
 pep8==1.5.7
 nose==1.3.4
+mock==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Bootstrap==3.3.0.1
 Flask-Script==2.0.5
 requests==2.5.1
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.4.2#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.5.0#egg=digitalmarketplace-utils
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/__init__.py
+++ b/tests/app/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'paulcraig'

--- a/tests/app/__init__.py
+++ b/tests/app/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'paulcraig'

--- a/tests/app/test_status.py
+++ b/tests/app/test_status.py
@@ -1,0 +1,1 @@
+__author__ = 'paulcraig'

--- a/tests/app/test_status.py
+++ b/tests/app/test_status.py
@@ -1,1 +1,77 @@
-__author__ = 'paulcraig'
+import json
+from flask import jsonify
+from ..helpers import BaseApplicationTest
+
+import mock
+from nose.tools import assert_equal, assert_in
+
+
+class TestStatus(BaseApplicationTest):
+
+    def test_status_ok(self):
+        with self.app.test_request_context():
+            api_response = jsonify(
+                status='ok'
+            )
+            api_response.status_code = 200
+
+            _api_response = mock.patch(
+                'app.status.utils.return_response_from_api_status_call',
+                return_value=api_response
+            ).start()
+
+            status_response = self.client.get('/_status')
+            assert_equal(200, status_response.status_code)
+
+            json_data = json.loads(status_response.get_data())
+            assert_equal("ok",
+                         "{}".format(json_data['api_status']['status']))
+            assert_equal("ok",
+                         "{}".format(json_data['search_api_status']['status']))
+
+            _api_response.stop()
+
+    def test_status_api_responses_return_500(self):
+        with self.app.test_request_context():
+            api_response = jsonify(
+                status='error'
+            )
+            api_response.status_code = 500
+
+            _api_response = mock.patch(
+                'app.status.utils.return_response_from_api_status_call',
+                return_value=api_response
+            ).start()
+
+            status_response = self.client.get('/_status')
+            assert_equal(500, status_response.status_code)
+
+            json_data = json.loads(status_response.get_data())
+            assert_equal("error",
+                         "{}".format(json_data['api_status']['status']))
+            assert_equal("error",
+                         "{}".format(json_data['search_api_status']['status']))
+            assert_in("Error connecting to",
+                      "{}".format(json_data['message']))
+
+            _api_response.stop()
+
+    def test_status_api_responses_are_none(self):
+        with self.app.test_request_context():
+
+            _api_response = mock.patch(
+                'app.status.utils.return_response_from_api_status_call',
+                return_value=None
+            ).start()
+
+            status_response = self.client.get('/_status')
+            assert_equal(500, status_response.status_code)
+
+            json_data = json.loads(status_response.get_data())
+            assert_equal(None, json_data['api_status'])
+            assert_equal(None, json_data['search_api_status'])
+
+            assert_in("Error connecting to",
+                      "{}".format(json_data['message']))
+
+            _api_response.stop()

--- a/tests/app/test_status.py
+++ b/tests/app/test_status.py
@@ -1,77 +1,65 @@
 import json
-from flask import jsonify
 from ..helpers import BaseApplicationTest
+from requests import Response
 
 import mock
 from nose.tools import assert_equal, assert_in
 
 
 class TestStatus(BaseApplicationTest):
+    def setup(self):
+        super(TestStatus, self).setup()
+
+        self._api_response = mock.patch(
+            'app.status.utils.return_response_from_api_status_call',
+        ).start()
+
+    def teardown(self):
+        self._api_response.stop()
 
     def test_status_ok(self):
-        with self.app.test_request_context():
-            api_response = jsonify(
-                status='ok'
-            )
-            api_response.status_code = 200
+        api_response = Response()
+        api_response.status_code = 200
+        api_response._content = json.dumps({
+            'status': 'ok'
+        }).encode('utf-8')
+        self._api_response.return_value = api_response
 
-            _api_response = mock.patch(
-                'app.status.utils.return_response_from_api_status_call',
-                return_value=api_response
-            ).start()
+        status_response = self.client.get('/_status')
+        assert_equal(200, status_response.status_code)
 
-            status_response = self.client.get('/_status')
-            assert_equal(200, status_response.status_code)
-
-            json_data = json.loads(status_response.get_data())
-            assert_equal("ok",
-                         "{}".format(json_data['api_status']['status']))
-            assert_equal("ok",
-                         "{}".format(json_data['search_api_status']['status']))
-
-            _api_response.stop()
+        json_data = json.loads(status_response.get_data().decode('utf-8'))
+        assert_equal(
+            "ok", "{}".format(json_data['api_status']['status']))
+        assert_equal(
+            "ok", "{}".format(json_data['search_api_status']['status']))
 
     def test_status_api_responses_return_500(self):
-        with self.app.test_request_context():
-            api_response = jsonify(
-                status='error'
-            )
-            api_response.status_code = 500
+        api_response = Response()
+        api_response.status_code = 500
+        api_response._content = json.dumps({
+            'status': 'error'
+        }).encode('utf-8')
+        self._api_response.return_value = api_response
 
-            _api_response = mock.patch(
-                'app.status.utils.return_response_from_api_status_call',
-                return_value=api_response
-            ).start()
+        status_response = self.client.get('/_status')
+        assert_equal(500, status_response.status_code)
 
-            status_response = self.client.get('/_status')
-            assert_equal(500, status_response.status_code)
-
-            json_data = json.loads(status_response.get_data())
-            assert_equal("error",
-                         "{}".format(json_data['api_status']['status']))
-            assert_equal("error",
-                         "{}".format(json_data['search_api_status']['status']))
-            assert_in("Error connecting to",
-                      "{}".format(json_data['message']))
-
-            _api_response.stop()
+        json_data = json.loads(status_response.get_data().decode('utf-8'))
+        assert_equal(
+            "error", "{}".format(json_data['api_status']['status']))
+        assert_equal(
+            "error", "{}".format(json_data['search_api_status']['status']))
+        assert_in(
+            "Error connecting to", "{}".format(json_data['message']))
 
     def test_status_api_responses_are_none(self):
-        with self.app.test_request_context():
+        self._api_response.return_value = None
 
-            _api_response = mock.patch(
-                'app.status.utils.return_response_from_api_status_call',
-                return_value=None
-            ).start()
+        status_response = self.client.get('/_status')
+        assert_equal(500, status_response.status_code)
 
-            status_response = self.client.get('/_status')
-            assert_equal(500, status_response.status_code)
-
-            json_data = json.loads(status_response.get_data())
-            assert_equal(None, json_data['api_status'])
-            assert_equal(None, json_data['search_api_status'])
-
-            assert_in("Error connecting to",
-                      "{}".format(json_data['message']))
-
-            _api_response.stop()
+        json_data = json.loads(status_response.get_data().decode('utf-8'))
+        assert_equal(None, json_data['api_status'])
+        assert_equal(None, json_data['search_api_status'])
+        assert_in("Error connecting to", "{}".format(json_data['message']))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from app import create_app
 
 


### PR DESCRIPTION
`/_status` endpoint knows about the (data) api and the search api.  

If all is well, response looks like this:
```json
{
  "api_status": {
    "db_version": "10_adding_supplier_to_user_table",
    "status": "ok",
    "version": null
  },
  "search_api_status": {
    "app_version": null,
    "db_status": {
      "message": [
        {
          "num_docs": 16423,
          "primary_size": "26mb"
        }
      ],
      "status_code": 200
    },
    "status": "ok"
  },
  "status": "ok",
  "version": null
}
```
If one of the APIs returns a 500-level response (maybe it's still responding, but no longer has a connection to its database), the status response looks more like this:
```json
{
  "api_status": {
    "message": "Error connecting to database",
    "status": "error",
    "version": null
  },
  "message": "Error connecting to the (Data) API.",
  "search_api_status": {
    "app_version": null,
    "db_status": {
      "message": [
        {
          "num_docs": 16423,
          "primary_size": "26mb"
        }
      ],
      "status_code": 200
    },
    "status": "ok"
  },
  "status": "error",
  "version": null
}
```
If our APIs are down:
```json
{
  "api_status": null,
  "message": "Error connecting to the (Data) API and the Search API.",
  "search_api_status": null,
  "status": "error",
  "version": null
}
```

#### Note : 

I'm referring to it as the (Data) API in the response message text in the case of an error, but haven't used the `data_` prefix anywhere else.