### PR TITLE
[#94571368] Expand acronyms on search results page

### DIFF
--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -211,7 +211,7 @@ class SearchResults(object):
 
     def _get_search_summary(self, results_total):
         template = u"<span class='search-summary-count'>{}</span> {} found"
-        if int(results_total) < 2:
+        if int(results_total) == 1:
             return Markup(template.format('1', u"result"))
         else:
             return Markup(template.format(results_total, u"results"))

--- a/app/templates/_search_results.html
+++ b/app/templates/_search_results.html
@@ -12,7 +12,17 @@
     </p>
     <ul aria-label="tags" class="search-result-metadata">
         <li class="search-result-metadata-item">
-            {{ service.lot }}
+        {% if service.lot == 'SaaS' %}
+            Software as a Service
+        {% elif service.lot == 'PaaS' %}
+            Platform as a Service
+        {% elif service.lot == 'IaaS' %}
+            Infrastructure as a Service
+        {% elif service.lot == 'SCS' %}
+            Specialist Cloud Services
+        {% else %}
+            Lot: {{ service.lot }}
+        {% endif %}
         </li>
         <li class="search-result-metadata-item">
             {{ service.frameworkName }}

--- a/tests/unit/test_search_presenters.py
+++ b/tests/unit/test_search_presenters.py
@@ -106,3 +106,13 @@ class TestSearchSummary(unittest.TestCase):
             search_results_instance.summary,
             Markup(
                 u"<span class='search-summary-count'>1</span> result found"))
+
+    def test_search_results_works_with_none(self):
+        empty_result = self.fixture.copy()
+        empty_result['services'] = []
+        empty_result['total'] = '0'
+        search_results_instance = SearchResults(empty_result)
+        self.assertEqual(
+            search_results_instance.summary,
+            Markup(
+                u"<span class='search-summary-count'>0</span> results found"))


### PR DESCRIPTION
See this story: https://www.pivotaltracker.com/story/show/94571368

I have done the translation of acronyms in the _search_results template - it seemed the natural place for it, rather than messing with the 'lot' in the results themselves. For the catch-all `else` if no lot has been matched I've added `Lot: ` to the front of the display of the lot.  This is because the only value (as far as I know) in our data that won't match any of the four lots is `"missing"`, and I think it would be good to make it clear that it's the lot that is missing rather than anything else.

This also fixes the "1 result found" bug when there are no search results.
