### PR TITLE
Make the 4xx apache logs alarm more specific

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -6,3 +6,6 @@ files:
     content: |
       LogFormat "apache-access buyer-frontend \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
       CustomLog logs/cwl_access_log cloudwatchlogs
+
+      LogFormat "{ \"application\": \"buyer-frontend\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}i\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\"}" cloudwatchjsonlogs
+      CustomLog logs/cwl_access_log.json cloudwatchjsonlogs

--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -29,10 +29,14 @@ Mappings:
   CWLogs:
     AccessLogs:
       LogFile: "/var/log/httpd/cwl_access_log"
+      JSONLogFile: "/var/log/httpd/cwl_access_log.json"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
+      JSONLogGroupName: {"Fn::GetOptionSetting": {"OptionName": "JSONLogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
+      Http400To403MetricFilter: "{ $.logType = apache-access && $.application = buyer-frontend && $.status >= 400 && $.status <= 403 }"
+      HttpNon400To403MetricFilter: "{ $.logType = apache-access && $.application = buyer-frontend && ($.status < 400 || $.status > 403) }"
       Http4xxMetricFilter: "[type=apache-access, app=buyer-frontend, ..., status=4*, size, referer, agent]"
       HttpNon4xxMetricFilter: "[type=apache-access, app=buyer-frontend, ..., status!=4*, size, referer, agent]"
       Http5xxMetricFilter: "[type=apache-access, app=buyer-frontend, ..., status=5*, size, referer, agent]"
@@ -60,6 +64,11 @@ Resources :
                 log_group_name = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}`
                 log_stream_name = `{"Fn::Join": ["-", ["apache-access", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
                 datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
+                [apache-access_log-json]
+                file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "JSONLogFile"]}`
+                log_group_name = `{"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}`
+                log_stream_name = `{"Fn::Join": ["-", ["apache-access", {"Fn::FindInMap":["CWLogs", "ApplicationLogs", "ApplicationName"]}]]}`
+                datetime_format = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "TimestampFormat"]}`
                 [apache-access_log-combined]
                 file = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogFile"]}`
                 log_group_name = `{"Fn::FindInMap":["CWLogs", "AccessLogs", "LogGroupName"]}`
@@ -74,6 +83,25 @@ Resources :
 
   ###########################
   ## Apache access log metric filters
+  AWSEBCWLHttp400To403MetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    Properties:
+      LogGroupName: {"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}
+      FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "Http400To403MetricFilter"]}
+      MetricTransformations:
+        - MetricValue: 1
+          MetricNamespace: {"Fn::Join": ["/", ["ElasticBeanstalk", {"Ref": "AWSEBEnvironmentName"}]]}
+          MetricName: CWLHttp400To403
+
+  AWSEBCWLHttpNon400To403MetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    Properties:
+      LogGroupName: {"Fn::FindInMap": ["CWLogs", "AccessLogs", "JSONLogGroupName"]}
+      FilterPattern: {"Fn::FindInMap": ["CWLogs", "FilterPatterns", "HttpNon400To403MetricFilter"]}
+      MetricTransformations:
+        - MetricValue: 0
+          MetricNamespace: {"Fn::Join": ["/", ["ElasticBeanstalk", {"Ref": "AWSEBEnvironmentName"}]]}
+          MetricName: CWLHttp400To403
 
   AWSEBCWLHttp4xxMetricFilter :
     Type : "AWS::Logs::MetricFilter"
@@ -161,12 +189,12 @@ Resources :
         "Fn::Join":
           - ""
           -
-            - "The buyer frontend is returning too high a proportion of 4xx responses.\n"
+            - "The buyer frontend is returning too high a proportion of 400, 401, 402 or 403 responses.\n"
             - "Stage and environment: "
             - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
             - "\n"
             - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#4xx-error-rate"
-      MetricName: CWLHttp4xx
+      MetricName: CWLHttp400To403
       Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
       Statistic: Average
       Period: 60


### PR DESCRIPTION
Only fire the alarm if the rate of 400 - 403s goes over the limit. 404s happen quite frequently and are not indicative of anything going wrong.

See https://github.com/alphagov/digitalmarketplace-search-api/pull/50