### PR TITLE
Add API error handling similar to supplier app

### DIFF
--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -3,15 +3,32 @@
 from flask import render_template, current_app, request
 from . import main
 from ..helpers.search_helpers import get_template_data
+from dmutils.apiclient import APIError
+
+
+@main.app_errorhandler(APIError)
+def api_error_handler(e):
+    return _render_error_page(e.status_code)
 
 
 @main.app_errorhandler(404)
 def page_not_found(e):
-    template_data = get_template_data(main, {})
-    return render_template("errors/404.html", **template_data), 404
+    return _render_error_page(404)
 
 
 @main.app_errorhandler(500)
 def page_not_found(e):
+    return _render_error_page(500)
+
+
+def _render_error_page(status_code):
+    templates = {
+        404: "errors/404.html",
+        500: "errors/500.html",
+        503: "errors/500.html",
+    }
+    if status_code not in templates:
+        status_code = 500
     template_data = get_template_data(main, {})
-    return render_template("errors/500.html", **template_data), 500
+
+    return render_template(templates[status_code], **template_data), status_code


### PR DESCRIPTION
Currently 404s returned by the API are resulting in 500s on the buyer app for invalid supplier requests. This change takes the model used in the supplier frontend to automatically handle uncaught APIErrors. It is not identical to the supplier app version because the default template data is generated in a different way.