### PR TITLE
Turn off G7-Live feature flag in prod

### DIFF
--- a/config.py
+++ b/config.py
@@ -94,7 +94,7 @@ class Preview(Config):
 class Live(Config):
     DEBUG = False
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-20')
-    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-09-01')
+    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
 
 class Staging(Live):


### PR DESCRIPTION
To deploy at 3pm - immediately after the API database migration.