### PR TITLE
Filter args for search summary

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -21,7 +21,8 @@ from ..presenters.service_presenters import Service
 from ..helpers.search_helpers import (
     get_keywords_from_request, get_template_data, pagination,
     get_page_from_request, query_args_for_pagination,
-    get_lot_from_request, build_search_query
+    get_lot_from_request, build_search_query,
+    clean_request_args
 )
 
 from ..exceptions import AuthException
@@ -248,7 +249,7 @@ def search():
 
     search_summary = SearchSummary(
         response['meta']['total'],
-        request.args,
+        clean_request_args(request.args, filters),
         filters
     )
 

--- a/app/presenters/search_summary.py
+++ b/app/presenters/search_summary.py
@@ -1,6 +1,6 @@
 import os
 import yaml
-from flask import Markup
+from flask import Markup, escape
 from dmutils.formats import get_label_for_lot_param
 
 
@@ -51,7 +51,7 @@ class SearchSummary(object):
                 )
 
     def _set_initial_sentence(self, results_total, request_args):
-        keywords = request_args.get('q', '', type=str)
+        keywords = escape(request_args.get('q', '', type=str))
         lot_label = get_label_for_lot_param(
             request_args.get('lot', 'all', type=str)) or 'All categories'
         lot = u"{}{}{}".format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 requests==2.5.1
 inflection==0.2.1
 pyyaml==3.11
-git+https://github.com/alphagov/digitalmarketplace-utils.git@3.0.0#egg=digitalmarketplace-utils==3.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@3.1.1#egg=digitalmarketplace-utils==3.1.1
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -333,3 +333,15 @@ class TestSearchResults(BaseApplicationTest):
         assert_true('a <em>Day</em>' in summary)
         assert_true('with a datacentre tier of' in summary)
         assert_true('<em>TIA-942 Tier 1</em>' in summary)
+
+    def test_should_ignore_unknown_arguments(self):
+        return_value = self.search_results_multiple_page
+        return_value["services"] = [return_value["services"][0]]
+        return_value["meta"]["total"] = 1
+        self._search_api_client.search_services.return_value = return_value
+
+        res = self.client.get(
+            '/g-cloud/search?q=&lot=saas' +
+            '&minimumContractPeriod=hr&minimumContractPeriod=dy')
+
+        assert_equal(200, res.status_code)

--- a/tests/unit/test_search_helpers.py
+++ b/tests/unit/test_search_helpers.py
@@ -133,6 +133,9 @@ class TestBuildSearchQueryHelpers(object):
             'question4': {},
             'question3': {'type': 'radios'},
             'question6': {'type': 'checkboxes'},
+            'page': {},
+            'lot': {},
+            'q': {},
         }
 
         def _mock_get_question(question):
@@ -176,24 +179,40 @@ class TestBuildSearchQueryHelpers(object):
             }
         )
 
-    def test_clean_request_filters(self):
+    def test_clean_request_args(self):
         filters = MultiDict({
             'question1': 'true',
             'question2': ['true', 'false', 1],
             'question3': ['option1', 'true', 'option5', 'option2', 2, None],
             'question6': '',
             'question4': 'false',
-            'lot': 'false',
-            'page': 'false',
+            'lot': 'saas',
+            'q': 'email',
+            'page': 9,
+            'unknown': 'key',
         })
 
         assert_equal(
-            search_helpers.clean_request_filters(filters, self.lot_filters),
+            search_helpers.clean_request_args(filters, self.lot_filters),
             MultiDict({
                 'question1': 'true',
                 'question2': 'true',
                 'question3': ['option1', 'option2'],
+                'page': 'false',
+                'q': 'email',
+                'lot': 'saas',
+                'page': 9,
             })
+        )
+
+    def test_clean_request_args_incorrect_lot(self):
+        filters = MultiDict({
+            'lot': 'saaspaas',
+        })
+
+        assert_equal(
+            search_helpers.clean_request_args(filters, self.lot_filters),
+            MultiDict({})
         )
 
     def test_group_request_filters(self):
@@ -207,9 +226,9 @@ class TestBuildSearchQueryHelpers(object):
         assert_equal(
             search_helpers.group_request_filters(filters, self._loader()),
             {
-                'question1': ['true'],
-                'question4': ['true'],
-                'question3': ['option1,option2'],
+                'question1': 'true',
+                'question4': 'true',
+                'question3': 'option1,option2',
                 'question6': ['option1', 'option3'],
             }
         )
@@ -234,9 +253,9 @@ class TestBuildSearchQueryHelpers(object):
                 'page': 5,
                 'q': 'email',
                 'lot': 'saas',
-                'question1': ['true'],
-                'question4': ['true'],
-                'question3': ['option1,option2'],
+                'question1': 'true',
+                'question4': 'true',
+                'question3': 'option1,option2',
                 'question6': ['option1', 'option3'],
             }
         )


### PR DESCRIPTION
### Pass cleaned request args to the SearchSummary
Removes any `None` parts from the search summary that used to appear
when request contained unknown filter values. Also fixes any issues
(including IndexErrors) related to search summary not handling invalid
filter/lot values.

### Escape keywords query string in search summary text
[#98448048](https://www.pivotaltracker.com/story/show/98448048)

Prevents HTML injection from search string text into search summary
by escaping the contents of the `q=` query parameter. This is the only
parameter that needs escaping since filters and lot are validated
against a list of known supported values.