### PR TITLE
Fix parsing of document URLs with semicolons in them

### DIFF
--- a/app/presenters/service_presenters.py
+++ b/app/presenters/service_presenters.py
@@ -180,12 +180,12 @@ class Meta(object):
         return caveats
 
     def _get_pretty_document_name_without_extension(self, document_url):
-        document_basename = os.path.basename(urlparse(document_url).path)
+        document_basename = os.path.basename(urlparse(document_url.replace(';', '%3B')).path)
         filename = unquote(os.path.splitext(document_basename)[0])
         return filename.replace('_', ' ')
 
     def _get_document_extension(self, document_url):
-        url_object = urlparse(document_url)
+        url_object = urlparse(document_url.replace(';', '%3B'))
         return os.path.splitext(url_object.path)[1].split('.')[1]
 
     def _if_both_keys_or_either(self, service_data, keys=[], values={}):


### PR DESCRIPTION
This will stop this page from giving a 500 error: https://www.digitalmarketplace.service.gov.uk/g-cloud/services/5-G5-0248-010

Before:
![screen shot 2015-09-10 at 14 54 49](https://cloud.githubusercontent.com/assets/6525554/9790083/f20ea248-57cb-11e5-874c-e1de7ce62958.png)

After:
![screen shot 2015-09-10 at 14 54 58](https://cloud.githubusercontent.com/assets/6525554/9790089/f8c74464-57cb-11e5-96c3-d85fb6f6d2a1.png)

Some G5 document URLs (well, at least one) have semicolons in them, which confuses `urlparse`, which splits off anything after a semicolon into params.

By replacing the semicolons with their URL-encoded escape then the methods changed here work properly.

As the methods are only used for finding the document extension and extracting a 'nice' document title, we don't need to worry overly about making the substitution here as the change will not be propagated to any displayed links, etc.