### PR TITLE
Show Contact Information on Service Pages

### DIFF
--- a/app/presenters/service_presenters.py
+++ b/app/presenters/service_presenters.py
@@ -186,6 +186,13 @@ class Meta(object):
         self.serviceId = self.get_service_id(service_data)
         self.documents = self.get_documents(service_data)
 
+    def set_contact_attribute(self, contactName, phone, email):
+        self.contact = {
+            'name': contactName,
+            'phone': phone,
+            'email': email
+        }
+
     def get_service_id(self, service_data):
         id = service_data['id']
         if re.findall("[a-zA-Z]", str(id)):

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -25,14 +25,14 @@
   </p>
   <h2 class="visuallyhidden">Contact details</h2>
   <details class="contact">
-    <summary class="summary">Contact Fastnet International Ltd</summary>
+    <summary class="summary">Contact {{ service.supplierName }}</summary>
     <div class="indented">
       <ul>
         <li>
           {{ service.meta.contact.name }}
         </li>
         <li>
-          {{ service.meta.contact.phone }}
+          {{ service.meta.contact.phone if service.meta.contact.phone }}
         </li>
         <li>
           <a href="mailto:{{ service.meta.contact.email }}" data-event-category="Email a supplier" data-event-label="Fastnet International Ltd">{{ service.meta.contact.email }}</a>

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -13,7 +13,7 @@
   <div class="column-two-thirds">
     <header class="page-heading-smaller">
       {% if service.supplierName %}
-      <p class="context">{{ service.supplierName }}
+      <p class="context">{{ service.supplierName }}</p>
       {% endif %}
       <h1>{{ service.title }}</h1>
     </header>

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -14,14 +14,34 @@ class TestServicePage(BaseApplicationTest):
         ).start()
 
         self.service = self._get_service_fixture_data()
+        self.supplier = self._get_supplier_fixture_data()
+
+        self._data_api_client.get_service.return_value = self.service
+        self._data_api_client.get_supplier.return_value = self.supplier
 
     def teardown(self):
         self._data_api_client.stop()
 
     def test_service_page_url(self):
-        self._data_api_client.get_service.return_value = \
-            self.service
 
-        res = self.client.get('/services/1234567890123456')
+        service_id = self.service['services']['id']
+
+        res = self.client.get('/services/{}'.format(service_id))
         assert_equal(200, res.status_code)
         assert_true("<h1>Blogging platform</h1>" in res.get_data(as_text=True))
+
+        supplier_name = self.supplier['suppliers']['name']
+        contact_info = self.supplier['suppliers']['contactInformation'][0]
+
+        assert_true(
+            "Contact {}".format(supplier_name) in res.get_data(as_text=True))
+
+        for contact_detail in [
+            contact_info['contactName'],
+            contact_info['phoneNumber'],
+            'mailto:{}'.format(contact_info['email'])
+        ]:
+
+            assert_true(
+                "{}".format(contact_detail)
+                in res.get_data(as_text=True))

--- a/tests/fixtures/service_fixture.json
+++ b/tests/fixtures/service_fixture.json
@@ -247,7 +247,7 @@
     "sfiaRateDocument": "Blogging platform SFIA.pdf",
     "sfiaRateDocumentURL": "https://assets.digitalmarketplace.service.gov.uk/documents/123456/1234567890123456-sfia-rate-card.pdf",
     "supplierId": 123456,
-    "supplierName": "Blogging platform supplier ltd",
+    "supplierName": "Example Company Limited",
     "supportAvailability": "24/7, 365 days a year",
     "supportForThirdParties": true,
     "supportResponseTime": "Normally 1 hour as standard, up to a maximum of 4 hours",

--- a/tests/fixtures/supplier_fixture.json
+++ b/tests/fixtures/supplier_fixture.json
@@ -1,0 +1,37 @@
+{
+  "suppliers": {
+    "id": 123456,
+    "name": "Example Company Limited",
+    "description": "Example Company Limited is an innovation station sensation; we deliver software so bleeding edge you literally won't be able to run any of it on your systems.",
+    "contactInformation": [
+      {
+        "website": "www.examplecompany.biz",
+        "contactName": "John Example",
+        "email": "j@examplecompany.biz",
+        "phoneNumber": "07309404738",
+        "address1": "123 Fake Street",
+        "city": "London",
+        "country": "United Kingdom",
+        "postcode": "F4 K1E"
+      },
+      {
+        "website": "http://www.scdp.com/team/lane.php",
+        "contactName": "Lane Pryce",
+        "email": "lane@scdp.com",
+        "phoneNumber": "020 7918 9200",
+        "address1": "14 Madison Ave",
+        "address2": "Flat 1",
+        "city": "London",
+        "country": "UK",
+        "postcode": "EC1A D0N"
+      }
+    ],
+    "dunsNumber": "333333333",
+    "eSourcingId": "333333",
+    "clients": [
+      "UK Ministry of Defence",
+      "Astula Ltd",
+      "Bedrock Communications Ltd"
+    ]
+  }
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,23 +10,26 @@ class BaseApplicationTest(object):
         self.client = self.app.test_client()
 
     @staticmethod
-    def _get_search_results_fixture_data():
+    def _get_fixture_data(fixture_filename):
         test_root = os.path.abspath(
             os.path.join(os.path.dirname(__file__), ".")
         )
         fixture_path = os.path.join(
-            test_root, 'fixtures', 'search_results_fixture.json'
+            test_root, 'fixtures', fixture_filename
         )
         with open(fixture_path) as fixture_file:
             return json.load(fixture_file)
 
     @staticmethod
+    def _get_search_results_fixture_data():
+        return BaseApplicationTest._get_fixture_data(
+            'search_results_fixture.json'
+        )
+
+    @staticmethod
     def _get_service_fixture_data():
-        test_root = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), ".")
-        )
-        fixture_path = os.path.join(
-            test_root, 'fixtures', 'service_fixture.json'
-        )
-        with open(fixture_path) as fixture_file:
-            return json.load(fixture_file)
+        return BaseApplicationTest._get_fixture_data('service_fixture.json')
+
+    @staticmethod
+    def _get_supplier_fixture_data():
+        return BaseApplicationTest._get_fixture_data('supplier_fixture.json')


### PR DESCRIPTION
Decided to just do two calls to the API on service pages: one to get service, and one to get supplier (which includes contact information.)

Added a supplier fixture as well for the purposes of the test. 

> [Story on Pivotal](https://www.pivotaltracker.com/story/show/91385166)