### PR TITLE
Refactor service presenters to use new new tables

### DIFF
--- a/app/helpers/service_page_manifest.yml
+++ b/app/helpers/service_page_manifest.yml
@@ -88,6 +88,7 @@
     - dataStorageMediaDisposal
     - dataSecureEquipmentDisposal
     - dataRedundantEquipmentAccountsRevoked
+    - serviceAvailabilityPercentage
 -
   name: Separation between consumers
   questions:

--- a/app/templates/_service_attributes.html
+++ b/app/templates/_service_attributes.html
@@ -11,11 +11,7 @@
   ) %}
     {% call summary.row() %}
       {{ summary.field_name(item.label) }}
-      {% if item.type == 'list' %}
-        {{ summary.list(item.value, item.assurance) }}
-      {% else %}
-        {{ summary.text(item.value) }}
-      {% endif %}
+      {{ summary[item.type](item.value, item.assurance) }}
     {% endcall %}
   {% endcall %}
 {% endfor %}

--- a/app/templates/_service_attributes.html
+++ b/app/templates/_service_attributes.html
@@ -1,13 +1,21 @@
+{% import "toolkit/summary-table.html" as summary %}
 {% for attributeGrouping in service.attributes %}
-  {%
-    with
-    heading = attributeGrouping.name,
-    caption = attributeGrouping.name,
-    field_headings = [
-      "Name", "Content"
+  {{ summary.heading(attributeGrouping.name) }}
+  {% call(item) summary.list_table(
+    attributeGrouping.rows,
+    caption=attributeGrouping.name,
+    field_headings=[
+      "Name", "Content",
     ],
-    rows = attributeGrouping.rows
-  %}
-    {% include "toolkit/forms/summary.html" %}
-  {% endwith %}
+    field_headings_visible = False
+  ) %}
+    {% call summary.row() %}
+      {{ summary.field_name(item.label) }}
+      {% if item.type == 'list' %}
+        {{ summary.list(item.value, item.assurance) }}
+      {% else %}
+        {{ summary.text(item.value) }}
+      {% endif %}
+    {% endcall %}
+  {% endcall %}
 {% endfor %}

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v7.1.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.1.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
   }

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.1.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v8.1.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
   }

--- a/tests/unit/test_service_presenters.py
+++ b/tests/unit/test_service_presenters.py
@@ -104,18 +104,18 @@ class TestService(unittest.TestCase):
             if group['name'] == 'Data-in-transit protection':
                 for row in group['rows']:
                     # string with bespoke assurance caveat
-                    if row['fields'][0] == 'Data protection between services':
+                    if row['label'] == 'Data protection between services':
                         self.assertEqual(
-                            row['fields'][1].strip(),
+                            row['value'],
                             (
                                 u'No encryption, assured by ' +
                                 u'independent validation of assertion'
                             )
                         )
                     # string with standard assurance caveat
-                    if row['fields'][0] == 'Data protection within service':
+                    if row['label'] == 'Data protection within service':
                         self.assertEqual(
-                            row['fields'][1].strip(),
+                            row['value'],
                             u'No encryption'
                         )
 
@@ -125,10 +125,10 @@ class TestService(unittest.TestCase):
             if group['name'] == 'Asset protection and resilience':
                 for row in group['rows']:
                     # list with bespoke assurance caveat
-                    if row['fields'][0] == 'Data management location':
+                    if row['label'] == 'Data management location':
                         self.assertIn(
                             u'Assured by independent validation of assertion',
-                            row['fields'][1]
+                            row['assurance']
                         )
 
 
@@ -246,7 +246,9 @@ class TestAttribute(unittest.TestCase):
 
     def test_rendering_of_string_attribute(self):
         attribute = Attribute('Gold star')
-        self.assertEqual(attribute.get_rendered().strip(), 'Gold star')
+        self.assertEqual(attribute.value, 'Gold star')
+        self.assertEqual(attribute.assurance, False)
+        self.assertEqual(attribute.type, 'string')
 
     def test_rendering_of_string_attribute_with_assurance(self):
         attribute = Attribute(
@@ -256,7 +258,7 @@ class TestAttribute(unittest.TestCase):
             }
         )
         self.assertEqual(
-            attribute.get_rendered().strip(),
+            attribute.value,
             'Gold star, assured by CESG-assured components'
         )
 
@@ -265,8 +267,12 @@ class TestAttribute(unittest.TestCase):
             ['Gold star', 'Bronze star']
         )
         self.assertEqual(
-            attribute.get_rendered().strip(),
-            "<ul><li>Gold star</li><li>Bronze star</li></ul>"
+            attribute.value,
+            ['Gold star', 'Bronze star'],
+        )
+        self.assertEqual(
+            attribute.assurance,
+            False
         )
 
     def test_rendering_of_string_list_with_assurance(self):
@@ -279,9 +285,12 @@ class TestAttribute(unittest.TestCase):
             }
         )
         self.assertEqual(
-            attribute.get_rendered().strip(),
-            "<ul><li>Gold star</li><li>Bronze star</li></ul>" +
-            " Assured by CESG-assured componenents"
+            attribute.value,
+            ['Gold star', 'Bronze star']
+        )
+        self.assertEqual(
+            attribute.assurance,
+            "Assured by CESG-assured componenents"
         )
 
 


### PR DESCRIPTION
Brings in: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/116

--

**This pull request changes the Attribute() class to be a mapping between the SSP content and the data returned from the API, and the field templates in the summary table pattern in the toolkit.** Pfewf.

--

Might be better explained with examples:

The method takes:
- question type from content, eg `checkboxes`, `percentage`
- value from the api, eg `["Gold", "Silver"]`, `99.99`

It returns an object which has:
- the field template that should be used to render the content, eg `list`, `text`
- the formatted value for that field, eg `["Gold", "Silver"]`, `99.99%`

It still takes care of assurance values and all that business.

It now also takes `label` as a parameter, which means one less method (`_get_row`) in the buyer app.