### PR TITLE
Content update after zendesk feedback

### DIFF
--- a/app/templates/content/buyers-guide-g-cloud.html
+++ b/app/templates/content/buyers-guide-g-cloud.html
@@ -238,7 +238,7 @@ Your contract details won't be published.
 <h2 id="g-cloud-order-form">
 <span class="number">2. </span>Choosing the right G-Cloud call-off contract document</h2>
 <p>
-Cloud services on the Digital Marketplace are on either <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557v">the G-Cloud 5 framework</a> or <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi">the G-Cloud 6 framework</a>. 
+Two iterations of the G-Cloud framework are currently available on the Digital Marketplace: <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557v">G-Cloud 5</a> and <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi">G-Cloud 6</a>. You can buy services from either framework.
 </p>
 
 <h3>G-Cloud 5 framework</h3>

--- a/app/templates/content/buyers-guide-g-cloud.html
+++ b/app/templates/content/buyers-guide-g-cloud.html
@@ -236,11 +236,16 @@ Your contract details won't be published.
 
 
 <h2 id="g-cloud-order-form">
-<span class="number">2. </span>Choosing the right G-Cloud call-off contract</h2>
+<span class="number">2. </span>Choosing the right G-Cloud call-off contract document</h2>
 <p>
-Cloud services on the Digital Marketplace will be on either <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557v">G-Cloud 5</a> or <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi">G-Cloud 6</a>. G-Cloud 6 is the latest call-off contract.
+Cloud services on the Digital Marketplace are on either <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557v">the G-Cloud 5 framework</a> or <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi">the G-Cloud 6 framework</a>. 
 </p>
 
+<h3>G-Cloud 5 framework</h3>
+<p>If you’re buying a G-Cloud 5 service, you need to use a G-Cloud 5 call-off contract document. You can find the G-Cloud 5 call-off contract under the documents tab of the <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557v">G-Cloud 5</a> page on the CCS website.</p>
+
+<h3>G-Cloud 6 framework</h3>
+<p>If you’re buying a G-Cloud 6 service, you need to use a G-Cloud 6 call-off contract document. You can find the G-Cloud 6 call-off contract under the documents tab of the <a rel="external" href="http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi">G-Cloud 6</a> page on the CCS website.</p>
 
 <h2 id="continuing-or-ending-g-cloud-services">
 <span class="number">3. </span>Continuing or ending G-Cloud services</h2>


### PR DESCRIPTION
Update to 'choosing the right call-off contract' content. Old content implied the G6 services were in some way more up-to-date than G5 services.