### PR TITLE
Enforce URLs without trailing slashes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, request, redirect
 from flask.ext.bootstrap import Bootstrap
 from config import configs
 from dmutils import apiclient, logging, config
@@ -42,5 +42,10 @@ def create_app(config_name):
         },
         'FILTER_GROUPS': filter_groups
     }
+
+    @application.before_request
+    def remove_trailing_slash():
+        if request.path != '/' and request.path.endswith('/'):
+            return redirect(request.path[:-1])
 
     return application


### PR DESCRIPTION
# Currently

This URL works:
https://preview.development.digitalmarketplace.service.gov.uk/buyers-guide

This URL doesn't work:
https://preview.development.digitalmarketplace.service.gov.uk/buyers-guide/

We need to support both because the existing app uses URLs with trailing slashes, which users may have bookmarked.

# This pull request…

…redirects all URLs with trailing slashes to their equivalent, non-trailing-slash brethren/sistren.

This means standardising on not having trailing slashes in our URLs, which @TheDoubleK and I think is cleaner.

_Fixes some of the issues found in [this story](https://www.pivotaltracker.com/story/show/94291320)_.