### PR TITLE
Remove deadline date from G-Cloud 7 notice

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -50,7 +50,7 @@
       </p>
     {% else %}
       <h2 id="g-cloud-7-notice-heading">
-        G&#8209;Cloud&nbsp;7 will be open for applications on 26 August
+        G&#8209;Cloud&nbsp;7 will be open for applications soon
       </h2>
     {% endif %}
     <p>


### PR DESCRIPTION
This will cause the dashboard notice to read as:

![image](https://cloud.githubusercontent.com/assets/87140/9361495/9fc3eff0-4693-11e5-8bb2-58c5b9c32e1a.png)