### PR TITLE
WIP: Change to use updated API response format …

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -190,7 +190,7 @@ def search():
     search_keywords = get_keywords_from_request(request)
     search_filters_obj = SearchFilters(blueprint=main, request=request)
     response = search_api_client.search_services(
-        **dict([a for a in request.args.lists()]))
+        **dict(request.args.lists()))
     search_results_obj = SearchResults(response)
 
     template_data = get_template_data(main, {

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -219,4 +219,4 @@ class SearchResults(object):
     def __init__(self, response):
         self.search_results = response['services']
         self._add_highlighting()
-        self.summary = self._get_search_summary(response['total'])
+        self.summary = self._get_search_summary(response['meta']['total'])

--- a/tests/fixtures/search_results_fixture.json
+++ b/tests/fixtures/search_results_fixture.json
@@ -1,4 +1,15 @@
 {
+  "links": {
+    "next": "http://localhost:5002/search?q=cdn&page=2"
+  },
+  "meta": {
+    "query": {
+      "q": "CDN",
+      "filter_lot": "saas"
+    },
+    "total": 9,
+    "took": 13
+  },
   "services": [
     {
       "serviceSummary": "Fastly CDN (Content Delivery Network) speeds up delivery of your website and its content to your users. When your client clicks on your site requesting a piece of information, we want them to feel your speed of delivery. No waiting. We want them to get to your closest point of presence\u2014in milliseconds\u2014to get what they want. Fastly delivers the world's only real-time content delivery network. At Fastly we think slow is unacceptable. Fastly enables a next-generation of businesses to give their users the best online and mobile experience. The patent-pending Fastly Caching Software delivers static, dynamic and streaming content with the lowest recorded time to first byte.",
@@ -238,11 +249,5 @@
       },
       "id": "5-G4-1270-002"
     }
-  ],
-  "query": {
-    "q": "CDN",
-    "filter_lot": "saas"
-  },
-  "total": 9,
-  "took": 13
+  ]
 }

--- a/tests/unit/test_search_presenters.py
+++ b/tests/unit/test_search_presenters.py
@@ -101,7 +101,7 @@ class TestSearchSummary(unittest.TestCase):
     def test_search_results_works_with_single(self):
         single_result = self.fixture.copy()
         single_result['services'] = [single_result['services'][0]]
-        single_result['total'] = '1'
+        single_result['meta']['total'] = '1'
         search_results_instance = SearchResults(single_result)
         self.assertEqual(
             search_results_instance.summary,


### PR DESCRIPTION
The search API response has been updated to be more in line with the
JSON API standard. This change also makes the `links` object available
to the buyers app.

NOTE: This commit is not complete. It depends on https://github.com/alphagov/digitalmarketplace-utils/pull/34 before the pagination can be integrated.