### PR TITLE
Update dmutils to 8.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ requests==2.5.1
 inflection==0.2.1
 pyyaml==3.11
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@6.9.1#egg=digitalmarketplace-utils==6.9.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@8.1.1#egg=digitalmarketplace-utils==8.1.1
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14


### PR DESCRIPTION
[#103403706](https://www.pivotaltracker.com/story/show/103403706)

Fixes missing request ID on error responses and logging of API
requests.