### PR TITLE
Capitalise 'British Summer Time'

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -46,7 +46,7 @@
       </h2>
       <p class="hint">
         Deadline for submissions<br />
-        3pm <abbr title="British summer time">BST</abbr>, 6 October 2015
+        3pm <abbr title="British Summer Time">BST</abbr>, 6 October 2015
       </p>
     {% else %}
       <h2 id="g-cloud-7-notice-heading">


### PR DESCRIPTION
This bug was originally spotted by @TheDoubleK here: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/247#issuecomment-136662723