### PR TITLE
Support searching for '.' versions of the G5 service IDs

### DIFF
--- a/app/helpers/search_helpers.py
+++ b/app/helpers/search_helpers.py
@@ -1,3 +1,4 @@
+import re
 from math import ceil
 
 from werkzeug.datastructures import MultiDict
@@ -103,6 +104,16 @@ def group_request_filters(request_filters, content_loader):
     return filter_query
 
 
+def replace_g5_search_dots(keywords_query):
+    """Replaces '.' with '-' in G5 service IDs to support old ID search format."""
+
+    return re.sub(
+        r'5\.G(\d)\.(\d{4})\.(\d{3})',
+        r'5-G\1-\2-\3',
+        keywords_query
+    )
+
+
 def build_search_query(request, lot_filters, content_loader):
     """Match request args with known filters.
 
@@ -117,6 +128,9 @@ def build_search_query(request, lot_filters, content_loader):
         request.args,
         lot_filters
     )
+
+    if 'q' in query:
+        query['q'] = replace_g5_search_dots(query['q'])
 
     return group_request_filters(query, content_loader)
 

--- a/tests/unit/test_search_helpers.py
+++ b/tests/unit/test_search_helpers.py
@@ -233,6 +233,18 @@ class TestBuildSearchQueryHelpers(object):
             }
         )
 
+    def test_replace_g5_search_dots(self):
+        assert_equal(
+            search_helpers.replace_g5_search_dots("some text 5.G4.1005.001 text"),
+            "some text 5-G4-1005-001 text"
+        )
+
+    def test_replace_g5_search_dots_no_id(self):
+        assert_equal(
+            search_helpers.replace_g5_search_dots("some text 5.G4.1005 text"),
+            "some text 5.G4.1005 text"
+        )
+
     def test_build_search_query(self):
         request = self._request({
             'page': 5,
@@ -302,4 +314,15 @@ class TestBuildSearchQueryHelpers(object):
             search_helpers.build_search_query(
                 request, self.lot_filters, self._loader()),
             {}
+        )
+
+    def test_build_search_query_g5_dots_id_search(self):
+        request = self._request({
+            'q': 'some text 5.G4.1005.001',
+        })
+
+        assert_equal(
+            search_helpers.build_search_query(
+                request, self.lot_filters, self._loader()),
+            {'q': 'some text 5-G4-1005-001'}
         )


### PR DESCRIPTION
[#99026308](https://www.pivotaltracker.com/story/show/99026308)

When forming a request for the search-api buyer frontend will look
for G5 service IDs in the query string and try to replace dots with
'-'. This way, search-api always gets a request containing '-' IDs.

This allows us to support searches for '.' service IDs without making
any changes to the search-api index.

Only service IDs with all-'.' are suppoted, mixing '.' and '-' will
not trigger the replacement and probably won't return any results.

**Note:** I haven't found any other G5 service ID regular expressions in our apps so I'm not sure if all of them have the same `5-G<digit>-<4 digits>-<3 digits>` format, but I haven't seen any that didn't.