### PR TITLE
Update node modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 var gulp = require('gulp');
-var uglify = require('gulp-uglifyjs');
+var uglify = require('gulp-uglify');
 var deleteFiles = require('del');
 var sass = require('gulp-sass');
 var filelog = require('gulp-filelog');
@@ -118,7 +118,6 @@ gulp.task('js', function () {
     .pipe(filelog('Compressing JavaScript files'))
     .pipe(include())
     .pipe(uglify(
-      jsDistributionFile,
       uglifyOptions[environment]
     ))
     .pipe(gulp.dest(jsDistributionFolder));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var sass = require('gulp-sass');
 var filelog = require('gulp-filelog');
 var include = require('gulp-include');
 var jasmine = require('gulp-jasmine-phantom');
+var sourcemaps = require('gulp-sourcemaps');
 
 // Paths
 var environment;
@@ -117,9 +118,11 @@ gulp.task('js', function () {
   var stream = gulp.src(jsSourceFile)
     .pipe(filelog('Compressing JavaScript files'))
     .pipe(include())
+    .pipe(sourcemaps.init())
     .pipe(uglify(
       uglifyOptions[environment]
     ))
+    .pipe(sourcemaps.write('./maps'))
     .pipe(gulp.dest(jsDistributionFolder));
 
   stream.on('end', function () {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bower": "1.5.2",
     "gulp" : "3.8.7",
     "gulp-uglify" : "1.4.0",
+    "gulp-sourcemaps": "1.5.2",
     "del" : "1.1.1",
     "gulp-sass" : "1.3.3",
     "gulp-shell" : "0.2.9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private" : true,
   "engine" : "node >= 0.10.0",
   "dependencies" : {
-    "bower": "1.4.1",
+    "bower": "1.5.2",
     "gulp" : "3.8.7",
     "gulp-uglify" : "1.4.0",
     "del" : "1.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies" : {
     "bower": "1.4.1",
     "gulp" : "3.8.7",
-    "gulp-uglifyjs" : "0.6.0",
+    "gulp-uglify" : "1.4.0",
     "del" : "1.1.1",
     "gulp-sass" : "1.3.3",
     "gulp-shell" : "0.2.9",


### PR DESCRIPTION
Bumping some old Node modules and replacing the deprecated gulp-uglifyjs with gulp-uglify, as requested by its messaging.

See https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/275 for comparable changes on the suppliers' app.