### PR TITLE
Make log in and create supplier links work

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -52,8 +52,8 @@
     {% endif %}
     <nav role="navigation" aria-labelledby="g-cloud-7-notice-heading">
       <ul>
-        <li><a href="/suppliers">Log in to existing supplier account</a></li>
-        <li><a href="">Create new supplier account</a></li>
+        <li><a href="/suppliers/login">Log in to existing supplier account</a></li>
+        <li><a href="/suppliers/create">Create new supplier account</a></li>
       </ul>
     </nav>
   </aside>


### PR DESCRIPTION
Point the 'Create new supplier account' link at the new route for that (encapsulated by the work in https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/167).

![create-supplier-link](https://cloud.githubusercontent.com/assets/87140/9222787/8421b4dc-40ec-11e5-9164-ffc662e9f0d8.png)