### PR TITLE
Fix retina image for black external link

### DIFF
--- a/app/assets/scss/_footer.scss
+++ b/app/assets/scss/_footer.scss
@@ -114,7 +114,7 @@
 
       @include device-pixel-ratio() {
         background-image: file-url("external-links/external-link-black-24x24.png");
-        background-size: 12px 400px;
+        background-size: 12px 12px;
       }
     }
 


### PR DESCRIPTION
The styles used for the black link (with no hover) assume the image is the same as that for the blue link, which has a hover state and so is 400px high. The image for the black link has no hover state and so should be sized to 12px high.