### PR TITLE
Fix g5 service pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ preview environment's `API` and `Search API` boxes, or use local API instances i
 you have them running:
 
 ```
-export DM_API_URL=http://localhost:5000
-export DM_BUYER_FRONTEND_API_AUTH_TOKEN=<auth_token_accepted_by_api>
+export DM_DATA_API_URL=http://localhost:5000
+export DM_DATA_API_AUTH_TOKEN=<auth_token_accepted_by_api>
 export DM_SEARCH_API_URL=http://localhost:5001
-export DM_BUYER_FRONTEND_SEARCH_API_AUTH_TOKEN=<auth_token_accepted_by_search_api>
+export DM_SEARCH_API_AUTH_TOKEN=<auth_token_accepted_by_search_api>
 ```
 
-Where `DM_BUYER_FRONTEND_API_AUTH_TOKEN` is a token accepted by the Data API 
-instance pointed to by `DM_API_URL`, and `DM_BUYER_FRONTEND_SEARCH_API_AUTH_TOKEN` 
+Where `DM_DATA_API_AUTH_TOKEN` is a token accepted by the Data API 
+instance pointed to by `DM_API_URL`, and `DM_SEARCH_API_AUTH_TOKEN` 
 is a token accepted by the Search API instance pointed to by `DM_SEARCH_API_URL`.
 
 ### Create and activate the virtual environment

--- a/app/presenters/service_presenters.py
+++ b/app/presenters/service_presenters.py
@@ -8,15 +8,23 @@ except ImportError:
 
 
 class Service(object):
+    def _add_as_attribute_if_key_exists(self, key, service_data):
+        if key[0] in service_data:
+            setattr(self, key[1], service_data[key[0]])
+
     def __init__(self, service):
         service_data = service['services']
+        # required attributes directly mapped to service_data values
         self.title = service_data['serviceName']
-        if 'supplierName' in service_data:
-            self.supplierName = service_data['supplierName']
         self.serviceSummary = service_data['serviceSummary']
-        self.features = service_data['serviceFeatures']
         self.lot = service_data['lot']
-        self.benefits = service_data['serviceBenefits']
+        # optional attributes directly mapped to service_data values
+        for key in [
+            ('supplierName', 'supplierName'),
+            ('serviceFeatures', 'features'),
+            ('serviceBenefits', 'benefits')
+        ]:
+            self._add_as_attribute_if_key_exists(key, service_data)
         self.attributes = self._get_service_attributes(service_data)
         self.meta = self._get_service_meta(service_data)
 

--- a/app/templates/_service_summary_features_and_benefits.html
+++ b/app/templates/_service_summary_features_and_benefits.html
@@ -1,13 +1,17 @@
 <p class="service-summary-lede">{{ service.serviceSummary }}</p>
+{% if service.features %}
 <h2 class="service-summary-heading">Features</h2>
 <ul class="service-summary-features-and-benefits">
 {% for feature in service.features %}
   <li>{{ feature }}</li>
 {% endfor %}
 </ul>
+{% endif %}
+{% if service.benefits %}
 <h2 class="service-summary-heading">Benefits</h2>
 <ul class="service-summary-features-and-benefits">
 {% for benefit in service.benefits %}
   <li>{{ benefit }}</li>
 {% endfor %}
 </ul>
+{% endif %}

--- a/app/templates/content/buyers-guide-g-cloud.html
+++ b/app/templates/content/buyers-guide-g-cloud.html
@@ -1,6 +1,8 @@
 {% from 'macros/_breadcrumb.html' import breadcrumb %}
 {% extends "_base_page.html" %}
 
+{% block page_title %}G-Cloud buyers' guide - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/content/buyers-guide.html
+++ b/app/templates/content/buyers-guide.html
@@ -1,6 +1,8 @@
 {% from 'macros/_breadcrumb.html' import breadcrumb %}
 {% extends "_base_page.html" %}
 
+{% block page_title %}Digital Marketplace buyers' guide - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/content/framework-crown-hosting.html
+++ b/app/templates/content/framework-crown-hosting.html
@@ -1,6 +1,8 @@
 {% from 'macros/_breadcrumb.html' import breadcrumb %}
 {% extends "_base_page.html" %}
 
+{% block page_title %}Crown Hosting Data Centres framework - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/content/framework-digital-services.html
+++ b/app/templates/content/framework-digital-services.html
@@ -1,6 +1,8 @@
 {% from 'macros/_breadcrumb.html' import breadcrumb %}
 {% extends "_base_page.html" %}
 
+{% block page_title %}Digital Services framework - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/content/framework-g-cloud.html
+++ b/app/templates/content/framework-g-cloud.html
@@ -1,6 +1,8 @@
 {% from 'macros/_breadcrumb.html' import breadcrumb %}
 {% extends "_base_page.html" %}
 
+{% block page_title %}G-Cloud framework - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/content/index-crown-hosting.html
+++ b/app/templates/content/index-crown-hosting.html
@@ -1,6 +1,8 @@
 {% from 'macros/_breadcrumb.html' import breadcrumb %}
 {% extends "_base_page.html" %}
 
