### PR TITLE
Add categories to filters

### DIFF
--- a/app/helpers/questions_manifest.yml
+++ b/app/helpers/questions_manifest.yml
@@ -1,4 +1,10 @@
 -
+  name: Categories
+  questions:
+    - serviceTypesSCS
+    - serviceTypesSaaS
+    - serviceTypesIaaS
+-
   name: Pricing
   questions:
     - freeOption

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -68,13 +68,11 @@ class SearchFilters(object):
             # if the 1st question has options, they will become the
             # filters and it's details will define the group
             if question['type'] in questions_with_options:
-                filters = (
-                    filters +
+                filters += \
                     SearchFilters.get_filters_from_question_with_options(
                         question,
                         len(filters)
                     )
-                )
             else:
                 filters.append(
                     SearchFilters.get_filters_from_default_question(

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -53,14 +53,14 @@ class SearchFilters(object):
         return filter_group
 
     @staticmethod
-    def get_filter_groups_from_questions(manifest=None, questions_dir=None):
+    def get_filter_groups_from_questions(manifest, questions_dir):
         filter_groups = []
         g6_questions = QuestionsLoader(
             manifest=manifest,
             questions_dir=questions_dir
         )
 
-        def add_filters_for_question(question=None, filters=None):
+        def add_filters_for_question(question, filters):
             questions_with_options = [
                 'radios',
                 'checkboxes'

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -38,10 +38,11 @@ class SearchFilters(object):
         else:
             filter_name = question['id']
         for option in question['options']:
+            filter_id = option['label'].lower().replace(' ', '-')
             filter = {
                 'label': option['label'],
                 'name': filter_name,
-                'id': '%s-%s' % (filter_name, option['label'].lower()),
+                'id': '%s-%s' % (filter_name, filter_id),
                 'value': option['label'].lower(),
                 'lots': [lot.strip() for lot in (
                     question['dependsOnLots'].lower().split(",")

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -1,3 +1,4 @@
+import re
 from werkzeug.datastructures import MultiDict
 from ..helpers.questions import QuestionsLoader
 
@@ -29,33 +30,58 @@ class SearchFilters(object):
         }
 
     @staticmethod
-    def get_filters_from_question_with_options(question):
+    def get_filters_from_question_with_options(question, index):
         filter_group = []
-        for index, option in enumerate(question['options']):
-            filter_group.append({
+
+        if re.match('^serviceTypes(SCS|SaaS|IaaS)', question['id']):
+            filter_name = 'serviceTypes'
+        else:
+            filter_name = question['id']
+        for option in question['options']:
+            filter = {
                 'label': option['label'],
-                'name': question['id'],
-                'id': question['id'] + option['label'].lower(),
+                'name': filter_name,
+                'id': '%s-%s' % (filter_name, option['label'].lower()),
                 'value': option['label'].lower(),
                 'lots': [lot.strip() for lot in (
                     question['dependsOnLots'].lower().split(",")
                 )]
-            })
+            }
+            filter_group.append(filter)
+            index = index + 1
         return filter_group
 
     @staticmethod
     def get_filter_groups_from_questions(manifest=None, questions_dir=None):
         filter_groups = []
-        get_filter_for = {
-            'boolean': SearchFilters.get_filters_from_default_question,
-            'text': SearchFilters.get_filters_from_default_question,
-            'pricing': SearchFilters.get_filters_from_default_question,
-            'options': SearchFilters.get_filters_from_question_with_options
-        }
         g6_questions = QuestionsLoader(
             manifest=manifest,
             questions_dir=questions_dir
         )
+
+        def add_filters_for_question(question=None, filters=None):
+            questions_with_options = [
+                'radios',
+                'checkboxes'
+            ]
+            # if the 1st question has options, they will become the
+            # filters and it's details will define the group
+            if question['type'] in questions_with_options:
+                filters = (
+                    filters +
+                    SearchFilters.get_filters_from_question_with_options(
+                        question,
+                        len(filters)
+                    )
+                )
+            else:
+                filters.append(
+                    SearchFilters.get_filters_from_default_question(
+                        question
+                    )
+                )
+            return filters
+
         for section in g6_questions.sections:
             filter_group = {
                 'label': section['name'],
@@ -63,26 +89,9 @@ class SearchFilters(object):
                 'filters': []
             }
             for question in section['questions']:
-                questionType = question['type']
-                if questionType == 'boolean':
-                    filter_group['filters'].append(get_filter_for['boolean'](
-                        question
-                    ))
-                elif questionType == 'text':
-                    filter_group['filters'].append(get_filter_for['text'](
-                        question
-                    ))
-                elif questionType == 'pricing':
-                    filter_group['filters'].append(get_filter_for['pricing'](
-                        question
-                    ))
-                else:
-                    # if the 1st question has options, they will become the
-                    # filters and it's details will define the group
-                    filter_group['filters'] = get_filter_for['options'](
-                        question
-                    )
-                    break
+                filter_group['filters'] = add_filters_for_question(
+                    question=question, filters=filter_group['filters']
+                )
             filter_groups.append(filter_group)
         return filter_groups
 

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace_frontend_toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v2.0.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
-    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#da2a7defe28bd7d9154a2e20769c50b41414b485"
+    "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#5137868d0b7e7c8f916fb52e3c4c655608408c94"
   }
 }


### PR DESCRIPTION
The service types weren't correct in the SSP content data so they could not be included as filters (the buyers app uses the SSP content data to render the search filters).

This was corrected in https://github.com/alphagov/digital-marketplace-ssp-content/pull/38 so this pull request brings in those changes and adds service types to the filters.

![image](https://cloud.githubusercontent.com/assets/87140/7511302/be8b00d0-f49b-11e4-9e05-563a2252c1e0.png)