### PR TITLE
Add maxlength attribute to keyword search element

### DIFF
--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -17,7 +17,7 @@
       Keywords
     </label>
   </div>
-  <input class="filter-field-text" type="text" name="q" id="keywords" value="{{ search_keywords }}">
+  <input class="filter-field-text" type="text" name="q" id="keywords" value="{{ search_keywords }}" maxlength="200">
 </div>
 {% if current_lot %}
 <input type="hidden" name="lot" value="{{ current_lot }}" />


### PR DESCRIPTION
Earlier IE versions limit the URL length to 2083 characters. To lessen
the risk of this affecting users this change limits the number of
characters that can be used in the search box to 150. From a sample of
1000 search queries the longest was 148.

This is a proposed solution to this story [#93336038](https://www.pivotaltracker.com/story/show/93336038).