### PR TITLE
Correct URLs in links on G-Cloud index page

### DIFF
--- a/app/templates/index-g-cloud.html
+++ b/app/templates/index-g-cloud.html
@@ -23,7 +23,7 @@
   </div>
   <ul class="browse-list">
     <li class="browse-list-item">
-      <a href="/search?lot=saas" class="browse-list-item-link">
+      <a href="/search?q=&lot=saas" class="browse-list-item-link">
           Software as a Service
       </a>
       <p class="browse-list-item-body">
@@ -34,7 +34,7 @@
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/search?lot=paas" class="browse-list-item-link">
+      <a href="/search?q=&lot=paas" class="browse-list-item-link">
           Platform as a Service
       </a>
       <p class="browse-list-item-body">
@@ -42,7 +42,7 @@
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/search?lot=iaas" class="browse-list-item-link">
+      <a href="/search?q=&lot=iaas" class="browse-list-item-link">
           Infrastructure as a Service
       </a>
       <p class="browse-list-item-body">
@@ -53,7 +53,7 @@
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/search?lot=scs" class="browse-list-item-link">
+      <a href="/search?q=&lot=scs" class="browse-list-item-link">
           Specialist Cloud Services
       </a>
       <p class="browse-list-item-body">

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 requests==2.5.1
 inflection==0.2.1
 pyyaml==3.11
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.6.0#egg=digitalmarketplace-utils
+-e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.10.2#egg=digitalmarketplace-utils
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14


### PR DESCRIPTION
The links on the G-Cloud home page pointed to searches without any keywords. 

![image](https://cloud.githubusercontent.com/assets/87140/7590740/e60c7858-f8c1-11e4-848f-60f97fbc41c3.png)

This did not work previously because:

1. their query string did not include the 'q' parameter
2. our search api client, in digitalmarketplace utils, did not support a blank 'q' parameter

This changes 1. and brings in a [new version of digitalmarketplace](https://github.com/alphagov/digitalmarketplace-utils/pull/32) utils to fix 2.