### PR TITLE
Fix presentation of G5 service IDs

### DIFF
--- a/app/presenters/service_presenters.py
+++ b/app/presenters/service_presenters.py
@@ -179,9 +179,11 @@ class Meta(object):
         self.documents = self.get_documents(service_data)
 
     def get_service_id(self, service_data):
-        return re.findall(
-            '....', str(service_data['id'])
-        )
+        id = service_data['id']
+        if re.findall("[a-zA-Z]", str(id)):
+            return [id]
+        else:
+            return re.findall("....", str(id))
 
     def get_documents(self, service_data):
         keys = [

--- a/tests/unit/test_service_presenters.py
+++ b/tests/unit/test_service_presenters.py
@@ -329,6 +329,10 @@ class TestMeta(unittest.TestCase):
             self.meta.get_service_id({'id': 1234567890123456}),
             ['1234', '5678', '9012', '3456']
         )
+        self.assertEqual(
+            self.meta.get_service_id({'id': '5-G4-1046-001'}),
+            ['5-G4-1046-001']
+        )
 
     def test_get_documents_returns_the_correct_document_information(self):
         keys = [


### PR DESCRIPTION
G5 service IDs should not be chunked into four parts. This commit copies the same logic used in the supplier and admin apps to prevent this.

Example of the problem:
![screen shot 2015-05-15 at 12 02 00](https://cloud.githubusercontent.com/assets/6525554/7651630/9147fa3c-fafa-11e4-9788-34f36783066c.png)