### PR TITLE
Only published services should be displayed.

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -197,6 +197,9 @@ def get_service_by_id(service_id):
         service = data_api_client.get_service(service_id)
         if service is None:
             abort(404, "Service ID '{}' can not be found".format(service_id))
+        if service['services'].get('status') != 'published':
+            abort(404, "Service ID '%s' can not be found" % service_id)
+
         service_view_data = Service(service)
 
         try:

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -195,10 +195,8 @@ def redirect_service_page(service_id):
 def get_service_by_id(service_id):
     try:
         service = data_api_client.get_service(service_id)
-        if service is None:
+        if service is None or service['services'].get('status') != 'published':
             abort(404, "Service ID '{}' can not be found".format(service_id))
-        if service['services'].get('status') != 'published':
-            abort(404, "Service ID '%s' can not be found" % service_id)
 
         service_view_data = Service(service)
 

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -110,9 +110,26 @@ class TestServicePage(BaseApplicationTest):
         self._assert_service_page_url()
 
     def test_g6_service_page_url(self):
-
         self.service = self._get_g6_service_fixture_data()
         self._data_api_client.get_service.return_value = self.service
 
         self._assert_redirect_deprecated_service_page_url()
         self._assert_service_page_url()
+
+    def test_enabled_service_not_displayed(self):
+        self.service = self._get_g6_service_fixture_data()
+        self.service['services']['status'] = 'enabled'
+        self._data_api_client.get_service.return_value = \
+            self.service
+        service_id = self.service['services']['id']
+        res = self.client.get('/g-cloud/services/{}'.format(service_id))
+        assert_equal(404, res.status_code)
+
+    def test_disabled_service_not_displayed(self):
+        self.service = self._get_g6_service_fixture_data()
+        self.service['services']['status'] = 'disabled'
+        self._data_api_client.get_service.return_value = \
+            self.service
+        service_id = self.service['services']['id']
+        res = self.client.get('/g-cloud/services/{}'.format(service_id))
+        assert_equal(404, res.status_code)

--- a/tests/fixtures/g6_service_fixture.json
+++ b/tests/fixtures/g6_service_fixture.json
@@ -1,5 +1,6 @@
 {
   "services": {
+    "status": "published",
     "analyticsAvailable": true,
     "apiAccess": false,
     "apiType": "RESTful",


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/94942196

Currently 'enabled' and 'disabled' services are displayed by the buyer frontend.
This change makes the buyer app only display published services.