### PR TITLE
[#105005304] DM homepage message contingent on framework status

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -36,7 +36,7 @@
 
   }
 
-  .g-cloud-7-notice {
+  .framework-message {
     margin-top: 45px;
 
     h2 {
@@ -75,8 +75,8 @@
     }
   }
 
-  /* `.g-cloud-7-notice p` overwrites the `margin-bottom` of paragraphs in the temporary message */
-  .g-cloud-7-notice .temporary-message-message {
+  /* `.framework-message p` overwrites the `margin-bottom` of paragraphs in the temporary message */
+  .framework-message .temporary-message-message {
     margin-bottom: 5px;
   }
 

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -39,6 +39,7 @@ $path: "/static/images/";
 @import "_atoz_navigation.scss";
 @import "_error-pages.scss";
 @import "toolkit/temporary-message.scss";
+@import "toolkit/framework-notice.scss";
 
 .return-to-top {
   display: block;

--- a/app/helpers/shared_helpers.py
+++ b/app/helpers/shared_helpers.py
@@ -8,3 +8,12 @@ def get_label_for_lot_param(lot_param):
     }
     if lot_param in lots:
         return lots[lot_param]
+
+
+def get_one_framework_by_status_in_order_of_preference(frameworks, statuses_in_order_of_preference):
+    for status in statuses_in_order_of_preference:
+        for framework in frameworks:
+            if framework.get('status') == status:
+                return framework
+
+    return None

--- a/app/helpers/shared_helpers.py
+++ b/app/helpers/shared_helpers.py
@@ -15,5 +15,3 @@ def get_one_framework_by_status_in_order_of_preference(frameworks, statuses_in_o
         for framework in frameworks:
             if framework.get('status') == status:
                 return framework
-
-    return None

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -33,7 +33,21 @@ from .. import search_api_client, data_api_client, content_loader
 @main.route('/')
 def index():
     template_data = get_template_data(main, {})
-    return render_template('index.html', **template_data)
+
+    framework_slug = 'digital-outcomes-and-specialists'
+    framework_slug = 'g-cloud-7'
+    # get framework status in a better way
+    framework_status = 'pending'
+    block = 'homepage-sidebar'
+
+    content_loader.load_messages(framework_slug, [block])
+    temporary_message = content_loader.get_message(framework_slug, block, framework_status)
+
+    return render_template(
+        'index.html',
+        temporary_message=temporary_message,
+        **template_data
+    )
 
 
 @main.route('/g-cloud')

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -44,15 +44,16 @@ def index():
             ['open', 'coming', 'pending']
         )
 
-        content_loader.load_messages(framework.get('slug'), ['homepage-sidebar'])
-        temporary_message = content_loader.get_message(
-            framework.get('slug'),
-            'homepage-sidebar',
-            framework.get('status')
-        )
+        if framework is not None:
+            content_loader.load_messages(framework.get('slug'), ['homepage-sidebar'])
+            temporary_message = content_loader.get_message(
+                framework.get('slug'),
+                'homepage-sidebar',
+                framework.get('status')
+            )
 
     # if no framework is found (should never happen), ditch the message and load the page
-    except (APIError, AttributeError):
+    except APIError:
         pass
     # if no message file is found (should never happen), throw a 500
     except ContentNotFoundError:

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -40,7 +40,6 @@
   </div>
     <div class="framework-message column-one-third">
       {% if temporary_message %}
-        {# define all variables used by any of the expected templates #}
         {%
           with
             heading = temporary_message.heading,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -51,11 +51,9 @@
       <p>
         Register your interest in becoming a G&#8209;Cloud&nbsp;7 supplier.
       </p>
-      {% if 'G_CLOUD_7_SUPPLIER_GUIDE' is active_feature %}
-        <p class="supplier-info">
-          <a href="">Read G&#8209;Cloud&nbsp;7 information for suppliers</a>
-        </p>
-      {% endif %}
+      <p class="supplier-info">
+        <a href="">Read G&#8209;Cloud&nbsp;7 information for suppliers</a>
+      </p>
       <nav role="navigation" aria-labelledby="g-cloud-7-notice-heading">
         <ul>
           <li><a href="/suppliers">Log in to existing supplier account</a></li>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,7 +4,6 @@
 
 {% block main_content %}
 
-{% if 'G_CLOUD_7_NOTICE' is active_feature %}
 <div class="index-page grid-row">
   <div class="column-two-thirds">
     <header class="page-heading">
@@ -76,40 +75,5 @@
       </div>
     {% endif %}
 </div>
-{% else %}
-<div class="index-page">
-  <header class="page-heading">
-    <h1>
-      Digital Marketplace
-    </h1>
-    <p class="lead">
-      Find technology or people for digital projects in the public sector
-    </p>
-  </header>
-  {% with
-    items = [
-      {
-        "link": "/g-cloud",
-        "title": "Find cloud technology and support",
-        "body": "eg web hosting or IT health checks",
-        "subtext": "Procurement framework: <a href='/g-cloud/framework'>G-Cloud</a>"
-      },
-      {
-        "link": "/crown-hosting",
-        "title": "Buy physical datacentre space for legacy systems",
-        "subtext": "Procurement framework: <a href='/crown-hosting/framework'>Crown Hosting Data Centres</a>"
-      },
-      {
-        "link": "https://digitalservicesstore.service.gov.uk/",
-        "title": "Find specialists to work on digital projects",
-        "body": "eg technical architects and user researchers",
-        "subtext": "Procurement framework: <a href='/digital-services/framework'>Digital Services</a>"
-      }
-    ]
-  %}
-    {% include "toolkit/browse-list.html" %}
-  {% endwith %}
-</div>
-{% endif %}
 
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -38,42 +38,20 @@
       {% include "toolkit/browse-list.html" %}
     {% endwith %}
   </div>
-  {% if 'G_CLOUD_7_IS_LIVE' is active_feature %}
-    <aside role="complementary" class="g-cloud-7-notice column-one-third">
-      <h2 id="g-cloud-7-notice-heading">
-        G&#8209;Cloud&nbsp;7 is open for applications
-      </h2>
-      <p class="hint">
-        Deadline for submissions<br />
-        3pm <abbr title="British Summer Time">BST</abbr>, 6 October 2015
-      </p>
-      <p>
-        Register your interest in becoming a G&#8209;Cloud&nbsp;7 supplier.
-      </p>
-      <p class="supplier-info">
-        <a href="">Read G&#8209;Cloud&nbsp;7 information for suppliers</a>
-      </p>
-      <nav role="navigation" aria-labelledby="g-cloud-7-notice-heading">
-        <ul>
-          <li><a href="/suppliers">Log in to existing supplier account</a></li>
-          <li><a href="/suppliers/create">Create new supplier account</a></li>
-        </ul>
-      </nav>
-    </aside>
-    {% else %}
-      <div class="g-cloud-7-notice column-one-third">
+    <div class="framework-message column-one-third">
+      {% if temporary_message %}
+        {# define all variables used by any of the expected templates #}
         {%
-        with
-          messages = [
-          "Applications are being reviewed.",
-          "G\u2011Cloud&nbsp;7 services will be available from 23&nbsp;November&nbsp;2015."
-          ],
-          heading = "G\u2011Cloud 7 is closed for applications"
+          with
+            heading = temporary_message.heading,
+            subheading = temporary_message.subheading,
+            messages = temporary_message.messages,
+            message = temporary_message.message
         %}
-        {% include "toolkit/temporary-message.html" %}
+          {% include "toolkit/{}.html".format(temporary_message.template_name) %}
         {% endwith %}
-      </div>
-    {% endif %}
+      {% endif %}
+    </div>
 </div>
 
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.3.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v11.4.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#8650c272bcdc754f5cb64e216f41fa134bbe5c61"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#ed98bd4de92fffe1ab3c64f32b5a0c87276e7a23"
   }
 }

--- a/config.py
+++ b/config.py
@@ -55,7 +55,6 @@ class Config(object):
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
-    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
     @staticmethod
     def init_app(app):
@@ -70,27 +69,24 @@ class Config(object):
 class Test(Config):
     DEBUG = True
     DM_LOG_LEVEL = 'CRITICAL'
-    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
 
 
 class Development(Config):
     DEBUG = True
 
     DM_SEARCH_PAGE_SIZE = 5
-    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
 
 class Preview(Config):
-    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
+    pass
 
 
 class Live(Config):
     DEBUG = False
-    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
 
 class Staging(Live):
-    FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
+    pass
 
 configs = {
     'development': Development,

--- a/config.py
+++ b/config.py
@@ -55,7 +55,6 @@ class Config(object):
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
-    FEATURE_FLAGS_G_CLOUD_7_NOTICE = False
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
     @staticmethod
@@ -71,7 +70,6 @@ class Config(object):
 class Test(Config):
     DEBUG = True
     DM_LOG_LEVEL = 'CRITICAL'
-    FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
 
 
@@ -79,23 +77,19 @@ class Development(Config):
     DEBUG = True
 
     DM_SEARCH_PAGE_SIZE = 5
-    FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
 
 class Preview(Config):
-    FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
 
 class Live(Config):
     DEBUG = False
-    FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-20')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
 
 class Staging(Live):
-    FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-18')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
 
 configs = {

--- a/config.py
+++ b/config.py
@@ -57,7 +57,6 @@ class Config(object):
     RAISE_ERROR_ON_MISSING_FEATURES = True
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = False
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
-    FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = False
 
     @staticmethod
     def init_app(app):
@@ -74,7 +73,6 @@ class Test(Config):
     DM_LOG_LEVEL = 'CRITICAL'
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = enabled_since('2015-08-03')
-    FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = enabled_since('2015-08-03')
 
 
 class Development(Config):
@@ -83,7 +81,6 @@ class Development(Config):
     DM_SEARCH_PAGE_SIZE = 5
     FEATURE_FLAGS_G_CLOUD_7_NOTICE = enabled_since('2015-08-03')
     FEATURE_FLAGS_G_CLOUD_7_IS_LIVE = False
-    FEATURE_FLAGS_G_CLOUD_7_SUPPLIER_GUIDE = enabled_since('2015-08-03')
 
 
 class Preview(Config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ requests==2.5.1
 inflection==0.2.1
 pyyaml==3.11
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@10.2.0#egg=digitalmarketplace-utils==10.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@10.6.0#egg=digitalmarketplace-utils==10.6.0
 
 # Required for SNI to work in requests
 pyOpenSSL==0.14

--- a/tests/app/views/test_application.py
+++ b/tests/app/views/test_application.py
@@ -1,5 +1,7 @@
-from nose.tools import assert_equal, assert_true, assert_in
+import mock
+from nose.tools import assert_equal, assert_true, assert_in, assert_not_in
 from ...helpers import BaseApplicationTest
+from dmutils.apiclient import APIError
 
 
 class TestApplication(BaseApplicationTest):
@@ -20,3 +22,125 @@ class TestApplication(BaseApplicationTest):
             '<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>'
             in res.get_data(as_text=True)
         )
+
+
+class TestHomepageSidebarMessage(BaseApplicationTest):
+    def setup(self):
+        super(TestHomepageSidebarMessage, self).setup()
+
+    @staticmethod
+    def _find_frameworks(framework_slugs_and_statuses):
+
+        _frameworks = []
+
+        for index, framework_slug_and_status in enumerate(framework_slugs_and_statuses):
+            framework_slug, framework_status = framework_slug_and_status
+            _frameworks.append({
+                'framework': 'framework',
+                'slug': framework_slug,
+                'id': index + 1,
+                'status': framework_status,
+                'name': 'Framework'
+            })
+
+        return {
+            'frameworks': _frameworks
+        }
+
+    @staticmethod
+    def _assert_message_container_is_empty(response_data):
+        empty_message_container = '<div class="framework-message column-one-third"></div>'
+        assert_in(
+            BaseApplicationTest._strip_whitespace(empty_message_container),
+            BaseApplicationTest._strip_whitespace(response_data),
+        )
+
+    @staticmethod
+    def _assert_message_container_is_not_empty(response_data):
+        empty_message_container = '<div class="framework-message column-one-third"></div>'
+        assert_not_in(
+            BaseApplicationTest._strip_whitespace(empty_message_container),
+            BaseApplicationTest._strip_whitespace(response_data),
+        )
+
+    @mock.patch('app.main.views.data_api_client')
+    def _load_homepage(self, framework_slugs_and_statuses, framework_messages, data_api_client):
+
+        data_api_client.find_frameworks.return_value = self._find_frameworks(framework_slugs_and_statuses)
+        res = self.client.get('/')
+        assert_equal(200, res.status_code)
+        response_data = res.get_data(as_text=True)
+
+        if framework_messages:
+            self._assert_message_container_is_not_empty(response_data)
+            for message in framework_messages:
+                assert_in(message, response_data)
+        else:
+            self._assert_message_container_is_empty(response_data)
+
+    def test_homepage_sidebar_message_exists_dos_coming(self):
+
+        framework_slugs_and_statuses = [
+            ('g-cloud-7', 'pending'),
+            ('digital-outcomes-and-specialists', 'coming')
+        ]
+        framework_messages = [
+            'Become a Digital Outcomes and Specialists supplier',
+            'Digital Outcomes and Specialists will be open for applications soon.'
+        ]
+
+        self._load_homepage(framework_slugs_and_statuses, framework_messages)
+
+    def test_homepage_sidebar_message_exists_dos_open(self):
+
+        framework_slugs_and_statuses = [
+            ('g-cloud-7', 'pending'),
+            ('digital-outcomes-and-specialists', 'open')
+        ]
+        framework_messages = [
+            'Become a Digital Outcomes and Specialists supplier',
+            'Digital Outcomes and Specialists is open for applications.'
+        ]
+
+        self._load_homepage(framework_slugs_and_statuses, framework_messages)
+
+    def test_homepage_sidebar_message_exists_g_cloud_7_pending(self):
+
+        framework_slugs_and_statuses = [
+            ('g-cloud-7', 'pending')
+        ]
+        framework_messages = [
+            'G‑Cloud 7 is closed for applications',
+            'G‑Cloud 7 services will be available from 23 November 2015.'
+        ]
+
+        self._load_homepage(framework_slugs_and_statuses, framework_messages)
+
+    def test_homepage_sidebar_message_doesnt_exist_without_frameworks(self):
+        framework_slugs_and_statuses = [
+            ('g-cloud-2', 'expired'),
+            ('g-cloud-3', 'expired'),
+            ('g-cloud-4', 'expired')
+        ]
+
+        # there are no messages
+        self._load_homepage(framework_slugs_and_statuses, None)
+
+    @mock.patch('app.main.views.data_api_client')
+    def test_api_error_message_doesnt_exist(self, data_api_client):
+
+        data_api_client.find_frameworks.side_effect = APIError()
+        res = self.client.get('/')
+        assert_equal(200, res.status_code)
+        self._assert_message_container_is_empty(res.get_data(as_text=True))
+
+    # here we've given an valid framework with a valid status but there is no message.yml file to read from
+    @mock.patch('app.main.views.data_api_client')
+    def test_g_cloud_6_open_blows_up(self, data_api_client):
+        framework_slugs_and_statuses = [
+            ('g-cloud-6', 'open')
+        ]
+
+        data_api_client.find_frameworks.return_value = self._find_frameworks(framework_slugs_and_statuses)
+        res = self.client.get('/')
+        assert_equal(500, res.status_code)

--- a/tests/app/views/test_application.py
+++ b/tests/app/views/test_application.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import mock
 from nose.tools import assert_equal, assert_true, assert_in, assert_not_in
 from ...helpers import BaseApplicationTest
@@ -85,8 +87,8 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
             ('digital-outcomes-and-specialists', 'coming')
         ]
         framework_messages = [
-            'Become a Digital Outcomes and Specialists supplier',
-            'Digital Outcomes and Specialists will be open for applications soon.'
+            u"Become a Digital Outcomes and Specialists supplier",
+            u"Digital Outcomes and Specialists will be open for applications soon."
         ]
 
         self._load_homepage(framework_slugs_and_statuses, framework_messages)
@@ -98,8 +100,8 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
             ('digital-outcomes-and-specialists', 'open')
         ]
         framework_messages = [
-            'Become a Digital Outcomes and Specialists supplier',
-            'Digital Outcomes and Specialists is open for applications.'
+            u"Become a Digital Outcomes and Specialists supplier",
+            u"Digital Outcomes and Specialists is open for applications."
         ]
 
         self._load_homepage(framework_slugs_and_statuses, framework_messages)
@@ -110,8 +112,8 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
             ('g-cloud-7', 'pending')
         ]
         framework_messages = [
-            'G‑Cloud 7 is closed for applications',
-            'G‑Cloud 7 services will be available from 23 November 2015.'
+            u"G‑Cloud 7 is closed for applications",
+            u"G‑Cloud 7 services will be available from 23 November 2015."
         ]
 
         self._load_homepage(framework_slugs_and_statuses, framework_messages)


### PR DESCRIPTION
This story changes the message on the Digital Marketplace homepage by looking for the message associated with the first framework it finds with the highest-priority status.  The list of statuses we care about is kept [in the route for the homepage](https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/pc_manage_mainpage_messages/app/main/views.py#L44). 
So, for example:
- If `pending` was the status we were most interested in, then [the message for `g-cloud-7`](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/g-cloud-7/messages/homepage-sidebar.yml#L1) would be returned.  [Same as exists currently](https://www.digitalmarketplace.service.gov.uk/).

- If we were looking for a `coming` framework, [the message for `digital-outcomes-and-specialists`](https://github.com/alphagov/digitalmarketplace-frameworks/blob/master/frameworks/digital-outcomes-and-specialists/messages/homepage-sidebar.yml#L1) would be returned.  [Same as Ralph's prototype](http://dm-prototype.herokuapp.com/states/homepage?dos.framework=coming).

- If we were looking for `[ "open", "coming", "pending" ]` frameworks (and there were no open frameworks), then the `coming` message for `digital-outcomes-and-specialists` would be returned.

Also, I removed all of the feature flags as all of them were being used to control how content appeared on the homepage.

##### To keep in mind 

- If two frameworks are in the same status of equal priority (ie, if two are `pending` and none are `open`), then the one returned first in the API response will be selected
- If a framework with a valid status has no corresponding `.yml` file in its `messages/` directory, the app returns a 500.  Since it's on the Digital Marketplace homepage, it's probably best to avoid this where possible.

***
:trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet: :tada: :trumpet:

![screen shot 2015-10-27 at 14 55 06](https://cloud.githubusercontent.com/assets/2454380/10761814/f59ad88c-7cba-11e5-90e0-e5f0d74ad8f0.png)