### PR TITLE
Replace the spacing below <p>'s in homepage notice

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -75,4 +75,9 @@
     }
   }
 
+  /* `.g-cloud-7-notice p` overwrites the `margin-bottom` of paragraphs in the temporary message */
+  .g-cloud-7-notice .temporary-message-message {
+    margin-bottom: 5px;
+  }
+
 }


### PR DESCRIPTION
[This line](https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/master/app/assets/scss/_index-page.scss#L48), included to set the spacing of the homepage G7 notice paragraphs, was cancelling out the spacing between paragraphs in the post-G7-closing notice.

This replaces the spacing to that in the original pattern.

### Before

![image](https://cloud.githubusercontent.com/assets/87140/10308800/38031ab8-6c30-11e5-93e3-0d749589ae6c.png)

### After

![image](https://cloud.githubusercontent.com/assets/87140/10308807/403a2a1e-6c30-11e5-9524-b6277f417a88.png)