### PR TITLE
Remove supplier A–Z feature flag

### DIFF
--- a/app/main/suppliers.py
+++ b/app/main/suppliers.py
@@ -51,7 +51,6 @@ def parse_links(links):
 
 
 @main.route('/g-cloud/suppliers')
-@flask_featureflags.is_active_feature('SUPPLIER_A_TO_Z')
 def suppliers_list_by_prefix():
     api_prefix = process_prefix(
         prefix=request.args.get('prefix', default=u"A"),
@@ -78,7 +77,6 @@ def suppliers_list_by_prefix():
 
 
 @main.route('/g-cloud/supplier/<supplier_id>')
-@flask_featureflags.is_active_feature('SUPPLIER_A_TO_Z')
 def suppliers_details(supplier_id):
     supplier = data_api_client.get_supplier(
         supplier_id=supplier_id)["suppliers"]

--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -29,11 +29,9 @@
       <li>
         <a href="https://www.gov.uk/government/organisations/crown-commercial-service" rel="external">Crown Commercial Service</a>
       </li>
-        {% if 'SUPPLIER_A_TO_Z' is active_feature %}
-        <li>
-            <a class="home" href="{{ url_for('main.suppliers_list_by_prefix') }}">G-Cloud supplier A-Z</a>
-        </li>
-        {% endif %}
+      <li>
+          <a class="home" href="{{ url_for('main.suppliers_list_by_prefix') }}">G-Cloud supplier A-Z</a>
+      </li>
     </ul>
     </div>
     <div class="footer-suppliers">

--- a/config.py
+++ b/config.py
@@ -55,7 +55,6 @@ class Config(object):
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
-    FEATURE_FLAGS_SUPPLIER_A_TO_Z = False
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = False
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
     FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = False
@@ -73,7 +72,6 @@ class Config(object):
 class Test(Config):
     DEBUG = True
     DM_LOG_LEVEL = 'CRITICAL'
-    FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = enabled_since('2015-08-03')
@@ -83,21 +81,18 @@ class Development(Config):
     DEBUG = True
 
     DM_SEARCH_PAGE_SIZE = 5
-    FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = enabled_since('2015-08-03')
 
 
 class Preview(Config):
-    FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-08')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
 
 
 class Live(Config):
     DEBUG = False
-    FEATURE_FLAGS_SUPPLIER_A_TO_Z = enabled_since('2015-07-30')
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-20')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-09-01')
 


### PR DESCRIPTION
Per https://www.pivotaltracker.com/story/show/102080450

> Some feature flags we will want to switch off again in future (e.g. G7 Submissions open), but others will never be turned off again and so should be removed from the codebase.