### PR TITLE
Update summary manifest to match content change

### DIFF
--- a/app/helpers/search_summary_manifest.yml
+++ b/app/helpers/search_summary_manifest.yml
@@ -49,7 +49,7 @@
     id: Data extraction/removal plan in place
   -
     preposition: the
-    id: Datacentres adhere to EU Code of Conduct for Operations
+    id: Datacentres adhere to the EU code of conduct for energy-efficient datacentres
   -
     preposition: there is a
     id: Backup, disaster recovery and resilience plan in place


### PR DESCRIPTION
The label for one of the filters was changed in https://github.com/alphagov/digitalmarketplace-frameworks/commit/881734dc27cc5430267512142c72390193dc13e0

This was causing `500`s in production because users were able to filter by something
that was not defined in the manifest.

This is an immediate fix. There is probably a longer-term solution that makes this more
robust