### PR TITLE
Fix cookie link on seen cookies message warning to use local cookies …

### DIFF
--- a/app/templates/_cookie_message.html
+++ b/app/templates/_cookie_message.html
@@ -1,2 +1,2 @@
-<p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>
 

--- a/tests/app/views/test_application.py
+++ b/tests/app/views/test_application.py
@@ -12,3 +12,11 @@ class TestApplication(BaseApplicationTest):
         assert_true(
             'trackPageview'
             in res.get_data(as_text=True))
+
+    def test_should_use_local_cookie_page_on_cookie_message(self):
+        res = self.client.get('/')
+        assert_equal(200, res.status_code)
+        assert_true(
+            '<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>'
+            in res.get_data(as_text=True)
+        )


### PR DESCRIPTION
…page

- seen cookie message pointed to GOV.UK
- changed to use /cookies