### PR TITLE
Fix some syntax errors in application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,7 +2,6 @@
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-classic-tracker.js
 //= include ../../../bower_components/jquery/dist/jquery.js
-//= include ../../../bower_components/jquery-details/jquery.details.js
-//= include ../../../bower_components/digitalmarketplace_frontend_toolkit/toolkit/javascripts/option-select.js
-//= include _analytics.js',
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/option-select.js
+//= include _analytics.js'
 //= include _onready.js'


### PR DESCRIPTION
Includes:
- the removal of jquery.details which is no longer
  used
- switching out underscores for hyphens in the
  toolkit repo name
- removing a stray comma