### PR TITLE
Fix page size environment variable

### DIFF
--- a/app/main/views.py
+++ b/app/main/views.py
@@ -188,7 +188,7 @@ def search():
 
     pagination_config = pagination(
         search_results_obj.total,
-        current_app.config["DM_SEARCH_PAGE_SIZE"],
+        int(current_app.config["DM_SEARCH_PAGE_SIZE"]),
         get_page_from_request(request)
     )
 


### PR DESCRIPTION
The page size needs to be an integer but when passed in with an environment variable it is always a string. This converts it to an integer at the point of use.