### PR TITLE
Update suppliers-guide-g-cloud.html

### DIFF
--- a/app/templates/content/suppliers-guide-g-cloud.html
+++ b/app/templates/content/suppliers-guide-g-cloud.html
@@ -77,7 +77,7 @@
   </h3>
 
   <p>
-  Start your application by creating, or logging into, <a href="/suppliers/login">your supplier account</a>.
+  <a href="/suppliers/create">Create an account</a> or <a href="/suppliers/login">log into your existing account</a> to start your application.
   </p>
 
   <p>You'll need a <a rel="external" href="http://salesmarketing.dnb.co.uk/find_my_company/">Data Universal Numbering System (<abbr title="Data Universal Numbering System">DUNS</abbr> number</a>) first.</p>


### PR DESCRIPTION
updated link text for creating an account and logging into an account. the previous link only took users to the login page.