### PR TITLE
Redirect URLs with query parameters, add tests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -46,6 +46,15 @@ def create_app(config_name):
     @application.before_request
     def remove_trailing_slash():
         if request.path != '/' and request.path.endswith('/'):
-            return redirect(request.path[:-1], code=301)
+            if request.query_string:
+                return redirect(
+                    '{}?{}'.format(
+                        request.path[:-1],
+                        request.query_string.decode('utf-8')
+                    ),
+                    code=301
+                )
+            else:
+                return redirect(request.path[:-1], code=301)
 
     return application

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -46,6 +46,6 @@ def create_app(config_name):
     @application.before_request
     def remove_trailing_slash():
         if request.path != '/' and request.path.endswith('/'):
-            return redirect(request.path[:-1])
+            return redirect(request.path[:-1], code=301)
 
     return application

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -17,3 +17,8 @@ class TestApplication(BaseApplicationTest):
         response = self.client.get('/trailing/')
         assert 301 == response.status_code
         assert "http://localhost/trailing" == response.location
+
+    def test_trailing_slashes_with_query_parameters(self):
+        response = self.client.get('/search/?q=r&s=t')
+        assert 301 == response.status_code
+        assert "http://localhost/search?q=r&s=t" == response.location

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -9,3 +9,11 @@ class TestApplication(BaseApplicationTest):
     def test_404(self):
         response = self.client.get('/not-found')
         assert 404 == response.status_code
+
+    def test_trailing_slashes(self):
+        response = self.client.get('')
+        assert 301 == response.status_code
+        assert "http://localhost/" == response.location
+        response = self.client.get('/trailing/')
+        assert 301 == response.status_code
+        assert "http://localhost/trailing" == response.location


### PR DESCRIPTION
This pull request adds the improvements to trailing slash redirection from the admin and supplier apps.

It also preserves query parameters when doing the redirection, in case anyone has a URL like `/search/?q=cloud` bookmarked.