### PR TITLE
Deny third-party sites from embedding in an iframe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 requests==2.5.1
 inflection==0.2.1
 pyyaml==3.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@0.21.0#egg=digitalmarketplace-utils==0.21.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@0.23.0#egg=digitalmarketplace-utils==0.23.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/views/test_application.py
+++ b/tests/app/views/test_application.py
@@ -12,4 +12,3 @@ class TestApplication(BaseApplicationTest):
         assert_true(
             'trackPageview'
             in res.get_data(as_text=True))
-        assert_in('DENY', res.headers['X-Frame-Options'])

--- a/tests/app/views/test_application.py
+++ b/tests/app/views/test_application.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal, assert_true
+from nose.tools import assert_equal, assert_true, assert_in
 from ...helpers import BaseApplicationTest
 
 
@@ -12,3 +12,4 @@ class TestApplication(BaseApplicationTest):
         assert_true(
             'trackPageview'
             in res.get_data(as_text=True))
+        assert_in('DENY', res.headers['X-Frame-Options'])

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -22,3 +22,8 @@ class TestApplication(BaseApplicationTest):
         response = self.client.get('/search/?q=r&s=t')
         assert 301 == response.status_code
         assert "http://localhost/search?q=r&s=t" == response.location
+
+    def test_header_xframeoptions_set_to_deny(self):
+        res = self.client.get('/')
+        assert 200 == res.status_code
+        assert 'DENY', res.headers['X-Frame-Options']


### PR DESCRIPTION
Upgrading to new verison of dmutils which initiates each app with the `X-Frame-Options` header set to `DENY`.
Also added test to confirm.