### PR TITLE
G cloud links

### DIFF
--- a/app/helpers/search_helpers.py
+++ b/app/helpers/search_helpers.py
@@ -9,7 +9,7 @@ def get_template_data(blueprint, view_data):
 
 
 def get_keywords_from_request(request):
-    if request.args['q']:
+    if 'q' in request.args:
         return request.args['q']
     else:
         return ""

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -216,10 +216,7 @@ def redirect_search():
 
 @main.route('/g-cloud/search')
 def search():
-    print "HERE"
     search_keywords = get_keywords_from_request(request)
-    print " KEY {}".format(search_keywords)
-    print " dONE"
     search_filters_obj = SearchFilters(blueprint=main, request=request)
     response = search_api_client.search_services(
         **dict([a for a in request.args.lists()]))

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 
 from . import main
+from datetime import datetime
+from dmutils.deprecation import deprecated
 from flask import abort, render_template, request, redirect, url_for
 from ..presenters.search_presenters import SearchFilters, SearchResults
 from ..presenters.service_presenters import Service
@@ -167,6 +169,7 @@ def terms_and_conditions():
 
 
 @main.route('/services/<service_id>')
+@deprecated(dies_at=datetime(2016, 1, 1))
 def redirect_service_page(service_id):
     return redirect(url_for(
         ".get_service_by_id",
@@ -210,6 +213,7 @@ def get_service_by_id(service_id):
 
 
 @main.route('/search')
+@deprecated(dies_at=datetime(2016, 1, 1))
 def redirect_search():
     return redirect(url_for(".search", **request.args), code=301)
 

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -167,6 +167,14 @@ def terms_and_conditions():
 
 
 @main.route('/services/<service_id>')
+def redirect_service_page(service_id):
+    return redirect(url_for(
+        ".get_service_by_id",
+        service_id=service_id), code=301
+    )
+
+
+@main.route('/g-cloud/services/<service_id>')
 def get_service_by_id(service_id):
     try:
         service = data_api_client.get_service(service_id)
@@ -202,8 +210,16 @@ def get_service_by_id(service_id):
 
 
 @main.route('/search')
+def redirect_search():
+    return redirect(url_for(".search", **request.args), code=301)
+
+
+@main.route('/g-cloud/search')
 def search():
+    print "HERE"
     search_keywords = get_keywords_from_request(request)
+    print " KEY {}".format(search_keywords)
+    print " dONE"
     search_filters_obj = SearchFilters(blueprint=main, request=request)
     response = search_api_client.search_services(
         **dict([a for a in request.args.lists()]))

--- a/app/templates/_search_results.html
+++ b/app/templates/_search_results.html
@@ -1,7 +1,7 @@
 {% for service in services %}
 <div class="search-result">
   <h2 class="search-result-title">
-        <a href="/services/{{ service.id }}">{{ service.serviceName }}</a>
+        <a href="{{ url_for('.get_service_by_id', service_id=service.id) }}">{{ service.serviceName }}</a>
     </h2>
     <p class="search-result-supplier">
         {{ service.supplierName }}

--- a/app/templates/index-g-cloud.html
+++ b/app/templates/index-g-cloud.html
@@ -16,7 +16,7 @@
     </h1>
   </header>
   <div class="grid-row">
-    <form action="/search" method="get" class="search-box column-two-thirds">
+    <form action="{{ url_for('.search') }}" method="get" class="search-box column-two-thirds">
         <input type="text" class="text-box" name="q">
         <button type="submit" class="button-save">
           Show services
@@ -25,7 +25,7 @@
   </div>
   <ul class="browse-list">
     <li class="browse-list-item">
-      <a href="/search?q=&lot=saas" class="browse-list-item-link">
+      <a href="{{ url_for('.search', lot='saas') }}" class="browse-list-item-link">
           Software as a Service
       </a>
       <p class="browse-list-item-body">
@@ -36,7 +36,7 @@
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/search?q=&lot=paas" class="browse-list-item-link">
+      <a href="{{ url_for('.search', lot='paas') }}" class="browse-list-item-link">
           Platform as a Service
       </a>
       <p class="browse-list-item-body">
@@ -44,7 +44,7 @@
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/search?q=&lot=iaas" class="browse-list-item-link">
+      <a href="{{ url_for('.search', lot='iaas') }}" class="browse-list-item-link">
           Infrastructure as a Service
       </a>
       <p class="browse-list-item-body">
@@ -55,7 +55,7 @@
       </p>
     </li>
     <li class="browse-list-item">
-      <a href="/search?q=&lot=scs" class="browse-list-item-link">
+      <a href="{{ url_for('.search', lot='scs') }}" class="browse-list-item-link">
           Specialist Cloud Services
       </a>
       <p class="browse-list-item-body">

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -6,7 +6,7 @@
 <header class="page-heading">
   <h1>Search results</h1>
 </header>
-<form action="/search" method="get">
+<form action="{{ url_for('.search') }}" method="get">
   <div class="grid-row">
     <div class="column-one-third search-page-filters">
     {% include '_search_filters.html' %}

--- a/tests/app/views/test_errors.py
+++ b/tests/app/views/test_errors.py
@@ -20,7 +20,7 @@ class TestErrors(BaseApplicationTest):
         self._search_api_client.stop()
 
     def test_404(self):
-        res = self.client.get('/service/1234')
+        res = self.client.get('/g-cloud/service/1234')
         assert_equal(404, res.status_code)
         assert_true(
             "Check you've entered the correct web "
@@ -40,7 +40,7 @@ class TestErrors(BaseApplicationTest):
             side_effect=ConnectionError('API is down')
         )
 
-        res = self.client.get('/search?q=email')
+        res = self.client.get('/g-cloud/search?q=email')
         assert_equal(500, res.status_code)
         assert_true(
             "Sorry, we're experiencing technical difficulties"

--- a/tests/app/views/test_gcloud-index.py
+++ b/tests/app/views/test_gcloud-index.py
@@ -1,0 +1,39 @@
+import mock
+from nose.tools import assert_equal, assert_true
+from ...helpers import BaseApplicationTest
+
+
+class TestGCloudIndexResults(BaseApplicationTest):
+    def setup(self):
+        super(TestGCloudIndexResults, self).setup()
+
+        self._search_api_client = mock.patch(
+            'app.main.views.search_api_client'
+        ).start()
+
+        self.search_results = self._get_search_results_fixture_data()
+
+    def teardown(self):
+        self._search_api_client.stop()
+
+    def test_renders_correct_search_links(self):
+        self._search_api_client.search_services.return_value = \
+            self.search_results
+
+        res = self.client.get('/g-cloud')
+        assert_equal(200, res.status_code)
+        assert_true(
+            'form action="/g-cloud/search'
+            in res.get_data(as_text=True))
+        assert_true(
+            '/g-cloud/search?lot=saas'
+            in res.get_data(as_text=True))
+        assert_true(
+            '/g-cloud/search?lot=scs'
+            in res.get_data(as_text=True))
+        assert_true(
+            '/g-cloud/search?lot=paas'
+            in res.get_data(as_text=True))
+        assert_true(
+            '/g-cloud/search?lot=iaas'
+            in res.get_data(as_text=True))

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -16,12 +16,30 @@ class TestSearchResults(BaseApplicationTest):
     def teardown(self):
         self._search_api_client.stop()
 
-    def test_search_page_results_service_links(self):
+    def test_search_page_redirect(self):
         self._search_api_client.search_services.return_value = \
             self.search_results
 
         res = self.client.get('/search?q=email')
+        assert_equal(301, res.status_code)
+        assert_equal('http://localhost/g-cloud/search?q=email', res.location)
+
+    def test_search_page_results_service_links(self):
+        self._search_api_client.search_services.return_value = \
+            self.search_results
+
+        res = self.client.get('/g-cloud/search?q=email')
         assert_equal(200, res.status_code)
         assert_true(
-            '<a href="/services/5-G3-0279-010">CDN VDMS</a>'
+            '<a href="/g-cloud/services/5-G3-0279-010">CDN VDMS</a>'
+            in res.get_data(as_text=True))
+
+    def test_search_page_form(self):
+        self._search_api_client.search_services.return_value = \
+            self.search_results
+
+        res = self.client.get('/g-cloud/search?q=email')
+        assert_equal(200, res.status_code)
+        assert_true(
+            '<form action="/g-cloud/search" method="get">'
             in res.get_data(as_text=True))

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -43,3 +43,13 @@ class TestSearchResults(BaseApplicationTest):
         assert_true(
             '<form action="/g-cloud/search" method="get">'
             in res.get_data(as_text=True))
+
+    def test_search_page_allows_non_keyword_search(self):
+        self._search_api_client.search_services.return_value = \
+            self.search_results
+
+        res = self.client.get('/g-cloud/search?lot=saas')
+        assert_equal(200, res.status_code)
+        assert_true(
+            '<a href="/g-cloud/services/5-G3-0279-010">CDN VDMS</a>'
+            in res.get_data(as_text=True))

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -37,7 +37,7 @@ class TestServicePage(BaseApplicationTest):
             self.service
         service_id = self.service['services']['id']
 
-        res = self.client.get('/services/{}'.format(service_id))
+        res = self.client.get('/g-cloud/services/{}'.format(service_id))
         assert_equal(200, res.status_code)
         assert_true("<h1>Blogging platform</h1>" in res.get_data(as_text=True))
 

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -22,8 +22,19 @@ class TestServicePage(BaseApplicationTest):
     def teardown(self):
         self._data_api_client.stop()
 
-    def test_service_page_url(self):
+    def test_service_page_redirect(self):
+        self._data_api_client.get_service.return_value = \
+            self.service
 
+        res = self.client.get('/services/1234567890123456')
+        assert_equal(301, res.status_code)
+        assert_equal(
+            'http://localhost/g-cloud/services/1234567890123456',
+            res.location)
+
+    def test_service_page_url(self):
+        self._data_api_client.get_service.return_value = \
+            self.service
         service_id = self.service['services']['id']
 
         res = self.client.get('/services/{}'.format(service_id))


### PR DESCRIPTION
Delivers: https://www.pivotaltracker.com/story/show/93097694

- Story to prefix search and services pages with the framework name
- As currently we only have a single framework this is hardcoded to g-cloud
- Added redirects to the existing urls to the new ones
- Decorated these old routes with the deprecated annotation
- Added tests for new and old endpoints

- Fixed bug where empty keywords caused an error.