### PR TITLE
Update buyers-guide.html

### DIFF
--- a/app/templates/content/buyers-guide.html
+++ b/app/templates/content/buyers-guide.html
@@ -42,7 +42,7 @@
 <h2 id="buying-services-on-digital-marketplace">
 <span class="number">1. </span>Digital Marketplace overview</h2>
 <p>
-  The Digital Marketplace helps you find and compare cloud technology and people to deliver digital projects.
+  The Digital Marketplace helps you find cloud technology and people for digital projects.
 </p>
 <p>
   It uses 3 frameworks (agreements between government and suppliers).
@@ -65,6 +65,7 @@
 
 <h2 id="g-cloud-order-form">
   <span class="number">2. </span>Digital Marketplace services</h2>
+<h3>Cloud-based services</h3>
 <p>
   There are over 19,000 cloud-based services on the Digital Marketplace, split into 4 categories:
 </p>
@@ -79,6 +80,7 @@
     Specialist Cloud Services (SCS)
   </li>
 </ul>
+<h3>Digital specialist services</h3>
 <p>
 More than 160 suppliers provide digital specialists to perform all or some of the following roles:
 </p>
@@ -121,7 +123,7 @@ More than 160 suppliers provide digital specialists to perform all or some of th
     </tr>
   </tbody>
 </table>
-<p>
+<h3>Datacentre hosting services</h3><p>
   One supplier provides datacentre hosting to government. It offers:
 </p>
 <ul>


### PR DESCRIPTION
- 'and compare' in this context was misleading. Reads like you might be comparing cloud services against specialist services.
- 'deliver' is a banned GDS word. Edited to reflect homepage description
- added in subheadings to make the distinction between frameworks clearer