### PR TITLE
Use option select from toolkit

### DIFF
--- a/app/assets/javascripts/_onready.js
+++ b/app/assets/javascripts/_onready.js
@@ -1,18 +1,10 @@
 (function (root) {
+
   var GOVUK = root.GOVUK || {};
-
-  if (GOVUK.CheckboxFilter) {
-    var filters = $('.js-openable-filter').map(function(){
-      return new GOVUK.CheckboxFilter({el:$(this)});
-    });
-
-    if (filters.length > 0 && $('.js-openable-filter').not('.closed').length == 0) {
-      filters[0].open();
-    }
-  }
 
   $('details').details();
   if (!$.fn.details.support) {
     $('html').addClass('no-details');
   }
+
 })(window);

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -42,7 +42,7 @@ class SearchFilters(object):
             filter = {
                 'label': option['label'],
                 'name': filter_name,
-                'id': '%s-%s' % (filter_name, filter_id),
+                'id': filter_id,
                 'value': option['label'].lower(),
                 'lots': [lot.strip() for lot in (
                     question['dependsOnLots'].lower().split(",")
@@ -186,13 +186,13 @@ class SearchFilters(object):
         for filter_group in self.filter_groups:
             for filter in filter_group['filters']:
                 if self.request_filters:
-                    filter['isSet'] = False
+                    filter['checked'] = False
                     param_values = self.request_filters.getlist(
                         filter['name'],
                         type=str
                     )
                     if len(param_values) > 0:
-                        filter['isSet'] = (
+                        filter['checked'] = (
                             filter['value'] in param_values
                         )
 

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -23,17 +23,12 @@
 <input type="hidden" name="lot" value="{{ current_lot }}" />
 {% endif %}
 {% for filter_group in filter_groups %}
-<div class="govuk-option-select">
-  <div class="container-head js-container-head">
-    <div class="option-select-label">{{ filter_group.label }}</div>
-  </div>
-  <div class="options-container">
-    <div class='js-auto-height-inner'>
-      {% for filter in filter_group.filters %}
-        {{ checkbox(filter.label, filter.name, filter.id, filter.value, filter.isSet, 'js-search-results.info') }}
-      {% endfor %}
-    </div>
-  </div>
-</div>
+  {%
+    with
+    label = filter_group.label,
+    options = filter_group.filters
+  %}
+    {% include "toolkit/forms/option-select.html" %}
+  {% endwith %}
 {% endfor %}
 <button class="button-save" type="submit">Filter</button>

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery": "1.11.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v3.1.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#5137868d0b7e7c8f916fb52e3c4c655608408c94"
   }


### PR DESCRIPTION
This updates the buyer app to
- use option-select from the Digital Marketplace frontend toolkit
- which, by proxy, uses the GOV.UK component version of option select, which this app previously did not use