### PR TITLE
Remove unused status.utils function and update dmutils

### DIFF
--- a/app/status/utils.py
+++ b/app/status/utils.py
@@ -1,5 +1,4 @@
 import os
-from dmutils.apiclient import ConnectionError
 
 
 def get_version_label():
@@ -10,17 +9,6 @@ def get_version_label():
             return f.read().strip()
     except IOError:
         return None
-
-
-def return_response_from_api_status_call(api_status_call):
-
-    try:
-        return api_status_call()
-
-    except ConnectionError:
-        pass
-
-    return None
 
 
 def return_json_or_none(response):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 requests==2.5.1
 inflection==0.2.1
 pyyaml==3.11
--e git+https://github.com/alphagov/digitalmarketplace-utils.git@0.10.2#egg=digitalmarketplace-utils
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.12.0#egg=digitalmarketplace-utils
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14


### PR DESCRIPTION
ConnectionError is no longer imported by dmutils, and since get_status
handles requests exceptions there's no need for a wrapper

Requires https://github.com/alphagov/digitalmarketplace-utils/pull/36