### PR TITLE
Remove supplier guide link from preview

### DIFF
--- a/config.py
+++ b/config.py
@@ -93,7 +93,6 @@ class Preview(Config):
     FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
-    FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = enabled_since('2015-08-03')
 
 
 class Live(Config):


### PR DESCRIPTION
We need to be able to view the sidebar module without it until further notice:

![g-cloud-7-side-bar-pre-launch-without-supplier-guide](https://cloud.githubusercontent.com/assets/87140/9089657/3195b974-3b8e-11e5-88a2-4cae390d09ca.png)

![g-cloud-7-side-bar-post-launch-without-supplier-guide](https://cloud.githubusercontent.com/assets/87140/9089661/3582d4ae-3b8e-11e5-802d-2c7731d14422.png)
