### PR TITLE
Add basic search summary

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -1,4 +1,12 @@
-@import "_search-result.scss";
+@import "search/_search-summary.scss";
+
+.search-summary {
+  padding: 0 0 $gutter-half;
+  margin: 0 0 $gutter-half;
+  border-bottom: 1px solid $border-colour;
+}
+
+@import "search/_search-result.scss";
 
 em.search-result-highlighted-text {
   font-style: normal;

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -14,7 +14,7 @@ $path: "/static/images/";
 @import "_breadcrumb.scss";
 @import "_footer.scss";
 @import "_page-headings.scss";
-@import "_search-result.scss";
+@import "search/_search-result.scss";
 @import "_browse_list.scss";
 @import "forms/_option-select.scss";
 @import "forms/_summary.scss";

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -66,6 +66,7 @@ def search():
         'lots': search_filters_obj.lot_filters,
         'search_keywords': search_keywords,
         'filter_groups': search_filters_obj.filter_groups,
-        'services': search_results_obj.search_results
+        'services': search_results_obj.search_results,
+        'summary': search_results_obj.summary
     })
     return render_template('search.html', **template_data)

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -209,6 +209,14 @@ class SearchResults(object):
                         ''.join(service['highlight']['serviceSummary'])
                     )
 
+    def _get_search_summary(self, results_total):
+        template = u"<span class='search-summary-count'>{}</span> {} found"
+        if int(results_total) < 2:
+            return Markup(template.format('1', u"result"))
+        else:
+            return Markup(template.format(results_total, u"results"))
+
     def __init__(self, response):
         self.search_results = response['services']
         self._add_highlighting()
+        self.summary = self._get_search_summary(response['total'])

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -97,12 +97,12 @@ class SearchFilters(object):
 
     def __init__(self, blueprint=False, request={}):
         self.filter_groups = blueprint.config['FILTER_GROUPS']
-        self.request_filters = self.__get_filters_from_request(request)
-        self.lot_filters = self.__get_lot_filters_from_request(request)
-        self.__sift_filters_based_on_lot(request.args.get('lot', 'all'))
-        self.__set_filter_states()
+        self.request_filters = self._get_filters_from_request(request)
+        self.lot_filters = self._get_lot_filters_from_request(request)
+        self._sift_filters_based_on_lot(request.args.get('lot', 'all'))
+        self._set_filter_states()
 
-    def __sift_filters_based_on_lot(self, lot):
+    def _sift_filters_based_on_lot(self, lot):
         sifted_groups = []
         lots = ['saas', 'paas', 'iaas', 'scs']
 
@@ -126,7 +126,7 @@ class SearchFilters(object):
                 sifted_groups.append(sifted_group)
         self.filter_groups = sifted_groups
 
-    def __get_lot_filters_from_request(self, request):
+    def _get_lot_filters_from_request(self, request):
         """Returns data to construct lot filters from"""
 
         def _get_url(keywords=None, lot=None):
@@ -174,7 +174,7 @@ class SearchFilters(object):
             lot_filters[lot_names.index(current_lot)]['isActive'] = True
         return lot_filters
 
-    def __get_filters_from_request(self, request):
+    def _get_filters_from_request(self, request):
         """Returns the filters applied to a search from the request object"""
 
         # TODO: only use request arguments that map to recognised filters
@@ -182,7 +182,7 @@ class SearchFilters(object):
         filters.poplist('q')
         return filters
 
-    def __set_filter_states(self):
+    def _set_filter_states(self):
         """Sets a flag on each filter to mark it as set or not"""
         for filter_group in self.filter_groups:
             for filter in filter_group['filters']:

--- a/app/templates/_search_summary.html
+++ b/app/templates/_search_summary.html
@@ -1,0 +1,3 @@
+<p class="search-summary">
+  {{ summary }}
+</p>

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -10,6 +10,7 @@
     {% include '_search_filters.html' %}
     </div>
     <div class="column-two-thirds">
+    {% include '_search_summary.html' %}
     {% include '_search_results.html' %}
     </div>
   </div>

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery": "1.11.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace_frontend_toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v2.0.2",
+    "digitalmarketplace_frontend_toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#5137868d0b7e7c8f916fb52e3c4c655608408c94"
   }

--- a/tests/unit/test_search_presenters.py
+++ b/tests/unit/test_search_presenters.py
@@ -77,3 +77,16 @@ class TestSearchResults(unittest.TestCase):
             result_with_service_name_highlight['serviceName'],
             "CDN VDMS"
         )
+
+
+class TestSearchSummary(unittest.TestCase):
+
+    def setUp(self):
+        self.fixture = _get_fixture_data()
+
+    def tearDown(self):
+        pass
+
+    def test_search_results_has_summary_set(self):
+        search_results_instance = SearchResults(self.fixture)
+        self.assertTrue(hasattr(search_results_instance, 'summary'))

--- a/tests/unit/test_search_presenters.py
+++ b/tests/unit/test_search_presenters.py
@@ -90,3 +90,20 @@ class TestSearchSummary(unittest.TestCase):
     def test_search_results_has_summary_set(self):
         search_results_instance = SearchResults(self.fixture)
         self.assertTrue(hasattr(search_results_instance, 'summary'))
+
+    def test_search_results_summary_with_multiple(self):
+        search_results_instance = SearchResults(self.fixture)
+        self.assertEqual(
+            search_results_instance.summary,
+            Markup(
+                u"<span class='search-summary-count'>9</span> results found"))
+
+    def test_search_results_works_with_single(self):
+        single_result = self.fixture.copy()
+        single_result['services'] = [single_result['services'][0]]
+        single_result['total'] = '1'
+        search_results_instance = SearchResults(single_result)
+        self.assertEqual(
+            search_results_instance.summary,
+            Markup(
+                u"<span class='search-summary-count'>1</span> result found"))


### PR DESCRIPTION
![search-summary](https://cloud.githubusercontent.com/assets/87140/7595128/0e07aeac-f8dd-11e4-9b2d-a85963404ef8.png)

A summary with all the filters included will come in a future pull request.

Includes some corrections to the method naming in the search presenter (2ebed9e)