### PR TITLE
Hide certifications header if there aren't any

### DIFF
--- a/app/presenters/service_presenters.py
+++ b/app/presenters/service_presenters.py
@@ -53,19 +53,20 @@ class Service(object):
                 continue
             data_value = attribute.get_data_value()
             data_type = attribute.get_data_type(data_value)
-            if data_type is not False:
-                current_row = {
-                    'key': row['key'],
-                    'value': data_value,
-                    'type': data_type
-                }
-                if hasattr(attribute, 'assurance'):
-                    current_row = attribute.add_assurance_to_row(
-                        attribute.assurance,
-                        current_row
-                    )
+            if data_type is not False and \
+                    attribute.is_empty_certifications_field() is False:
+                    current_row = {
+                        'key': row['key'],
+                        'value': data_value,
+                        'type': data_type
+                    }
+                    if hasattr(attribute, 'assurance'):
+                        current_row = attribute.add_assurance_to_row(
+                            attribute.assurance,
+                            current_row
+                        )
 
-                rows.append(current_row)
+                    rows.append(current_row)
 
         return rows
 
@@ -135,6 +136,16 @@ class Attribute(object):
         else:
             row_object = self._add_assurance_to_string(row_object)
             return row_object
+
+    def is_empty_certifications_field(self):
+        if self.key != 'vendorCertifications':
+            return False
+
+        value = self.service_data[self.key]
+        if len(value) == 0:
+            return True
+        else:
+            return False
 
     def _add_assurance_to_list(self, row_object):
         if self.assurance != 'Service provider assertion':

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -33,6 +33,10 @@ class BaseApplicationTest(object):
         )
 
     @staticmethod
+    def _get_g4_service_fixture_data():
+        return BaseApplicationTest._get_fixture_data('g4_service_fixture.json')
+
+    @staticmethod
     def _get_g5_service_fixture_data():
         return BaseApplicationTest._get_fixture_data('g5_service_fixture.json')
 

--- a/tests/unit/test_service_presenters.py
+++ b/tests/unit/test_service_presenters.py
@@ -298,14 +298,24 @@ class TestAttribute(unittest.TestCase):
         self.assertEqual(attribute.format(False), 'No')
 
     def test_format_returns_empty_string_for_a_empty_list(self):
-        # The service API returns empty lists as [ "None" ]
-        attribute = Attribute('vendorCertifications', self.fixture)
+        self.fixture['supportedDevices'] = []
+        attribute = Attribute('supportedDevices', self.fixture)
         self.assertEqual(attribute.format([]), "")
 
     def test_format_returns_the_first_item_for_a_list_with_one_item(self):
-        # The service API returns empty lists as [ "None" ]
+        self.fixture['supportedDevices'] = ['PC']
+        attribute = Attribute('supportedDevices', self.fixture)
+        self.assertEqual(attribute.format(["PC"]), "PC")
+
+    def test_is_empty_certifications_field_works_with_empty_list(self):
+        self.fixture['vendorCertifications'] = []
         attribute = Attribute('vendorCertifications', self.fixture)
-        self.assertEqual(attribute.format(["None"]), "None")
+        self.assertEqual(attribute.is_empty_certifications_field(), True)
+
+    def test_is_empty_certifications_field_works_with_full_list(self):
+        self.fixture['vendorCertifications'] = ['Not applicable']
+        attribute = Attribute('vendorCertifications', self.fixture)
+        self.assertEqual(attribute.is_empty_certifications_field(), False)
 
 
 class TestMeta(unittest.TestCase):


### PR DESCRIPTION
Some services in lot 4 have no certifications but still show that section of attributes. They should hide them if this is the case.

See https://www.pivotaltracker.com/story/show/95242202 for reference.

Note: some of the tests for attributes with empty lists referenced the 'vendorCertifications' field so broke when this change was made. This pull request includes fixes for them.