### PR TITLE
[#94576802] Update Json api format

### DIFF
--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -219,4 +219,4 @@ class SearchResults(object):
     def __init__(self, response):
         self.search_results = response['services']
         self._add_highlighting()
-        self.summary = self._get_search_summary(response['total'])
+        self.summary = self._get_search_summary(response['meta']['total'])

--- a/tests/fixtures/search_results_fixture.json
+++ b/tests/fixtures/search_results_fixture.json
@@ -1,4 +1,12 @@
 {
+  "meta": {
+    "query": {
+      "q": "CDN",
+      "filter_lot": "saas"
+    },
+    "total": 9,
+    "took": 13
+  },
   "services": [
     {
       "serviceSummary": "Fastly CDN (Content Delivery Network) speeds up delivery of your website and its content to your users. When your client clicks on your site requesting a piece of information, we want them to feel your speed of delivery. No waiting. We want them to get to your closest point of presence\u2014in milliseconds\u2014to get what they want. Fastly delivers the world's only real-time content delivery network. At Fastly we think slow is unacceptable. Fastly enables a next-generation of businesses to give their users the best online and mobile experience. The patent-pending Fastly Caching Software delivers static, dynamic and streaming content with the lowest recorded time to first byte.",
@@ -238,11 +246,5 @@
       },
       "id": "5-G4-1270-002"
     }
-  ],
-  "query": {
-    "q": "CDN",
-    "filter_lot": "saas"
-  },
-  "total": 9,
-  "took": 13
+  ]
 }

--- a/tests/unit/test_search_presenters.py
+++ b/tests/unit/test_search_presenters.py
@@ -100,7 +100,7 @@ class TestSearchSummary(unittest.TestCase):
     def test_search_results_works_with_single(self):
         single_result = self.fixture.copy()
         single_result['services'] = [single_result['services'][0]]
-        single_result['total'] = '1'
+        single_result['meta']['total'] = '1'
         search_results_instance = SearchResults(single_result)
         self.assertEqual(
             search_results_instance.summary,
@@ -110,7 +110,7 @@ class TestSearchSummary(unittest.TestCase):
     def test_search_results_works_with_none(self):
         empty_result = self.fixture.copy()
         empty_result['services'] = []
-        empty_result['total'] = '0'
+        empty_result['meta']['total'] = '0'
         search_results_instance = SearchResults(empty_result)
         self.assertEqual(
             search_results_instance.summary,


### PR DESCRIPTION
See this story in Pivotal: https://www.pivotaltracker.com/story/show/94576802 - the main aim is to make API response formats consistent across the Data and Search APIs.

There are FOUR related pull-requests to complete this story.  The other three are:
https://github.com/alphagov/digitalmarketplace-api/pull/132
https://github.com/alphagov/digitalmarketplace-search-api/pull/42
https://github.com/alphagov/digitalmarketplace-utils/pull/39

Changes in the buyer frontend are to get search result count from 'meta' root-level key in search results.

See these gists for examples of the new API responses:
[Example services data API response](https://gist.github.com/TheDoubleK/0d7cd9363440e700a50d)
[Example suppliers data API response](https://gist.github.com/TheDoubleK/4fde0400e052f20ed2c0)
[Example services search API response](https://gist.github.com/TheDoubleK/8e82782502e611faabcc)