### PR TITLE
[#98094170] Prettify G5 additional filenames

### DIFF
--- a/app/presenters/service_presenters.py
+++ b/app/presenters/service_presenters.py
@@ -231,18 +231,18 @@ class Meta(object):
                 extension = self._get_document_extension(url)
                 documents.append({
                     'name':  names[index],
-                    'url': self._replace_whitespace(url, '%20'),
+                    'url': url,
                     'extension': extension
                 })
 
         # get additional documents, if they exist
         if 'additionalDocumentURLs' in service_data:
-            for document_url in service_data['additionalDocumentURLs']:
-                extension = self._get_document_extension(document_url)
-                name = self._get_document_name_without_extension(document_url)
+            for index, url in enumerate(service_data['additionalDocumentURLs'], 1):
+                extension = self._get_document_extension(url)
+                name = "Additional document #{}".format(index)
                 documents.append({
                     'name':  name,
-                    'url': self._replace_whitespace(document_url, '%20'),
+                    'url': url,
                     'extension': extension
                 })
 
@@ -301,17 +301,9 @@ class Meta(object):
             caveats.append(options)
         return caveats
 
-    def _get_document_name_without_extension(self, document_url):
-        document_basename = os.path.basename(urlparse(document_url).path)
-        return os.path.splitext(document_basename)[0]
-
     def _get_document_extension(self, document_url):
         url_object = urlparse(document_url)
         return os.path.splitext(url_object.path)[1].split('.')[1]
-
-    def _replace_whitespace(self, string, replacement_substring):
-                # Replace all runs of whitespace with replacement_substring
-                return re.sub(r"\s+", replacement_substring, string)
 
     def _if_both_keys_or_either(self, service_data, keys=[], values={}):
         def is_not_false(key):
@@ -320,7 +312,6 @@ class Meta(object):
             else:
                 return False
 
-        caveat = ''
         if is_not_false(keys[0]) and is_not_false(keys[1]):
             caveat = values['if_both']
         elif is_not_false(keys[0]):

--- a/app/presenters/service_presenters.py
+++ b/app/presenters/service_presenters.py
@@ -5,6 +5,10 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse
+try:
+    from urllib import unquote
+except ImportError:
+    from urllib.parse import unquote
 
 
 class Service(object):
@@ -239,7 +243,7 @@ class Meta(object):
         if 'additionalDocumentURLs' in service_data:
             for index, url in enumerate(service_data['additionalDocumentURLs'], 1):
                 extension = self._get_document_extension(url)
-                name = "Additional document #{}".format(index)
+                name = self._get_pretty_document_name_without_extension(url)
                 documents.append({
                     'name':  name,
                     'url': url,
@@ -300,6 +304,11 @@ class Meta(object):
         if options:
             caveats.append(options)
         return caveats
+
+    def _get_pretty_document_name_without_extension(self, document_url):
+        document_basename = os.path.basename(urlparse(document_url).path)
+        filename = unquote(os.path.splitext(document_basename)[0])
+        return filename.replace('_', ' ')
 
     def _get_document_extension(self, document_url):
         url_object = urlparse(document_url)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [pep8]
 exclude = ./venv,./bower_components,./node_modules
+max-line-length = 120

--- a/tests/fixtures/g5_service_fixture.json
+++ b/tests/fixtures/g5_service_fixture.json
@@ -34,13 +34,13 @@
     "selfServiceProvisioning": false,
     "supportForThirdParties": true,
     "educationPricing": true,
-    "pricingDocumentURL": "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Pricing Document.docx",
-    "serviceDefinitionDocumentURL": "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Service Definition.docx",
-    "sfiaRateDocumentURL": "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Rate card.docx",
+    "pricingDocumentURL": "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Pricing%20Document.docx",
+    "serviceDefinitionDocumentURL": "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Service%20Definition.docx",
+    "sfiaRateDocumentURL": "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Rate%20card.docx",
     "termsAndConditionsDocumentURL": "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/TandC_data_collection.doc",
     "additionalDocumentURLs": [
-      "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Appendix 1.pdf",
-      "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Appendix 2.pdf"
+      "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Appendix%201.pdf",
+      "http://assets-production.govstore.service.gov.uk/G5/Supplier/someId/Appendix%202.pdf"
     ]
   }
 }


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/98094170

Rather than re-introduce spaces to the filenames for link text, I think it is better to standardise on "Additional document #1", etc. for consistency.

This PR also bumps the PEP8 line length limit to 120 characters.

Before: 
![screen shot 2015-07-01 at 12 29 10](https://cloud.githubusercontent.com/assets/6525554/8454395/db7a93de-1ff4-11e5-9c6c-d03024832899.png)

After:
![screen shot 2015-07-01 at 13 29 54](https://cloud.githubusercontent.com/assets/6525554/8454450/528b234e-1ff5-11e5-9ee7-e117cb791a57.png)

