### PR TITLE
Remove warning banners from supplier A–Z

### DIFF
--- a/app/templates/_warning.html
+++ b/app/templates/_warning.html
@@ -1,6 +1,0 @@
-<div class="banner-warning-without-action">
-    <p class="banner-message">
-        <strong>This page is for information only</strong><br/>Services should be chosen using your requirements.<br/>
-        Please use the <a href="https://www.digitalmarketplace.service.gov.uk/buyers-guide/">buyers guide</a> for help.
-    </p>
-</div>

--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -30,8 +30,6 @@
 
 {% block main_content %}
 
-{% include '_warning.html' %}
-
 <div class="grid-row">
     <div class="column-two-thirds">
       {%

--- a/app/templates/suppliers_list.html
+++ b/app/templates/suppliers_list.html
@@ -22,8 +22,6 @@
 
 {% block main_content %}
 
-{% include '_warning.html' %}
-
 {%
   with
   heading = "Suppliers"

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -133,17 +133,6 @@ class TestSuppliersPage(BaseApplicationTest):
             supplier_html
             in self._strip_whitespace(res.get_data(as_text=True)))
 
-    def test_should_show_warning_message_on_supplier_list(self):
-        res = self.client.get('/g-cloud/suppliers')
-        assert_equal(200, res.status_code)
-
-        assert_true(
-            '<strong>This page is for information only</strong><br/>Services should be chosen using your requirements.'  # noqa
-            in res.get_data(as_text=True))
-        assert_true(
-            'Please use the <a href="https://www.digitalmarketplace.service.gov.uk/buyers-guide/">buyers guide</a> for help.'  # noqa
-            in res.get_data(as_text=True))
-
     def test_should_show_next_page_on_supplier_list(self):
         res = self.client.get('/g-cloud/suppliers')
         assert_equal(200, res.status_code)
@@ -245,16 +234,6 @@ class TestSuppliersPage(BaseApplicationTest):
             next_html_page
             in res.get_data(as_text=True)
         )
-
-    def test_should_show_warning_message_on_supplier_details(self):
-        res = self.client.get('/g-cloud/supplier/92191')
-        assert_equal(200, res.status_code)
-        assert_true(
-            '<strong>This page is for information only</strong><br/>Services should be chosen using your requirements.'  # noqa
-            in res.get_data(as_text=True))
-        assert_true(
-            'Please use the <a href="https://www.digitalmarketplace.service.gov.uk/buyers-guide/">buyers guide</a> for help.'  # noqa
-            in res.get_data(as_text=True))
 
     def test_should_have_supplier_details_on_supplier_page(self):
         res = self.client.get('/g-cloud/supplier/92191')


### PR DESCRIPTION
Since we're not showing any of the supplier's services on these pages it's not possible for a buyer to use them to do a non compliant procurement.

Therefore we don't need to show the warning.

Discussed with Caroline this morning.

After
--
![image](https://cloud.githubusercontent.com/assets/355079/8746763/6505d460-2c84-11e5-8105-1733ac7b9e21.png)

Before
--
![image](https://cloud.githubusercontent.com/assets/355079/8746784/9286ce08-2c84-11e5-857e-c7dfb23f9400.png)
