### PR TITLE
Fix highlighting SCSS & add styles for <em> tag

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -1,5 +1,9 @@
 @import "_search-result.scss";
 
+em.search-result-highlighted-text {
+  font-style: normal;
+}
+
 .search-page-filters {
   .lot-filters {
     h3 {
@@ -28,5 +32,4 @@
     padding: 5px;
     border: 1px solid $border-colour;
   }
-}
 }


### PR DESCRIPTION
A loose trailing bracket was breaking the Sass compilation and some extra SCSS needed adding to deal with the italic styling inherited from using the `<em>` tag.