### PR TITLE
Use DM-Request-ID header from the response

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -4,8 +4,8 @@ files:
     owner: root
     group: root
     content: |
-      LogFormat "apache-access buyer-frontend \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
+      LogFormat "apache-access buyer-frontend \"%{DM-Request-ID}o\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
       CustomLog logs/cwl_access_log cloudwatchlogs
 
-      LogFormat "{ \"application\": \"buyer-frontend\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}i\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\"}" cloudwatchjsonlogs
+      LogFormat "{ \"application\": \"buyer-frontend\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}o\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\"}" cloudwatchjsonlogs
       CustomLog logs/cwl_access_log.json cloudwatchjsonlogs


### PR DESCRIPTION
Use the DM-Request-ID header from the response rather than the request.
As this app is what generates the request ID (Nginx strips any that may
have been nefariously set from outside) there will be no DM-Request-ID
request header here.

http://httpd.apache.org/docs/2.2/mod/mod_log_config.html#formats

See: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/242