### PR TITLE
Update the README file so that tests can be run

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ source ./venv/bin/activate
 
 Install new Python dependencies with pip
 
-```pip install -r requirements.txt```
+```pip install -r requirements_for_test.txt```
+
+[Install frontend dependencies](https://github.com/alphagov/digitalmarketplace-buyer-frontend#front-end) with npm and gulp
+
+```
+npm install
+```
 
 ### Run the tests
 


### PR DESCRIPTION
Yesterday working alongside Andrew, we noticed that the information in the README is a bit out of order.
Basically, you'd need to install `requirements_for_test.txt` and also make sure your npm dependencies are installed beforehand.