### PR TITLE
Add G-Cloud 7 info sidebar

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -36,4 +36,39 @@
 
   }
 
+  .g-cloud-7-notice {
+    margin-top: 45px;
+
+    h2 {
+      @include bold-24;
+      margin-bottom: $gutter-half;
+    }
+
+    p {
+      margin: 0 0 $gutter-half;
+
+      &.hint {
+        color: $grey-1;
+        margin-bottom: 5px;
+      }
+    }
+
+    nav {
+      margin-top: $gutter-half;
+      border-top: 1px solid $border-colour;
+      padding-top: $gutter-half;
+
+      ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+
+        li {
+          margin-bottom: 5px;
+        }
+
+      }
+    }
+  }
+
 }

--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -45,17 +45,21 @@
     }
 
     p {
-      margin: 0 0 $gutter-half;
+      margin: 0;
 
       &.hint {
         color: $grey-1;
         margin-bottom: 5px;
       }
+
+      &.supplier-info {
+        margin-top: $gutter-half;
+        border-bottom: 1px solid $border-colour;
+        padding-bottom: $gutter-half;
+      }
     }
 
     nav {
-      margin-top: $gutter-half;
-      border-top: 1px solid $border-colour;
       padding-top: $gutter-half;
 
       ul {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -43,6 +43,9 @@
     <h2 id="g-cloud-7-notice-heading">G-Cloud is open for applications</h2>
     <p class="hint">Deadline 20 October</p>
     <p>Register for G-Cloud 7 to sell cloud services to the public sector</p>
+    {% if 'G_CLOUD_7_IS_LIVE' is active_feature %}
+    <p><a href="">Read G-Cloud 7 information for suppliers</a></p>
+    {% endif %}
     <nav role="navigation" aria-labelledby="g-cloud-7-notice-heading">
       <ul>
         <li><a href="/suppliers">Log in to existing supplier account</a></li>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -40,10 +40,14 @@
     {% endwith %}
   </div>
   <aside role="complementary" class="g-cloud-7-notice column-one-third">
+    {% if 'G_CLOUD_7_IS_LIVE' is active_feature %}
     <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud 7 is open for applications</h2>
     <p class="hint">Deadline 20 October</p>
+    {% else %}
+    <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud 7 will be open for applications on 26 August</h2>
+    {% endif %}
     <p>Register as a G&#8209;Cloud 7 supplier to sell cloud services to the public sector</p>
-    {% if 'G_CLOUD_7_IS_LIVE' is active_feature %}
+    {% if 'G_CLOUD_7_SUPPLIER_GUIDE' is active_feature %}
     <p class="supplier-info"><a href="">Read G&#8209;Cloud 7 information for suppliers</a></p>
     {% endif %}
     <nav role="navigation" aria-labelledby="g-cloud-7-notice-heading">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -39,7 +39,7 @@
       {% include "toolkit/browse-list.html" %}
     {% endwith %}
   </div>
-  <aside class="g-cloud-7-notice column-one-third">
+  <aside role="complementary" class="g-cloud-7-notice column-one-third">
     <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud 7 is open for applications</h2>
     <p class="hint">Deadline 20 October</p>
     <p>Register as a G&#8209;Cloud 7 supplier to sell cloud services to the public sector</p>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,7 +21,7 @@
           "link": "/g-cloud",
           "title": "Find cloud technology and support",
           "body": "eg web hosting or IT health checks",
-          "subtext": "Procurement framework: <a href='/g-cloud/framework'>G-Cloud</a>"
+          "subtext": "Procurement framework: <a href='/g-cloud/framework'>G&#8209;Cloud</a>"
         },
         {
           "link": "/crown-hosting",
@@ -40,11 +40,11 @@
     {% endwith %}
   </div>
   <aside class="g-cloud-7-notice column-one-third">
-    <h2 id="g-cloud-7-notice-heading">G-Cloud is open for applications</h2>
+    <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud 7 is open for applications</h2>
     <p class="hint">Deadline 20 October</p>
-    <p>Register for G-Cloud 7 to sell cloud services to the public sector</p>
+    <p>Register as a G&#8209;Cloud 7 supplier to sell cloud services to the public sector</p>
     {% if 'G_CLOUD_7_IS_LIVE' is active_feature %}
-    <p><a href="">Read G-Cloud 7 information for suppliers</a></p>
+    <p class="supplier-info"><a href="">Read G&#8209;Cloud 7 information for suppliers</a></p>
     {% endif %}
     <nav role="navigation" aria-labelledby="g-cloud-7-notice-heading">
       <ul>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,6 +4,54 @@
 
 {% block main_content %}
 
+{% if 'G_CLOUD_7_NOTICE' is active_feature %}
+<div class="index-page grid-row">
+  <div class="column-two-thirds">
+    <header class="page-heading">
+      <h1>
+        Digital Marketplace
+      </h1>
+      <p class="lead">
+        Find technology or people for digital projects in the public sector
+      </p>
+    </header>
+    {% with
+      items = [
+        {
+          "link": "/g-cloud",
+          "title": "Find cloud technology and support",
+          "body": "eg web hosting or IT health checks",
+          "subtext": "Procurement framework: <a href='/g-cloud/framework'>G-Cloud</a>"
+        },
+        {
+          "link": "/crown-hosting",
+          "title": "Buy physical datacentre space for legacy systems",
+          "subtext": "Procurement framework: <a href='/crown-hosting/framework'>Crown Hosting Data Centres</a>"
+        },
+        {
+          "link": "https://digitalservicesstore.service.gov.uk/",
+          "title": "Find specialists to work on digital projects",
+          "body": "eg technical architects and user researchers",
+          "subtext": "Procurement framework: <a href='/digital-services/framework'>Digital Services</a>"
+        }
+      ]
+    %}
+      {% include "toolkit/browse-list.html" %}
+    {% endwith %}
+  </div>
+  <aside class="g-cloud-7-notice column-one-third">
+    <h2 id="g-cloud-7-notice-heading">G-Cloud is open for applications</h2>
+    <p class="hint">Deadline 20 October</p>
+    <p>Register for G-Cloud 7 to sell cloud services to the public sector</p>
+    <nav role="navigation" aria-labelledby="g-cloud-7-notice-heading">
+      <ul>
+        <li><a href="/suppliers">Log in to existing supplier account</a></li>
+        <li><a href="">Create new supplier account</a></li>
+      </ul>
+    </nav>
+  </aside>
+</div>
+{% else %}
 <div class="index-page">
   <header class="page-heading">
     <h1>
@@ -37,5 +85,6 @@
     {% include "toolkit/browse-list.html" %}
   {% endwith %}
 </div>
+{% endif %}
 
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -41,14 +41,14 @@
   </div>
   <aside role="complementary" class="g-cloud-7-notice column-one-third">
     {% if 'G_CLOUD_7_IS_LIVE' is active_feature %}
-    <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud 7 is open for applications</h2>
+    <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud&nbsp;7 is open for applications</h2>
     <p class="hint">Deadline 6 October</p>
     {% else %}
-    <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud 7 will be open for applications on 26 August</h2>
+    <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud&nbsp;7 will be open for applications on 26 August</h2>
     {% endif %}
-    <p>Register as a G&#8209;Cloud 7 supplier to sell cloud services to the public sector</p>
+    <p>Register as a G&#8209;Cloud&nbsp;7 supplier to sell cloud services to the public sector</p>
     {% if 'G_CLOUD_7_SUPPLIER_GUIDE' is active_feature %}
-    <p class="supplier-info"><a href="">Read G&#8209;Cloud 7 information for suppliers</a></p>
+    <p class="supplier-info"><a href="">Read G&#8209;Cloud&nbsp;7 information for suppliers</a></p>
     {% endif %}
     <nav role="navigation" aria-labelledby="g-cloud-7-notice-heading">
       <ul>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -42,7 +42,7 @@
   <aside role="complementary" class="g-cloud-7-notice column-one-third">
     {% if 'G_CLOUD_7_IS_LIVE' is active_feature %}
     <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud 7 is open for applications</h2>
-    <p class="hint">Deadline 20 October</p>
+    <p class="hint">Deadline 6 October</p>
     {% else %}
     <h2 id="g-cloud-7-notice-heading">G&#8209;Cloud 7 will be open for applications on 26 August</h2>
     {% endif %}

--- a/config.py
+++ b/config.py
@@ -58,6 +58,7 @@ class Config(object):
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = False
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = False
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
+    FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = False
 
     @staticmethod
     def init_app(app):
@@ -75,6 +76,7 @@ class Test(Config):
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
+    FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = enabled_since('2015-08-03')
 
 
 class Development(Config):
@@ -84,12 +86,14 @@ class Development(Config):
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
+    FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = enabled_since('2015-08-03')
 
 
 class Preview(Config):
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
+    FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = enabled_since('2015-08-03')
 
 
 class Live(Config):

--- a/config.py
+++ b/config.py
@@ -56,6 +56,7 @@ class Config(object):
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = False
+    FEATURE_FLAGS_G_CLOUD_7_NOTICE = False
 
     @staticmethod
     def init_app(app):
@@ -71,6 +72,7 @@ class Test(Config):
     DEBUG = True
     DM_LOG_LEVEL = 'CRITICAL'
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
+    FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
 
 
 class Development(Config):
@@ -78,10 +80,12 @@ class Development(Config):
 
     DM_SEARCH_PAGE_SIZE = 5
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
+    FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
 
 
 class Preview(Config):
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
+    FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
 
 
 class Live(Config):

--- a/config.py
+++ b/config.py
@@ -57,6 +57,7 @@ class Config(object):
     RAISE_ERROR_ON_MISSING_FEATURES = True
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = False
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = False
+    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
     @staticmethod
     def init_app(app):
@@ -73,6 +74,7 @@ class Test(Config):
     DM_LOG_LEVEL = 'CRITICAL'
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
+    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
 
 
 class Development(Config):
@@ -81,11 +83,13 @@ class Development(Config):
     DM_SEARCH_PAGE_SIZE = 5
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
+    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
 
 
 class Preview(Config):
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
+    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
 
 
 class Live(Config):


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/997836/stories/100212536

This is hidden behind three feature flags:

1. G_CLOUD_7_NOTICE (to display the sidebar)
2. G_CLOUD_7_IS_LIVE
3. G_CLOUD_7_SUPPLIER_GUIDE (to show the link to the supplier's guide)

The sidebar, pre-launch, without the supplier guide link looks like:

![g-cloud-7-side-bar-pre-launch-without-supplier-guide](https://cloud.githubusercontent.com/assets/87140/9058788/ef827d9e-3a9b-11e5-9c2d-340f44fbfb67.png)

The sidebar, pre-launch, with the supplier guide link looks like:

![g-cloud-7-side-bar-pre-launch-with-supplier-guide](https://cloud.githubusercontent.com/assets/87140/9058793/f5c74612-3a9b-11e5-81b5-f70ba7862e11.png)

The sidebar, post-launch, without the supplier guide link looks like:

![g-cloud-7-side-bar-post-launch-without-supplier-guide](https://cloud.githubusercontent.com/assets/87140/9058796/fb337c60-3a9b-11e5-823c-83ba9f0344f3.png)

The sidebar, post-launch, with the supplier guide link looks like:

![g-cloud-7-side-bar-post-launch-with-supplier-guide](https://cloud.githubusercontent.com/assets/87140/9058809/08c0982c-3a9c-11e5-9b60-dd652c91ae68.png)

All links in the sidebar, except that to the suppliers login, will have blank URLs until those pages exist.