### PR TITLE
Update links to CCS

### DIFF
--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -27,7 +27,7 @@
         <a href="/digital-services/framework">Digital Services framework</a>
       </li>
       <li>
-        <a href="https://ccs.cabinetoffice.gov.uk">Crown Commercial Service</a>
+        <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
       </li>
     </ul>
   </div>

--- a/app/templates/content/buyers-guide-g-cloud.html
+++ b/app/templates/content/buyers-guide-g-cloud.html
@@ -63,7 +63,7 @@
 <li>Review services and apply the filters to create your shortlist.</li>
 <li>Evaluate your options to find the cheapest or best value for money.</li>
 <li>Select your service, award and sign the call-off agreement.</li>
-<li>Complete the <a rel="external" href="http://ccs.cabinetoffice.gov.uk/sites/default/files/contracts/G-Cloud%20Customer%20Savings%20Record_0.docx">Crown Commercial Service (CCS) savings form</a>.</li>
+<li>Complete the <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/sites/default/files/contracts/G-Cloud%20Customer%20Benefits%20Record.docx">Crown Commercial Service (CCS) benefits form</a>.</li>
 </ol>
 
 <figure class="image embedded"><div class="img"><img alt="CloudStore buying process" src="/static/images/buying-process.png"></div>
@@ -213,7 +213,7 @@ The G-Cloud framework is unlike most other frameworks because it includes the su
 CCS works with departments and organisations across the public sector to improve service delivery quality and ensure every commercial relationship provides value for money. That means it has to record savings and monitor the ongoing performance of the G-Cloud framework(s).
 </p><p>
 You must fill in the CCS
-<a  rel="external" href='http://ccs.cabinetoffice.gov.uk/sites/default/files/contracts/G-Cloud%20Customer%20Savings%20Record_0.docx'>G-Cloud Customer Savings Record</a> form every time you enter into a call-off agreement. Email a copy of your G-Cloud Customer Savings Record form to <a href='mailto:gcloud-savings@ccs.gsi.gov.uk'>gcloud-savings@ccs.gsi.gov.uk</a>.
+<a  rel="external" href='http://ccs-agreements.cabinetoffice.gov.uk/sites/default/files/contracts/G-Cloud%20Customer%20Benefits%20Record.docx'>G-Cloud Customer Benefits Record</a> form every time you enter into a call-off agreement. Email a copy of your G-Cloud Customer Savings Record form to <a href='mailto:gcloud-savings@ccs.gsi.gov.uk'>gcloud-savings@ccs.gsi.gov.uk</a>.
 </p><p>
 Your contract details won't be published.
 </p>
@@ -222,7 +222,7 @@ Your contract details won't be published.
 <h2 id="g-cloud-order-form">
 <span class="number">2. </span>Choosing the right G-Cloud call-off contract</h2>
 <p>
-Cloud services on the Digital Marketplace will be on either <a rel="external" href="http://ccs.cabinetoffice.gov.uk/contracts/rm1557v">G-Cloud 5</a> or <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi">G-Cloud 6</a>. G-Cloud 6 is the latest call-off contract.
+Cloud services on the Digital Marketplace will be on either <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557v">G-Cloud 5</a> or <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi">G-Cloud 6</a>. G-Cloud 6 is the latest call-off contract.
 </p>
 
 

--- a/app/templates/content/framework-g-cloud.html
+++ b/app/templates/content/framework-g-cloud.html
@@ -96,7 +96,7 @@
         <span class="number">4. </span>Which framework agreement?
       </h2>
       <p>
-        Cloud services on the Digital Marketplace will be on either <a  rel="external" href="http://ccs.cabinetoffice.gov.uk/contracts/rm1557v">G-Cloud 5</a> or <a  rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi">G-Cloud 6</a>. G-Cloud 6 is the latest framework agreement.
+        Cloud services on the Digital Marketplace will be on either <a  rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557v">G-Cloud 5</a> or <a  rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi">G-Cloud 6</a>. G-Cloud 6 is the latest framework agreement.
       </p>
       <p>
         If you’d like to buy technology services from another framework, please email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> or <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/">find an agreement</a> on the Crown Commercial Service (CCS) website.


### PR DESCRIPTION
Crown Commercial Service's (CCS) website has transitioned to GOV.UK, and
uses Bouncer - a GOV.UK project - to redirect users from the old URL to the
new GOV.UK one. In this instance, Bouncer responds to requests for
https://ccs.cabinetoffice.gov.uk by sending a HTTP 301 in the response to
send users to
https://www.gov.uk/government/organisations/crown-commercial-service.

One thing that Bouncer explicitly doesn't do is hold SSL/TLS certificates
for domains external to GOV.UK, because that adds additional burden on to
the whole notion of URL redirection. As such, users will get an SSL
certificate error when they click the link to go to the CCS website in the
Digital Marketplace because the SSL certificate presented is for GOV.UK, not
the Common Name of the host header value - ccs.cabinetoffice.gov.uk.

Fixes URLs to avoid this.