### PR TITLE
Fix cross-domain tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,8 @@ npm install
 
 Note: `npm run frontend-install` is run automatically as a post-install task when you run `npm install`.
 
+## Frontend tests
+
+To run the JavaScript tests, navigate to `spec/javascripts/support/` and open `LocalTestRunner.html` in a browser.
+
+TODO: Add a Gulp task which is run as part of `./scripts/run_tests.sh`.

--- a/app/assets/javascripts/analytics/_dm-analytics.js
+++ b/app/assets/javascripts/analytics/_dm-analytics.js
@@ -1,18 +1,38 @@
 (function() {
   "use strict";
+  // Rewritten GOVUK.Analytics
+  var DMAnalytics = function(config) {
+    this.trackers = [];
+    if (typeof config.universalId != 'undefined') {
+      if (typeof config.receiveCrossDomainTracking !== 'undefined') {
+        this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain, true));
+      } else {
+        this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain));
+      }
+    }
+  };
+  DMAnalytics.load = GOVUK.Analytics.load;
+  DMAnalytics.prototype = GOVUK.Analytics.prototype;
+  GOVUK.Analytics = DMAnalytics;
   // wrapper function for calls to window.ga, used by all Google Analytics trackers
   function sendToGa() {
     if (typeof window.ga === "function") {
       ga.apply(window, arguments);
     }
-  }
+  };
   // Rewritten universal tracker to allow setting of the autoLinker property
-  var DMGoogleAnalyticsUniversalTracker = function(id, cookieDomain) {
-    configureProfile(id, cookieDomain);
+  var DMGoogleAnalyticsUniversalTracker = function(id, cookieDomain, allowLinker) {
+    this.defaultTrackerIsAutoLinked = false;
+    configureProfile.apply(this, arguments);
     anonymizeIp();
 
-    function configureProfile(id, cookieDomain) {
-      sendToGa('create', id, {'cookieDomain': cookieDomain, 'allowLinker': true });
+    function configureProfile(id, cookieDomain, allowLinker) {
+      var gaOptions = { 'cookieDomain' : cookieDomain };
+
+      if (typeof allowLinker !== 'undefined') {
+        gaOptions.allowLinker = allowLinker;
+      }
+      sendToGa('create', id, gaOptions);
     }
 
     function anonymizeIp() {
@@ -22,5 +42,34 @@
   };
   DMGoogleAnalyticsUniversalTracker.load = GOVUK.GoogleAnalyticsUniversalTracker.load;
   DMGoogleAnalyticsUniversalTracker.prototype = GOVUK.GoogleAnalyticsUniversalTracker.prototype;
+  // Rewritten add linked tracker domain method too allow use of an existing tracker
+  DMGoogleAnalyticsUniversalTracker.prototype.addLinkedTrackerDomain = function(domain, trackerOptions) {
+    // if a new tracker is required, create it here
+    if (typeof trackerOptions !== 'undefined') {
+      sendToGa('create',
+               trackerOptions.trackerId,
+               'auto',
+               {'name': trackerOptions.name});
+
+      // Load the plugin.
+      sendToGa(name + '.require', 'linker');
+
+      // Define which domains to autoLink.
+      sendToGa(name + '.linker:autoLink', [domain]);
+
+      sendToGa(name + '.set', 'anonymizeIp', true);
+      sendToGa(name + '.send', 'pageview');
+    }
+
+    if (!this.defaultTrackerIsAutoLinked) {
+      // Load the plugin.
+      sendToGa('require', 'linker');
+
+      // Define which domains to autoLink.
+      sendToGa('linker:autoLink', [domain]);
+
+      this.defaultTrackerIsAutoLinked = true
+    }
+  };
   GOVUK.GoogleAnalyticsUniversalTracker = DMGoogleAnalyticsUniversalTracker;
 })();

--- a/app/assets/javascripts/analytics/_init.js
+++ b/app/assets/javascripts/analytics/_init.js
@@ -6,8 +6,9 @@
   GOVUK.Analytics.load();
   GOVUK.analytics = new GOVUK.Analytics({
     universalId: property,
-    cookieDomain: cookieDomain
+    cookieDomain: cookieDomain,
+    receiveCrossDomainTracking: true
   });
   GOVUK.analytics.trackPageview();
-  GOVUK.analytics.addLinkedTrackerDomain(property, 'link', 'digitalservicesstore.service.gov.uk');
+  GOVUK.analytics.addLinkedTrackerDomain('digitalservicesstore.service.gov.uk');
 })();

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -1,19 +1,19 @@
 describe("GOVUK.Analytics", function () {
   var analytics;
 
-  beforeEach(function() {
+  beforeEach(function () {
     window.ga = function() {};
     spyOn(window, 'ga');
-    analytics = new window.GOVUK.Analytics({
-      universalId: 'universal-id',
-      cookieDomain: 'www.digitalmarketplace.service.gov.uk'
-    });
   });
 
   describe('when created', function() {
     var universalSetupArguments;
 
     beforeEach(function() {
+      analytics = new window.GOVUK.Analytics({
+        universalId: 'universal-id',
+        cookieDomain: 'www.digitalmarketplace.service.gov.uk'
+      });
       universalSetupArguments = window.ga.calls.allArgs();
     });
 
@@ -24,4 +24,59 @@ describe("GOVUK.Analytics", function () {
       }]);
     });
   })
+
+  describe('when setting up cross-domain tracking', function () {
+    var sortCalls = function (calls) {
+      var gaMethodCalls = {},
+          callNum = calls.length;
+
+      while (callNum--) {
+        var method = calls[callNum].args.shift(),
+            args = calls[callNum].args;
+
+        if (gaMethodCalls.hasOwnProperty(method)) {
+          gaMethodCalls[method].push(args);
+        } else {
+          gaMethodCalls[method] = [args];
+        }
+      }
+      this._calls = gaMethodCalls;
+    };
+    sortCalls.prototype.callsTo = function (method) {
+      if (this._calls.hasOwnProperty(method)) {
+        return this._calls[method];
+      }
+      return [];
+    }; 
+
+    beforeEach(function() {
+      window.ga.calls.reset();
+      analytics = new window.GOVUK.Analytics({
+        universalId: 'universal-id',
+        cookieDomain: 'www.digitalmarketplace.service.gov.uk'
+      });
+      analytics.trackPageview();
+      analytics.addLinkedTrackerDomain('universal-id', 'link', 'digitalservicesstore.service.gov.uk');
+    });
+
+    it('only sets up one tracker', function () {
+      var gaMethodCalls = new sortCalls(window.ga.calls.all());
+      expect(window.ga.calls.count()).toEqual(5);
+      // create tracker
+      expect(gaMethodCalls.callsTo('create').length).toEqual(1);
+      expect(gaMethodCalls.callsTo('create')[0]).toEqual(['universal-id', { 'cookieDomain': 'www.digitalmarketplace.service.gov.uk', 'allowLinker': true }]);
+      // anonymize IP
+      expect(gaMethodCalls.callsTo('set').length).toEqual(1);
+      expect(gaMethodCalls.callsTo('set')[0]).toEqual(['anonymizeIp', true]);
+      // send pageview
+      expect(gaMethodCalls.callsTo('send').length).toEqual(1);
+      expect(gaMethodCalls.callsTo('send')[0]).toEqual(['pageview']);
+      // require linker plugin
+      expect(gaMethodCalls.callsTo('require').length).toEqual(1);
+      expect(gaMethodCalls.callsTo('require')[0]).toEqual(['linker']);
+      // autolink the second domain
+      expect(gaMethodCalls.callsTo('linker:autoLink').length).toEqual(1);
+      expect(gaMethodCalls.callsTo('linker:autoLink')[0]).toEqual([['digitalservicesstore.service.gov.uk']]);
+    });
+  });
 });

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -19,8 +19,7 @@ describe("GOVUK.Analytics", function () {
 
     it('configures a universal tracker', function() {
       expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {
-        'cookieDomain': 'www.digitalmarketplace.service.gov.uk',
-        'allowLinker': true
+        'cookieDomain': 'www.digitalmarketplace.service.gov.uk'
       }]);
     });
   })
