### PR TITLE
[#102587184] Update login link to take logged-in users straight to dashboard

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -63,7 +63,7 @@
     {% endif %}
     <nav role="navigation" aria-labelledby="g-cloud-7-notice-heading">
       <ul>
-        <li><a href="/suppliers/login">Log in to existing supplier account</a></li>
+        <li><a href="/suppliers">Log in to existing supplier account</a></li>
         <li><a href="/suppliers/create">Create new supplier account</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/102587184