### PR TITLE
Update links on homepage

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,7 +10,7 @@
       Digital Marketplace
     </h1>
     <p class="lead">
-      Find technology or people to deliver digital projects in the public sector
+      Find technology or people for digital projects in the public sector
     </p>
   </header>
 
@@ -23,7 +23,7 @@
           eg web hosting or IT health checks
       </p>
       <p class="browse-list-item-subtext">
-        Procurement framework: <a href="/g-cloud/framework">G-Cloud</a>
+        <a href="/g-cloud/framework">Procurement framework: G-Cloud</a>
       </p>
     </li>
     <li class="browse-list-item">
@@ -31,7 +31,7 @@
         Buy physical datacentre space for legacy systems
       </a>
       <p class="browse-list-item-subtext">
-        Procurement framework: <a href="/crown-hosting/framework">Crown Hosting Data Centres</a>
+        <a href="/crown-hosting/framework">Procurement framework: Crown Hosting Data Centres</a>
       </p>
     </li>
     <li class="browse-list-item">
@@ -42,7 +42,7 @@
           eg technical architects and user researchers
       </p>
       <p class="browse-list-item-subtext">
-        Procurement framework: <a href="/digital-services/framework">Digital Services</a>
+        <a href="/digital-services/framework">Procurement framework: Digital Services</a>
       </p>
     </li>
   </ul>

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v5.0.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v6.0.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.0/jinja_govuk_template-0.14.0.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
   }


### PR DESCRIPTION
Includes:
- https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/101 – custom underlines for browse list

This is a breaking version change, but since buyer frontend doesn't use selection buttons (the thing that's changed) it shouldn't cause any problems.