@@ -53,10 +52,11 @@ describe("GOVUK.Analytics", function () {
       window.ga.calls.reset();
       analytics = new window.GOVUK.Analytics({
         universalId: 'universal-id',
-        cookieDomain: 'www.digitalmarketplace.service.gov.uk'
+        cookieDomain: 'www.digitalmarketplace.service.gov.uk',
+        receiveCrossDomainTracking: true
       });
       analytics.trackPageview();
-      analytics.addLinkedTrackerDomain('universal-id', 'link', 'digitalservicesstore.service.gov.uk');
+      analytics.addLinkedTrackerDomain('digitalservicesstore.service.gov.uk');
     });
 
     it('only sets up one tracker', function () {


### PR DESCRIPTION
The cross-domain tracking is currently setting 2 trackers which is producing duplicate pageviews.

https://www.pivotaltracker.com/story/show/100627412

As described by Persicope, our analytics contractor, the following calls to the `ga` method should be removed:

```
ga(‘create’, ‘UA-49258698-1’, ‘auto’, { ‘name’: ‘link’ });
ga(‘link.require’, ‘linker’)
ga(‘link.linker:autoLink’, [‘digitalservicesstore.service.gov.uk’])
ga(‘link.set’, ‘anonymizeIp’, true)
ga(‘link.send’, ‘pageview’)
```

...while these should be preserved:

```
ga(‘create’, ‘UA-49258698-1’, { ‘cookieDomain’: ‘.digitalmarketplace.service.gov.uk’, ‘allowLinker’: true });
ga(‘set’, ‘anonymizeIp’, true)
ga(‘send’, ‘pageview’)
ga(‘require’, ‘linker’)
ga(‘linker:autoLink’, [‘digitalservicesstore.service.gov.uk’])
```

The GOVUK.Analytics code sets an additional tracker for cross-domain tracking by default so this part of the code has had to be rewritten to allow the above requirements.

The tests can be run by navigating to `/spec/javascripts/support` and opening `LocalTestRunner.html` in a browser.