### PR TITLE
Add all the links to the footer

### DIFF
--- a/app/assets/scss/_footer.scss
+++ b/app/assets/scss/_footer.scss
@@ -49,7 +49,7 @@
         margin-top: $gutter-half;
 
       }
-    
+
       li {
         display: block;
         margin-bottom: 5px;
@@ -73,6 +73,16 @@
       @include media(tablet) {
         margin: 0;
       }
+    }
+
+  }
+
+  .footer-meta {
+
+    .terms-and-conditions {
+      display: block;
+      @include core-16;
+      margin: 0 0 20px 0;
     }
 
   }

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -19,8 +19,8 @@
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">
-      {% block main_content %}    
-      {% endblock %}    
+      {% block main_content %}
+      {% endblock %}
     </main>
   </div>
 {% endblock %}
@@ -29,7 +29,10 @@
   {% include "_footer_categories.html" %}
 {% endblock %}
 
+{% block footer_support_links %}
+  <a href="/terms-and-conditions" class="terms-and-conditions">Terms and conditions</a>
+{% endblock %}
+
 {% block body_end %}
   {% include "_javascripts.html" %}
 {% endblock %}
-

--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -1,29 +1,55 @@
 <div class="footer-categories">
   <div class="footer-about">
-    <h2>About the Digital Marketplace</h2>
+    <h2>
+      Contact
+    </h2>
     <ul>
-      <li><a href="https://digitalmarketplace.blog.gov.uk/">Digital Marketplace blog</a></li>
-      <li><a href="/terms-and-conditions">Terms and conditions</a></li>
-      <li><a href="https://ccs.cabinetoffice.gov.uk">Crown Commercial Service website </a></li>
+      <li>
+        <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">Digital Marketplace support</a>
+      </li>
     </ul>
   </div>
   <div class="footer-buyers">
     <h2>
-      Buyers
+      About the Digital Marketplace
     </h2>
     <ul>
       <li>
-        <a href="/buyers-guide/">Preparing to buy</a>
+        <a href="https://digitalmarketplace.blog.gov.uk">Digital Marketplace blog</a>
+      </li>
+      <li>
+        <a href="/g-cloud/framework">G-Cloud framework</a>
+      </li>
+      <li>
+        <a href="/crown-hosting/framework">Crown Hosting framework</a>
+      </li>
+      <li>
+        <a href="/digital-services/framework">Digital Services framework</a>
+      </li>
+      <li>
+        <a href="https://ccs.cabinetoffice.gov.uk">Crown Commercial Service</a>
       </li>
     </ul>
   </div>
   <div class="footer-suppliers">
     <h2>
-      Suppliers
+      Guidance
     </h2>
     <ul>
       <li>
-        <a href="/suppliers-guide/">Supplying a service</a>
+        <a href="/buyers-guide">Digital Marketplace buyers' guide</a>
+      </li>
+      <li>
+        <a href="/g-cloud/buyers-guide">G-Cloud buyers' guide</a>
+      </li>
+      <li>
+        <a href="/g-cloud/suppliers-guide">G-Cloud suppliers' guide</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/government/publications/digital-services-store-buyers-guide/digital-services-store-buyers-guide">Digital Services buyers' guide</a>
+      </li>
+      <li>
+        <a href="https://www.gov.uk/how-to-use-the-digital-services-store">Digital Services detailed guide</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Based on [this Google doc](https://docs.google.com/spreadsheets/d/19_Bn72s0POsH_qUJ6c8i-OQXazhjQ2CyLQM896ruvQQ/edit#gid=1897495985) and [story 92441646](https://www.pivotaltracker.com/n/projects/997836/stories/92441646)

There should be three columns in the footer:
- Contact
- About the Digital Marketplace
- Guidance

Terms & Conditions should live down above OGL (consistent with GOV.UK)

---

![image](https://cloud.githubusercontent.com/assets/355079/7679326/7fefc0ac-fd53-11e4-82a3-80de3e61c788.png)

Under "About the Digital Marketplace" there should be five entries:
- Digital Marketplace blog
- G-Cloud framework
- Crown Hosting framework
- Digital Services framework
- Crown Commercial Service

Under "Guidance",
- Digital Marketplace buyers' guide
- G-Cloud buyers' guide
- G-Cloud suppliers' guide
- Digital Services buyers' guide
- Digital Services detailed guide