### PR TITLE
Add tests for filters

### DIFF
--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -61,13 +61,9 @@ class SearchFilters(object):
         )
 
         def add_filters_for_question(question, filters):
-            questions_with_options = [
-                'radios',
-                'checkboxes'
-            ]
             # if the 1st question has options, they will become the
-            # filters and it's details will define the group
-            if question['type'] in questions_with_options:
+            # filters and it's label will become the group label
+            if question['type'] in ['radios', 'checkboxes']:
                 filters += \
                     SearchFilters.get_filters_from_question_with_options(
                         question,
@@ -176,9 +172,9 @@ class SearchFilters(object):
     def _get_filters_from_request(self, request):
         """Returns the filters applied to a search from the request object"""
 
-        # TODO: only use request arguments that map to recognised filters
         filters = MultiDict(request.args.copy())
         filters.poplist('q')
+        filters.poplist('lot')
         return filters
 
     def _set_filter_states(self):
@@ -201,8 +197,8 @@ class SearchResults(object):
     """Provides access to the search results information"""
 
     @staticmethod
-    def get_search_summary(results_total, request_filters, filter_groups):
-        return SearchSummary(results_total, request_filters, filter_groups)
+    def get_search_summary(results_total, request_args, filter_groups):
+        return SearchSummary(results_total, request_args, filter_groups)
 
     def _add_highlighting(self):
         for index, service in enumerate(self.search_results):

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -42,7 +42,7 @@ class SearchFilters(object):
             filter = {
                 'label': option['label'],
                 'name': filter_name,
-                'id': filter_id,
+                'id': '{}-{}'.format(filter_name, filter_id),
                 'value': option['label'].lower(),
                 'lots': [lot.strip() for lot in (
                     question['dependsOnLots'].lower().split(",")

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -90,7 +90,7 @@ class SearchFilters(object):
             filter_groups.append(filter_group)
         return filter_groups
 
-    def __init__(self, blueprint=False, request={}):
+    def __init__(self, blueprint=None, request=None):
         self.filter_groups = blueprint.config['FILTER_GROUPS']
         self.request_filters = self._get_filters_from_request(request)
         self.lot_filters = self._get_lot_filters_from_request(request)

--- a/app/presenters/search_presenters.py
+++ b/app/presenters/search_presenters.py
@@ -131,9 +131,9 @@ class SearchFilters(object):
             if lot is not None:
                 params.append('lot=' + lot)
             if len(params) == 0:
-                return '/search'
+                return '/g-cloud/search'
             else:
-                return '/search?' + '&'.join(params)
+                return '/g-cloud/search?' + '&'.join(params)
 
         lot_names = ['all', 'saas', 'paas', 'iaas', 'scs']
         current_lot = request.args.get('lot', 'all')
@@ -181,16 +181,15 @@ class SearchFilters(object):
         """Sets a flag on each filter to mark it as set or not"""
         for filter_group in self.filter_groups:
             for filter in filter_group['filters']:
-                if self.request_filters:
-                    filter['checked'] = False
-                    param_values = self.request_filters.getlist(
-                        filter['name'],
-                        type=str
+                filter['checked'] = False
+                param_values = self.request_filters.getlist(
+                    filter['name'],
+                    type=str
+                )
+                if len(param_values) > 0:
+                    filter['checked'] = (
+                        filter['value'] in param_values
                     )
-                    if len(param_values) > 0:
-                        filter['checked'] = (
-                            filter['value'] in param_values
-                        )
 
 
 class SearchResults(object):

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery": "1.11.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#5137868d0b7e7c8f916fb52e3c4c655608408c94"
   }

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -5,6 +5,10 @@ else
   source ./venv/bin/activate 2>/dev/null && echo "Virtual environment activated."
 fi
 
+# Build front-end static assets
+npm run frontend-build:production
+echo ""
+
 # Use default environment vars for localhost if not already set
 export DM_DATA_API_URL=${DM_DATA_API_URL:=http://localhost:5000}
 export DM_DATA_API_AUTH_TOKEN=${DM_DATA_API_AUTH_TOKEN:=myToken}

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -6,7 +6,10 @@ from ...helpers import BaseApplicationTest
 
 
 def find_pagination_links(res_data):
-    return re.findall(r'<a href="(/g-cloud/search\?[^"]+)"', res_data)
+    return re.findall(
+        '<li class="[next|previous]+">[^<]+<a\ href="(/g-cloud/search\?[^"]+)',
+        res_data,
+        re.MULTILINE)
 
 
 def find_search_summary(res_data):
@@ -115,7 +118,6 @@ class TestSearchResults(BaseApplicationTest):
         assert_true(
             '<li class="next">'
             in res.get_data(as_text=True))
-
         (prev_link, next_link) = find_pagination_links(
             res.get_data(as_text=True))
 

--- a/tests/fixtures/g6_questions/data/booleanExample1.yml
+++ b/tests/fixtures/g6_questions/data/booleanExample1.yml
@@ -1,4 +1,4 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+dependsOnLots: 'SaaS, PaaS' 
 type: boolean
 filterLabel: 'Option 1'
 validations:

--- a/tests/fixtures/g6_questions/data/booleanExample1.yml
+++ b/tests/fixtures/g6_questions/data/booleanExample1.yml
@@ -1,0 +1,8 @@
+dependsOnLots: 'SaaS, PaaS, IaaS'
+type: boolean
+filterLabel: 'Option 1'
+validations:
+  -
+    name: answer_required
+    message: 'This question requires an answer.'
+question: 'Option 1'

--- a/tests/fixtures/g6_questions/data/booleanExample2.yml
+++ b/tests/fixtures/g6_questions/data/booleanExample2.yml
@@ -1,0 +1,8 @@
+dependsOnLots: 'SaaS, PaaS, IaaS'
+type: boolean
+filterLabel: 'Option 2'
+validations:
+  -
+    name: answer_required
+    message: 'This question requires an answer.'
+question: 'Option 2'

--- a/tests/fixtures/g6_questions/data/booleanExample2.yml
+++ b/tests/fixtures/g6_questions/data/booleanExample2.yml
@@ -1,4 +1,4 @@
-dependsOnLots: 'SaaS, PaaS, IaaS'
+dependsOnLots: 'SaaS, PaaS'
 type: boolean
 filterLabel: 'Option 2'
 validations:

--- a/tests/fixtures/g6_questions/data/checkboxesExample.yml
+++ b/tests/fixtures/g6_questions/data/checkboxesExample.yml
@@ -1,0 +1,15 @@
+dependsOnLots: 'SaaS, PaaS, IaaS'
+hint: 'Choose all options that apply'
+type: checkboxes
+options:
+    -
+        label: 'Option 1'
+        filterLabel: 'Option 1'
+    -
+        label: 'Option 2'
+        filterLabel: 'Option 2'
+validations:
+  -
+    name: answer_required
+    message: 'This question requires an answer.'
+question: 'Choose all options that apply'

--- a/tests/fixtures/g6_questions/data/listExample.yml
+++ b/tests/fixtures/g6_questions/data/listExample.yml
@@ -1,0 +1,6 @@
+dependsOnLots: 'SaaS, PaaS, IaaS'
+hint: 'Enter all the parts of the answer'
+listItemName: 'certification example'
+type: list
+addthing: 'Add another part'
+question: 'Enter your answer'

--- a/tests/fixtures/g6_questions/data/radiosExample.yml
+++ b/tests/fixtures/g6_questions/data/radiosExample.yml
@@ -1,0 +1,14 @@
+dependsOnLots: 'SaaS, PaaS, IaaS'
+type: radios
+options:
+    -
+        label: "Option 1"
+        filterLabel: "Option 1"
+    -
+        label: "Option 2"
+        filterLabel: "Option 2"
+validations:
+  -
+    name: answer_required
+    message: 'This question requires an answer.'
+question: 'Choose one option'

--- a/tests/fixtures/g6_questions/manifest.yml
+++ b/tests/fixtures/g6_questions/manifest.yml
@@ -1,0 +1,13 @@
+-
+  name: Booleans example
+  questions:
+    - booleanExample1
+    - booleanExample2
+-
+  name: Checkboxes example
+  questions:
+    - checkboxesExample
+-
+  name: Radios example
+  questions:
+    - radiosExample

--- a/tests/unit/test_search_presenters.py
+++ b/tests/unit/test_search_presenters.py
@@ -323,8 +323,6 @@ class TestSearchSummary(unittest.TestCase):
 
 class TestSearchFilters(unittest.TestCase):
 
-    maxDiff = None
-
     def setup(self):
         pass
 
@@ -335,6 +333,18 @@ class TestSearchFilters(unittest.TestCase):
         for filter_group in filter_groups:
             if filter_group['label'] == label:
                 return filter_group
+
+    def _get_blueprint_mock(self):
+        blueprint = Mock(config={
+            'FILTER_GROUPS': SearchFilters.get_filter_groups_from_questions(
+                manifest="tests/fixtures/g6_questions/manifest.yml",
+                questions_dir="tests/fixtures/g6_questions/data/"
+            )
+        })
+        return blueprint
+
+    def _get_request_for_params(self, params):
+        return Mock(args=MultiDict(params))
 
     def test_get_filter_groups_from_questions_with_radio_filters(self):
         filter_groups = SearchFilters.get_filter_groups_from_questions(
@@ -408,24 +418,230 @@ class TestSearchFilters(unittest.TestCase):
         self.assertEqual({
             'label': 'Booleans example',
             'depends_on_lots': [
-                'saas', 'paas', 'iaas', 'saas', 'paas', 'iaas'],
+                'saas', 'paas', 'saas', 'paas'],
             'filters': [
                 {
                     'label': 'Option 1',
                     'name': 'booleanExample1',
                     'id': 'booleanExample1',
                     'value': 'true',
-                    'lots': ['saas', 'paas', 'iaas']
+                    'lots': ['saas', 'paas']
                 },
                 {
                     'label': 'Option 2',
                     'name': 'booleanExample2',
                     'id': 'booleanExample2',
                     'value': 'true',
-                    'lots': ['saas', 'paas', 'iaas']
+                    'lots': ['saas', 'paas']
                 }
             ]
         }, booleans_filter_group)
+
+    def test_request_filters_are_set(self):
+        search_filters = SearchFilters(
+            blueprint=self._get_blueprint_mock(),
+            request=self._get_request_for_params({
+                'q': 'email',
+                'booleanExample1': 'true'
+            })
+        )
+
+        self.assertIsInstance(search_filters.request_filters, MultiDict)
+        self.assertEqual(
+            search_filters.request_filters.get('booleanExample1'), 'true')
+
+    def test_request_filters_strip_out_lot_and_keywords(self):
+        search_filters = SearchFilters(
+            blueprint=self._get_blueprint_mock(),
+            request=self._get_request_for_params({
+                'q': 'email',
+                'lot': 'saas',
+                'booleanExample1': 'true'
+            })
+        )
+
+        self.assertEqual(
+            search_filters.request_filters.get('lot', ''), '')
+
+    def test_filter_groups_have_correct_default_state(self):
+        search_filters = SearchFilters(
+            blueprint=self._get_blueprint_mock(),
+            request=self._get_request_for_params({
+                'q': 'email',
+                'lot': 'paas'
+            })
+        )
+        boolean_filter_group = self._get_filter_group_by_label(
+            search_filters.filter_groups, 'Booleans example'
+        )
+        self.assertEqual(
+            boolean_filter_group,
+            {
+                'label': 'Booleans example',
+                'depends_on_lots': [
+                    'saas', 'paas', 'saas', 'paas'],
+                'filters': [
+                    {
+                        'isSet': False,
+                        'label': 'Option 1',
+                        'name': 'booleanExample1',
+                        'id': 'booleanExample1',
+                        'value': 'true',
+                        'lots': ['saas', 'paas']
+                    },
+                    {
+                        'isSet': False,
+                        'label': 'Option 2',
+                        'name': 'booleanExample2',
+                        'id': 'booleanExample2',
+                        'value': 'true',
+                        'lots': ['saas', 'paas']
+                    }
+                ]
+            }
+        )
+
+    def test_filter_groups_have_correct_state_when_changed(self):
+        search_filters = SearchFilters(
+            blueprint=self._get_blueprint_mock(),
+            request=self._get_request_for_params({
+                'q': 'email',
+                'lot': 'paas',
+                'booleanExample1': 'true'
+            })
+        )
+        boolean_filter_group = self._get_filter_group_by_label(
+            search_filters.filter_groups, 'Booleans example'
+        )
+        self.assertEqual(
+            boolean_filter_group,
+            {
+                'label': 'Booleans example',
+                'depends_on_lots': [
+                    'saas', 'paas', 'saas', 'paas'],
+                'filters': [
+                    {
+                        'isSet': True,
+                        'label': 'Option 1',
+                        'name': 'booleanExample1',
+                        'id': 'booleanExample1',
+                        'value': 'true',
+                        'lots': ['saas', 'paas']
+                    },
+                    {
+                        'isSet': False,
+                        'label': 'Option 2',
+                        'name': 'booleanExample2',
+                        'id': 'booleanExample2',
+                        'value': 'true',
+                        'lots': ['saas', 'paas']
+                    }
+                ]
+            }
+        )
+
+    def test_lot_filters_work_when_no_lot_is_selected(self):
+        search_filters = SearchFilters(
+            blueprint=self._get_blueprint_mock(),
+            request=self._get_request_for_params({
+                'q': 'email'
+            })
+        )
+        self.assertEqual(
+            search_filters.lot_filters,
+            [
+                {
+                    'isActive': True,
+                    'label': u'All categories',
+                    'url': '/g-cloud/search?q=email'
+                },
+                {
+                    'isActive': False,
+                    'label': u'Software as a Service',
+                    'url': '/g-cloud/search?q=email&lot=saas'
+                },
+                {
+                    'isActive': False,
+                    'label': u'Platform as a Service',
+                    'url': '/g-cloud/search?q=email&lot=paas'
+                },
+                {
+                    'isActive': False,
+                    'label': u'Infrastructure as a Service',
+                    'url': '/g-cloud/search?q=email&lot=iaas'
+                },
+                {
+                    'isActive': False,
+                    'label': u'Specialist Cloud Services',
+                    'url': '/g-cloud/search?q=email&lot=scs'
+                }
+            ])
+
+    def test_lot_filters_work_when_a_lot_is_selected(self):
+        search_filters = SearchFilters(
+            blueprint=self._get_blueprint_mock(),
+            request=self._get_request_for_params({
+                'q': 'email',
+                'lot': 'saas'
+            })
+        )
+        self.assertEqual(
+            search_filters.lot_filters,
+            [
+                {
+                    'isActive': False,
+                    'label': u'All categories',
+                    'url': '/g-cloud/search?q=email'
+                },
+                {
+                    'isActive': True,
+                    'label': u'Software as a Service',
+                    'url': '/g-cloud/search?q=email&lot=saas'
+                },
+                {
+                    'isActive': False,
+                    'label': u'Platform as a Service',
+                    'url': '/g-cloud/search?q=email&lot=paas'
+                },
+                {
+                    'isActive': False,
+                    'label': u'Infrastructure as a Service',
+                    'url': '/g-cloud/search?q=email&lot=iaas'
+                },
+                {
+                    'isActive': False,
+                    'label': u'Specialist Cloud Services',
+                    'url': '/g-cloud/search?q=email&lot=scs'
+                }
+            ])
+
+    def test_instance_has_correct_filter_groups_for_paas(self):
+        search_filters = SearchFilters(
+            blueprint=self._get_blueprint_mock(),
+            request=self._get_request_for_params({
+                'q': 'email',
+                'lot': 'paas'
+            })
+        )
+        filter_group_labels = [
+            group['label'] for group in search_filters.filter_groups]
+        self.assertTrue('Booleans example' in filter_group_labels)
+        self.assertTrue('Checkboxes example' in filter_group_labels)
+        self.assertTrue('Radios example' in filter_group_labels)
+
+    def test_instance_has_correct_filter_groups_for_iaas(self):
+        search_filters = SearchFilters(
+            blueprint=self._get_blueprint_mock(),
+            request=self._get_request_for_params({
+                'q': 'email',
+                'lot': 'iaas'
+            })
+        )
+        filter_group_labels = [
+            group['label'] for group in search_filters.filter_groups]
+        self.assertFalse('Booleans example' in filter_group_labels)
+        self.assertTrue('Checkboxes example' in filter_group_labels)
+        self.assertTrue('Radios example' in filter_group_labels)
 
 
 class TestSummaryRules(unittest.TestCase):

--- a/tests/unit/test_search_presenters.py
+++ b/tests/unit/test_search_presenters.py
@@ -321,6 +321,113 @@ class TestSearchSummary(unittest.TestCase):
             Markup(u"5 results found with option1 and option2"))
 
 
+class TestSearchFilters(unittest.TestCase):
+
+    maxDiff = None
+
+    def setup(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def _get_filter_group_by_label(self, filter_groups, label):
+        for filter_group in filter_groups:
+            if filter_group['label'] == label:
+                return filter_group
+
+    def test_get_filter_groups_from_questions_with_radio_filters(self):
+        filter_groups = SearchFilters.get_filter_groups_from_questions(
+            manifest="tests/fixtures/g6_questions/manifest.yml",
+            questions_dir="tests/fixtures/g6_questions/data/"
+        )
+        radios_filter_group = self._get_filter_group_by_label(
+            filter_groups,
+            'Radios example'
+        )
+        self.assertEqual({
+            'label': 'Radios example',
+            'depends_on_lots': ['saas', 'paas', 'iaas'],
+            'filters': [
+                {
+                    'label': 'Option 1',
+                    'name': 'radiosExample',
+                    'id': 'radiosExample-option-1',
+                    'value': 'option 1',
+                    'lots': ['saas', 'paas', 'iaas']
+                },
+                {
+                    'label': 'Option 2',
+                    'name': 'radiosExample',
+                    'id': 'radiosExample-option-2',
+                    'value': 'option 2',
+                    'lots': ['saas', 'paas', 'iaas']
+                }
+            ]
+        }, radios_filter_group)
+
+    def test_get_filter_groups_from_questions_with_checkbox_filters(self):
+        filter_groups = SearchFilters.get_filter_groups_from_questions(
+            manifest="tests/fixtures/g6_questions/manifest.yml",
+            questions_dir="tests/fixtures/g6_questions/data/"
+        )
+        checkboxes_filter_group = self._get_filter_group_by_label(
+            filter_groups,
+            'Checkboxes example'
+        )
+        self.assertEqual({
+            'label': 'Checkboxes example',
+            'depends_on_lots': ['saas', 'paas', 'iaas'],
+            'filters': [
+                {
+                    'label': 'Option 1',
+                    'name': 'checkboxesExample',
+                    'id': 'checkboxesExample-option-1',
+                    'value': 'option 1',
+                    'lots': ['saas', 'paas', 'iaas']
+                },
+                {
+                    'label': 'Option 2',
+                    'name': 'checkboxesExample',
+                    'id': 'checkboxesExample-option-2',
+                    'value': 'option 2',
+                    'lots': ['saas', 'paas', 'iaas']
+                }
+            ]
+        }, checkboxes_filter_group)
+
+    def test_get_filter_groups_from_questions_with_boolean_filters(self):
+        filter_groups = SearchFilters.get_filter_groups_from_questions(
+            manifest="tests/fixtures/g6_questions/manifest.yml",
+            questions_dir="tests/fixtures/g6_questions/data/"
+        )
+        booleans_filter_group = self._get_filter_group_by_label(
+            filter_groups,
+            'Booleans example'
+        )
+        self.assertEqual({
+            'label': 'Booleans example',
+            'depends_on_lots': [
+                'saas', 'paas', 'iaas', 'saas', 'paas', 'iaas'],
+            'filters': [
+                {
+                    'label': 'Option 1',
+                    'name': 'booleanExample1',
+                    'id': 'booleanExample1',
+                    'value': 'true',
+                    'lots': ['saas', 'paas', 'iaas']
+                },
+                {
+                    'label': 'Option 2',
+                    'name': 'booleanExample2',
+                    'id': 'booleanExample2',
+                    'value': 'true',
+                    'lots': ['saas', 'paas', 'iaas']
+                }
+            ]
+        }, booleans_filter_group)
+
+
 class TestSummaryRules(unittest.TestCase):
 
     def setUp(self):

--- a/tests/unit/test_search_presenters.py
+++ b/tests/unit/test_search_presenters.py
@@ -482,7 +482,7 @@ class TestSearchFilters(unittest.TestCase):
                     'saas', 'paas', 'saas', 'paas'],
                 'filters': [
                     {
-                        'isSet': False,
+                        'checked': False,
                         'label': 'Option 1',
                         'name': 'booleanExample1',
                         'id': 'booleanExample1',
@@ -490,7 +490,7 @@ class TestSearchFilters(unittest.TestCase):
                         'lots': ['saas', 'paas']
                     },
                     {
-                        'isSet': False,
+                        'checked': False,
                         'label': 'Option 2',
                         'name': 'booleanExample2',
                         'id': 'booleanExample2',
@@ -521,7 +521,7 @@ class TestSearchFilters(unittest.TestCase):
                     'saas', 'paas', 'saas', 'paas'],
                 'filters': [
                     {
-                        'isSet': True,
+                        'checked': True,
                         'label': 'Option 1',
                         'name': 'booleanExample1',
                         'id': 'booleanExample1',
@@ -529,7 +529,7 @@ class TestSearchFilters(unittest.TestCase):
                         'lots': ['saas', 'paas']
                     },
                     {
-                        'isSet': False,
+                        'checked': False,
                         'label': 'Option 2',
                         'name': 'booleanExample2',
                         'id': 'booleanExample2',


### PR DESCRIPTION
The `SearchFilters` class never had any tests so this adds some:

https://www.pivotaltracker.com/story/show/94070154

Also includes some extra code to deal with the new way the SSP content is loaded and used by the `ContentLoader` helper (see https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/76).