### PR TITLE
Fix typo in CloudWatch application logs

### DIFF
--- a/.ebextensions/cwl-logs-application.config
+++ b/.ebextensions/cwl-logs-application.config
@@ -7,7 +7,7 @@ Mappings:
       JSONLogFile: "/var/log/digitalmarketplace/application.log.json"
       TimestampFormat: "%Y-%m-%dT%H:%M:%S"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
-      LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
+      JSONLogGroupName: {"Fn::GetOptionSetting": {"OptionName": "JSONLogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
 
 Resources:


### PR DESCRIPTION
I had entered the LogGroupName twice rather than adding a
JSONLogGroupName