+{% block page_title %}Physical datacentre space for legacy systems - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/content/suppliers-guide-g-cloud.html
+++ b/app/templates/content/suppliers-guide-g-cloud.html
@@ -1,6 +1,8 @@
 {% from 'macros/_breadcrumb.html' import breadcrumb %}
 {% extends "_base_page.html" %}
 
+{% block page_title %}G-Cloud suppliers' guide - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/content/terms-and-conditions.html
+++ b/app/templates/content/terms-and-conditions.html
@@ -1,6 +1,8 @@
 {% from 'macros/_breadcrumb.html' import breadcrumb %}
 {% extends "_base_page.html" %}
 
+{% block page_title %}Terms and conditions - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/index-g-cloud.html
+++ b/app/templates/index-g-cloud.html
@@ -1,6 +1,8 @@
 {% from 'macros/_breadcrumb.html' import breadcrumb %}
 {% extends "_base_page.html" %}
 
+{% block page_title %}G-Cloud - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Digital Marketplace{% endblock %}
+
 {% block main_content %}
 
 <div class="index-page">

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -1,5 +1,7 @@
 {% extends "_base_page.html" %}
 
+{% block page_title %}Search - Digital Marketplace{% endblock %}
+
 {% block main_content %}
 <header class="page-heading">
   <h1>Search results</h1>

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -2,6 +2,8 @@
 
 {% extends "_base_page.html" %}
 
+{% block page_title %}{{ service.title }} - Digital Marketplace{% endblock %}
+
 {% block breadcrumb %}
   {{ breadcrumb(crumbs) }}
 {% endblock %}

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -11,8 +11,10 @@
 {% block main_content %}
 <div class="grid-row">
   <div class="column-two-thirds">
-    <header class="page-heading page-heading-with-context page-heading-smaller">
+    <header class="page-heading-smaller">
+      {% if service.supplierName %}
       <p class="context">{{ service.supplierName }}
+      {% endif %}
       <h1>{{ service.title }}</h1>
     </header>
   </div>

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -6,8 +6,8 @@ else
 fi
 
 # Use default environment vars for localhost if not already set
-export DM_API_URL=${DM_API_URL:=http://localhost:5000}
-export DM_BUYER_FRONTEND_API_AUTH_TOKEN=${DM_BUYER_FRONTEND_API_AUTH_TOKEN:=myToken}
+export DM_DATA_API_URL=${DM_DATA_API_URL:=http://localhost:5000}
+export DM_DATA_API_AUTH_TOKEN=${DM_DATA_API_AUTH_TOKEN:=myToken}
 export DM_SEARCH_API_URL=${DM_SEARCH_API_URL:=http://localhost:5001}
 export DM_SEARCH_API_AUTH_TOKEN=${DM_SEARCH_API_AUTH_TOKEN:=myToken}
 export ES_ENABLED=${ES_ENABLED:=True}

--- a/tests/unit/test_service_presenters.py
+++ b/tests/unit/test_service_presenters.py
@@ -34,20 +34,27 @@ class TestService(unittest.TestCase):
             self.service.lot,
             self.fixture['services']['lot'])
 
-    def test_supplierName_attribute_is_set(self):
-        self.assertEquals(
-            self.service.supplierName, self.fixture['services']['supplierName']
-        )
-
     def test_Service_works_if_supplierName_is_not_set(self):
         del self.fixture['services']['supplierName']
         self.service = Service(self.fixture)
         self.assertFalse(hasattr(self.service, 'supplierName'))
 
+    def test_Service_works_if_serviceFeatures_is_not_set(self):
+        del self.fixture['services']['serviceFeatures']
+        self.service = Service(self.fixture)
+        self.assertFalse(hasattr(self.service, 'features'))
+
+    def test_Service_works_if_serviceBenefits_is_not_set(self):
+        del self.fixture['services']['serviceBenefits']
+        self.service = Service(self.fixture)
+        self.assertFalse(hasattr(self.service, 'benefits'))
+
     def test_features_attributes_are_correctly_set(self):
+        self.assertTrue(hasattr(self.service, 'features'))
         self.assertEquals(len(self.service.features), 6)
 
     def test_benefits_attributes_are_correctly_set(self):
+        self.assertTrue(hasattr(self.service, 'benefits'))
         self.assertEquals(len(self.service.benefits), 6)
 
     def test_attributes_are_correctly_set(self):


### PR DESCRIPTION
Some G5 service pages don't have features or benefits which was breaking the presenter (and so those pages).

https://www.pivotaltracker.com/story/show/94291604

This was because both of those attributes are not in the [required list](https://github.com/alphagov/digitalmarketplace-api/blob/master/json_schemas/services-g5.json#L208) for G5 services. The changes here add protection for all attributes not required for G5.

This also includes:

- fixes for environment variables to match those for the [search](https://github.com/alphagov/digitalmarketplace-utils/blob/master/dmutils/apiclient.py#L121) and [data](https://github.com/alphagov/digitalmarketplace-utils/blob/master/dmutils/apiclient.py#L183) APIs in DM utils
- titles for all the pages as they didn't have any

A G5 service (to prove it works):

![g5_service](https://cloud.githubusercontent.com/assets/87140/7651058/38f9ab6a-faf4-11e4-80ee-2a6ef6d4bfce.png)
