### PR TITLE
Fix &copy; in footer (should be ©)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v6.0.2",
-    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.0/jinja_govuk_template-0.14.0.tgz",
+    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
   }
 }


### PR DESCRIPTION
Updates GOV.UK template to bring in https://github.com/alphagov/govuk_template/pull/164

Depends on https://github.com/alphagov/govuk_template/pull/165

Addresses [story #98957756](https://www.pivotaltracker.com/story/show/98957756)