### PR TITLE
Handle service ID not found

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -195,6 +195,8 @@ def redirect_service_page(service_id):
 def get_service_by_id(service_id):
     try:
         service = data_api_client.get_service(service_id)
+        if service is None:
+            abort(404, "Service ID '{}' can not be found".format(service_id))
         service_view_data = Service(service)
 
         try:


### PR DESCRIPTION
get_service returns None if the API returns a 404. This may change in
the future to raise an HTTPError (which is already handled) but this
change will just become dead code then.