### PR TITLE
Use contact details pattern from toolkit

### DIFF
--- a/app/assets/javascripts/_onready.js
+++ b/app/assets/javascripts/_onready.js
@@ -2,9 +2,4 @@
 
   var GOVUK = root.GOVUK || {};
 
-  $('details').details();
-  if (!$.fn.details.support) {
-    $('html').addClass('no-details');
-  }
-
 })(window);

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -22,6 +22,8 @@ $path: "/static/images/";
 @import "forms/_summary.scss";
 @import "forms/_textboxes.scss";
 @import "_document.scss";
+@import "toolkit/contact-details.scss";
+
 @import "_table.scss";
 @import "_notice.scss";
 

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -23,21 +23,14 @@
     <span>{{ group }}</span>
   {% endfor %}
   </p>
-  <h2 class="visuallyhidden">Contact details</h2>
-  <details class="contact">
-    <summary class="summary">Contact {{ service.supplierName }}</summary>
-    <div class="indented">
-      <ul>
-        <li>
-          {{ service.meta.contact.name }}
-        </li>
-        <li>
-          {{ service.meta.contact.phone if service.meta.contact.phone }}
-        </li>
-        <li>
-          <a href="mailto:{{ service.meta.contact.email }}" data-event-category="Email a supplier" data-event-label="Fastnet International Ltd">{{ service.meta.contact.email }}</a>
-        </li>
-      </ul>
-    </div>
-  </details>
+  {%
+    with
+    organisation_type="supplier",
+    organisation=service.supplierName,
+    telephone=service.meta.contact.phone or None,
+    contact_name=service.meta.contact.name,
+    email_address=service.meta.contact.email
+  %}
+    {% include "toolkit/contact-details.html" %}
+  {% endwith %}
 </div>

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.12.0/jinja_govuk_template-0.12.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#5137868d0b7e7c8f916fb52e3c4c655608408c94"

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -34,18 +34,20 @@ class TestServicePage(BaseApplicationTest):
         contact_info = self.supplier['suppliers']['contactInformation'][0]
 
         meta = document.xpath('//div[@id="meta"]')[0]
-        contact_heading = meta.xpath('//details/summary/text()')[0]
-        lis = [li.text_content().strip() for li in meta.xpath('//details//li')]
+        contact_heading = meta.xpath('//div/p[@class="contact-details-organisation"]/span/text()')[0]  # noqa
+        ps = [
+            p.text_content().strip()
+            for p in meta.xpath('//div[@class="contact-details"]//p')
+        ]
 
-        assert_equal("Contact {}".format(supplier_name), contact_heading)
+        assert_equal(supplier_name, contact_heading)
 
         for contact_detail in [
             contact_info['contactName'],
             contact_info['phoneNumber'],
             contact_info['email']
         ]:
-
-            assert_in("{}".format(contact_detail), lis)
+            assert_in("{}".format(contact_detail), ps)
 
     def _assert_document_links(self, document):
 


### PR DESCRIPTION
--
![image](https://cloud.githubusercontent.com/assets/355079/8163625/2a44f21e-137c-11e5-8463-6c59fa46991b.png)
--

This pull request:
- uses the shared templates from the toolkit
- which means no more ▶ ▼

Finishes this story: https://www.pivotaltracker.com/story/show/96536378