### PR TITLE
Pull out `_status` error handling into dmutils

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ class Config(object):
         'DM_BUYER_FRONTEND_SEARCH_API_AUTH_TOKEN'
     )
     # This is just a placeholder
-    ES_ENABLED = None
+    ES_ENABLED = True
 
     # Search API
     DM_SEARCH_API_URL = "http://localhost:5001"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 requests==2.5.1
 inflection==0.2.1
 pyyaml==3.11
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.5.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.6.0#egg=digitalmarketplace-utils
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14


### PR DESCRIPTION
API Client now handles exceptions and errors, meaning that _status routes for our frontend apps need less logic.
Also updated dmutils tag and set `ES_ENABLED` to true in config (I was having problems running the app and testing the status endpoint with `ES_ENABLED` set to `None`)