### PR TITLE
Move search button underneath for mobile layouts

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -21,6 +21,7 @@
 
     button {
       height: 48px;
+      width: 100%;
 
       @include media(tablet) {
         width: 7.6em;

--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -11,16 +11,26 @@
     position: relative;
 
     input {
-      margin-right: 180px;
       width: 100%;
+      height: 50px;
+
+      @include media(tablet) {
+        margin-right: 7.6em;
+      }
     }
 
     button {
-      width: 180px;
-      position: absolute;
-      top: 0;
-      right: -180px + 15px + 1px;
-      padding: 9px 0;
+      height: 48px;
+
+      @include media(tablet) {
+        width: 7.6em;
+        position: absolute;
+        top: 0;
+        right: -7.6em;
+        margin-right: $gutter-half;
+      }
+      padding-top: 5px;
+      padding-bottom: 5px;
     }
 
   }


### PR DESCRIPTION
Allows the search box to be as big as possible on smaller screens.

This also includes a shift from pixels to ems for the button width to make it relative to the font rendering which was causing an issue on IE8, Windows XP.

### Desktop/tablet

![search_box_desktop](https://cloud.githubusercontent.com/assets/87140/8796854/e958aee6-2f8f-11e5-8b49-0f6e0017091a.png)

### Mobile

![search_box_mobile](https://cloud.githubusercontent.com/assets/87140/8797687/02d37d42-2f95-11e5-91ec-75d94a00201a.png)

