### PR TITLE
Allow the JavaScript tests to run in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,16 @@ Install new Python dependencies with pip
 
 ### Run the tests
 
+To run the whole testsuite:
+
 ```
 ./scripts/run_tests.sh
+```
+
+To only run the JavaScript tests:
+
+```
+npm test
 ```
 
 ### Run the development server

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var deleteFiles = require('del');
 var sass = require('gulp-sass');
 var filelog = require('gulp-filelog');
 var include = require('gulp-include');
+var jasmine = require('gulp-jasmine-phantom');
 
 // Paths
 var environment;
@@ -232,6 +233,25 @@ gulp.task(
     sspContentRoot, 'app/content'
   )
 );
+
+gulp.task('test', function () {
+  var manifest = require(repoRoot + 'spec/javascripts/manifest.js').manifest;
+
+  manifest.support = manifest.support.map(function (val) {
+    return val.replace(/^(\.\.\/){3}/, '');
+  });
+  manifest.test = manifest.test.map(function (val) {
+    return val.replace(/^\.\.\//, 'spec/javascripts/');
+  });
+
+  return gulp.src(manifest.test)
+    .pipe(jasmine({
+      'jasmine': '2.0',
+      'integration': true,
+      'abortOnFail': true,
+      'vendor': manifest.support
+    }));
+});
 
 gulp.task('watch', ['build:development'], function () {
   var jsWatcher = gulp.watch([ assetsFolder + '/**/*.js' ], ['js']);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "gulp-shell" : "0.2.9",
     "gulp-filelog" : "0.4.1",
     "gulp-include": "1.1.1",
-    "govuk_frontend_toolkit" : "4.1.1"
+    "govuk_frontend_toolkit" : "4.1.1",
+    "gulp-jasmine-phantom": "git://github.com/alphagov/gulp-jasmine-phantom#203c1cb2c4e951ff6aac7f3022d0f61111c8d9f4"
   },
   "scripts": {
     "test" : "./node_modules/gulp/bin/gulp.js test",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "frontend-build:development" : "./node_modules/gulp/bin/gulp.js build:development",
     "frontend-build:production" : "./node_modules/gulp/bin/gulp.js build:production",
     "frontend-build:watch" : "./node_modules/gulp/bin/gulp.js watch",
+    "test": "./node_modules/gulp/bin/gulp.js test",
     "postinstall": "npm run frontend-install"
   }
 }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -36,4 +36,7 @@ npm run --silent frontend-build:production
 display_result $? 1 "Build of front end static assets"
 
 nosetests -v -s --with-doctest
-display_result $? 3 "Unit tests"
+display_result $? 3 "Python unit tests"
+
+npm test
+display_result $? 3 "JavaScript unit tests"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -39,4 +39,4 @@ nosetests -v -s --with-doctest
 display_result $? 3 "Python unit tests"
 
 npm test
-display_result $? 3 "JavaScript unit tests"
+display_result $? 4 "JavaScript unit tests"

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -9,3 +9,7 @@ var manifest = {
     '../unit/AnalyticsSpec.js'
   ]
 };
+
+if (typeof exports !== 'undefined') {
+  exports.manifest = manifest;
+}


### PR DESCRIPTION
You can currently only run the JavaScript tests by loading the test runner in a browser.

This adds a Gulp task which uses PhantomJS to run the tests so it can be done from a command as well.

This is a copy of the same changes made to the supplier app:

https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/264