### PR TITLE
Pin dmutils version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 requests==2.5.1
 inflection==0.2.1
 pyyaml==3.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.12.0#egg=digitalmarketplace-utils
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.12.0#egg=digitalmarketplace-utils==0.12.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14


### PR DESCRIPTION
As it is no longer an editable package we need to pin the version so
that pip knows to update it.