### PR TITLE
Move contact details if no clients/description

### DIFF
--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -46,17 +46,19 @@
 </div>
 
 <div class="grid-row supplier-profile">
-    <div class="column-two-thirds">
-        <p class="supplier-description">
-            {{ supplier.description }}
-        </p>
-        {% if supplier.clients %}
-            <h2>Clients</h2>
-            <p class="supplier-description">
-              {{ ", ".join(supplier.clients) }}
-            </p>
-        {% endif %}
-    </div>
+    {% if supplier.description or supplier.clients %}
+      <div class="column-two-thirds">
+          <p class="supplier-description">
+              {{ supplier.description }}
+          </p>
+          {% if supplier.clients %}
+              <h2>Clients</h2>
+              <p class="supplier-description">
+                {{ ", ".join(supplier.clients) }}
+              </p>
+          {% endif %}
+      </div>
+    {% endif %}
 
     <div class="column-one-third">
       {%


### PR DESCRIPTION
It looks weird to have the contact details all the way over to the right of the page if the left hand column is empty. This commit removes the left hand column if a supplier has no clients or description.

After
--
![image](https://cloud.githubusercontent.com/assets/355079/8747013/d906d1d2-2c86-11e5-93ca-7d0066b4a4f9.png)


Before
--
![image](https://cloud.githubusercontent.com/assets/355079/8747018/e7564c4a-2c86-11e5-8799-93619887d68b.png)
