### PR TITLE
Fix search summary missing keywords containing unicode characters

### DIFF
--- a/app/presenters/search_summary.py
+++ b/app/presenters/search_summary.py
@@ -51,7 +51,7 @@ class SearchSummary(object):
                 )
 
     def _set_initial_sentence(self, results_total, request_args):
-        keywords = escape(request_args.get('q', '', type=str))
+        keywords = escape(request_args.get('q', ''))
         lot_label = get_label_for_lot_param(
             request_args.get('lot', 'all', type=str)) or 'All categories'
         lot = u"{}{}{}".format(

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -357,3 +357,17 @@ class TestSearchResults(BaseApplicationTest):
         assert_equal(200, res.status_code)
         summary = find_search_summary(res.get_data(as_text=True))[0]
         assert_in('&lt;div&gt;XSS&lt;/div&gt;', summary)
+
+    def test_summary_for_unicode_query_keywords(self):
+        return_value = self.search_results_multiple_page
+        return_value["services"] = [return_value["services"][0]]
+        return_value["meta"]["total"] = 1
+        self._search_api_client.search_services.return_value = return_value
+
+        res = self.client.get(u'/g-cloud/search?q=email+\U0001f47e&lot=saas')
+        assert_equal(200, res.status_code)
+        summary = find_search_summary(res.get_data(as_text=True))[0]
+        assert_true(
+            u'<span class="search-summary-count">1</span> result found' +
+            u' containing <em>email \U0001f47e</em> in' +
+            u' <em>Software as a Service</em>' in summary)


### PR DESCRIPTION
`request.args.get` with `type` returns a default value (`''`) if a
ValueError is raised by the `type` callable. Since `str` raises an
exception on non-ASCII characters, `type=str` removes any keywords
with unicode characters from the search summary text.

Removing the `type` argument fixes the issue. The `request.args` is
unicode by default, so there's no need to add any type conversion.