### PR TITLE
Fix yellow mark element

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v10.1.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v10.1.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digital-marketplace-ssp-content": "git://github.com/alphagov/digital-marketplace-ssp-content#15fcaeab5b24893a04bece14a56ff2fa425e5633"
   }


### PR DESCRIPTION
Brings in https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/157

Which does what https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/156 should have done.

> Highlights were changed to use the `<mark>` element in alphagov/digitalmarketplace-search-api#54

> Some browsers, by default, style the `<mark>` element with a bright yellow background.

> This makes sure that doesn't happen.





![aaeaaqaaaaaaaaikaaaajgzlmzc5ogrkltexntgtngjmzi1imgjklti1mzq0ytk0mznkzg](https://cloud.githubusercontent.com/assets/355079/9931654/7b85dea6-5d35-11e5-9ccf-180fb7106294.jpg)