### PR TITLE
Add trailing slashes to URLs

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -20,7 +20,7 @@ def index():
     return render_template('index.html', **template_data)
 
 
-@main.route('/g-cloud')
+@main.route('/g-cloud/')
 def index_g_cloud():
     breadcrumb = [
         {'text': 'Cloud technology and support'}
@@ -32,7 +32,7 @@ def index_g_cloud():
     return render_template('index-g-cloud.html', **template_data)
 
 
-@main.route('/g-cloud/framework')
+@main.route('/g-cloud/framework/')
 def framework_g_cloud():
     template_data = get_template_data(main, {
         'title': 'G-Cloud framework – Digital Marketplace',
@@ -49,7 +49,7 @@ def framework_g_cloud():
     return render_template('content/framework-g-cloud.html', **template_data)
 
 
-@main.route('/digital-services/framework')
+@main.route('/digital-services/framework/')
 def framework_digital_services():
     template_data = get_template_data(main, {
         'title': 'Digital Services framework – Digital Marketplace',
@@ -68,7 +68,7 @@ def framework_digital_services():
     )
 
 
-@main.route('/crown-hosting')
+@main.route('/crown-hosting/')
 def index_crown_hosting():
     template_data = get_template_data(main, {
         'title': 'Physical datacentre space for legacy systems – Digital Marketplace',  # noqa
@@ -79,7 +79,7 @@ def index_crown_hosting():
     return render_template('content/index-crown-hosting.html', **template_data)
 
 
-@main.route('/crown-hosting/framework')
+@main.route('/crown-hosting/framework/')
 def framework_crown_hosting():
     template_data = get_template_data(main, {
         'title': 'Crown Hosting Data Centres framework – Digital Marketplace',
@@ -98,7 +98,7 @@ def framework_crown_hosting():
     )
 
 
-@main.route('/buyers-guide')
+@main.route('/buyers-guide/')
 def buyers_guide():
     template_data = get_template_data(main, {
         'title': 'Buyers guide – Digital Marketplace',
@@ -111,12 +111,12 @@ def buyers_guide():
     return render_template('content/buyers-guide.html', **template_data)
 
 
-@main.route('/suppliers-guide')
+@main.route('/suppliers-guide/')
 def suppliers_guide():
     return redirect('/g-cloud/suppliers-guide', 301)
 
 
-@main.route('/g-cloud/buyers-guide')
+@main.route('/g-cloud/buyers-guide/')
 def buyers_guide_g_cloud():
     template_data = get_template_data(main, {
         'title': 'G-Cloud buyers\' guide – Digital Marketplace',
@@ -135,7 +135,7 @@ def buyers_guide_g_cloud():
     )
 
 
-@main.route('/g-cloud/suppliers-guide')
+@main.route('/g-cloud/suppliers-guide/')
 def suppliers_guide_g_cloud():
     template_data = get_template_data(main, {
         'title': 'G-Cloud suppliers\' guide – Digital Marketplace',
@@ -154,7 +154,7 @@ def suppliers_guide_g_cloud():
     )
 
 
-@main.route('/terms-and-conditions')
+@main.route('/terms-and-conditions/')
 def terms_and_conditions():
     template_data = get_template_data(main, {
         'title': 'Terms and conditions – Digital Marketplace',
@@ -165,7 +165,7 @@ def terms_and_conditions():
     )
 
 
-@main.route('/services/<service_id>')
+@main.route('/services/<service_id>/')
 def get_service_by_id(service_id):
     try:
         service = data_api_client.get_service(service_id)
@@ -184,7 +184,7 @@ def get_service_by_id(service_id):
         abort(404, "Service ID '%s' can not be found" % service_id)
 
 
-@main.route('/search')
+@main.route('/search/')
 def search():
     search_keywords = get_keywords_from_request(request)
     search_filters_obj = SearchFilters(blueprint=main, request=request)

--- a/app/templates/_search_results.html
+++ b/app/templates/_search_results.html
@@ -1,7 +1,7 @@
 {% for service in services %}
 <div class="search-result">
   <h2 class="search-result-title">
-        <a href="/services/{{ service.id }}">{{ service.serviceName }}</a>
+        <a href="/services/{{ service.id }}/">{{ service.serviceName }}</a>
     </h2>
     <p class="search-result-supplier">
         {{ service.supplierName }}

--- a/app/templates/index-g-cloud.html
+++ b/app/templates/index-g-cloud.html
@@ -16,7 +16,7 @@
     </h1>
   </header>
   <div class="grid-row">
-    <form action="/search" method="get" class="search-box column-two-thirds">
+    <form action="/search/" method="get" class="search-box column-two-thirds">
         <input type="text" class="text-box" name="q">
         <button type="submit" class="button-save">
           Show services
@@ -25,7 +25,7 @@
   </div>
   <ul class="browse-list">
     <li class="browse-list-item">
-      <a href="/search?q=&lot=saas" class="browse-list-item-link">
+      <a href="/search/?q=&lot=saas" class="browse-list-item-link">
           Software as a Service
       </a>
       <p class="browse-list-item-body">
@@ -36,7 +36,7 @@
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/search?q=&lot=paas" class="browse-list-item-link">
+      <a href="/search/?q=&lot=paas" class="browse-list-item-link">
           Platform as a Service
       </a>
       <p class="browse-list-item-body">
@@ -44,7 +44,7 @@
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/search?q=&lot=iaas" class="browse-list-item-link">
+      <a href="/search/?q=&lot=iaas" class="browse-list-item-link">
           Infrastructure as a Service
       </a>
       <p class="browse-list-item-body">
@@ -55,7 +55,7 @@
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/search?q=&lot=scs" class="browse-list-item-link">
+      <a href="/search/?q=&lot=scs" class="browse-list-item-link">
           Specialist Cloud Services
       </a>
       <p class="browse-list-item-body">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,22 +16,22 @@
 
   <ul class="browse-list">
     <li class="browse-list-item">
-      <a href="/g-cloud" class="browse-list-item-link">
+      <a href="/g-cloud/" class="browse-list-item-link">
           Find cloud technology and support
       </a>
       <p class="browse-list-item-body">
           eg web hosting or IT health checks
       </p>
       <p class="browse-list-item-subtext">
-        Procurement framework: <a href="/g-cloud/framework">G-Cloud</a>
+        Procurement framework: <a href="/g-cloud/framework/">G-Cloud</a>
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/crown-hosting" class="browse-list-item-link">
+      <a href="/crown-hosting/" class="browse-list-item-link">
         Buy physical datacentre space for legacy systems
       </a>
       <p class="browse-list-item-subtext">
-        Procurement framework: <a href="/crown-hosting/framework">Crown Hosting Data Centres</a>
+        Procurement framework: <a href="/crown-hosting/framework/">Crown Hosting Data Centres</a>
       </p>
     </li>
     <li class="browse-list-item">
@@ -42,7 +42,7 @@
           eg technical architects and user researchers
       </p>
       <p class="browse-list-item-subtext">
-        Procurement framework: <a href="/digital-services/framework">Digital Services</a>
+        Procurement framework: <a href="/digital-services/framework/">Digital Services</a>
       </p>
     </li>
   </ul>

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -20,8 +20,8 @@ class TestSearchResults(BaseApplicationTest):
         self._search_api_client.search_services.return_value = \
             self.search_results
 
-        res = self.client.get('/search?q=email')
+        res = self.client.get('/search/?q=email')
         assert_equal(200, res.status_code)
         assert_true(
-            '<a href="/services/5-G3-0279-010">CDN VDMS</a>'
+            '<a href="/services/5-G3-0279-010/">CDN VDMS</a>'
             in res.get_data(as_text=True))

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -22,6 +22,6 @@ class TestServicePage(BaseApplicationTest):
         self._data_api_client.get_service.return_value = \
             self.service
 
-        res = self.client.get('/services/1234567890123456')
+        res = self.client.get('/services/1234567890123456/')
         assert_equal(200, res.status_code)
         assert_true("<h1>Blogging platform</h1>" in res.get_data(as_text=True))


### PR DESCRIPTION
This URL works:
https://preview.development.digitalmarketplace.service.gov.uk/buyers-guide

This URL doesn't work:
https://preview.development.digitalmarketplace.service.gov.uk/buyers-guide/

We need to support both because the existing app uses URLs with trailing
slashes, which users may have bookmarked.

That we standardise on having trailing slashes in our URLs. If we go
with this option then Flask handles the redirects for us.

---

The alternative would be something like the following, but it doesn't feel as clean:
``` Python
@app.before_request
def remove_trailing_slash():
    if request.path != '/' and request.path.endswith('/'):
        return redirect(request.path[:-1])
```

Bring thy reckons.