### PR TITLE
Add error handling for 410 responses

### DIFF
--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -16,6 +16,11 @@ def page_not_found(e):
     return _render_error_page(404)
 
 
+@main.app_errorhandler(410)
+def page_gone(e):
+    return _render_error_page(410)
+
+
 @main.app_errorhandler(500)
 def page_not_found(e):
     return _render_error_page(500)
@@ -24,6 +29,7 @@ def page_not_found(e):
 def _render_error_page(status_code):
     templates = {
         404: "errors/404.html",
+        410: "errors/410.html",
         500: "errors/500.html",
         503: "errors/500.html",
     }

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -194,8 +194,10 @@ def get_service_by_id(service_id):
         return render_template('service.html', **template_data)
     except AuthException:
         abort(500, "Application error")
-    except KeyError as e:
+    except KeyError:
         abort(404, "Service ID '%s' can not be found" % service_id)
+    except HTTPError as e:
+        abort(e.status_code)
 
 
 @main.route('/search')

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -197,7 +197,11 @@ def get_service_by_id(service_id):
     except KeyError:
         abort(404, "Service ID '%s' can not be found" % service_id)
     except HTTPError as e:
-        abort(e.status_code)
+        if e.status_code == 410:
+            template_data = get_template_data(main, {})
+            return render_template('errors/410_service_gone.html', **template_data), 410
+        else:
+            abort(e.status_code)
 
 
 @main.route('/search')

--- a/app/templates/errors/404.html
+++ b/app/templates/errors/404.html
@@ -5,16 +5,20 @@
 {% block main_content %}
 
 <div class="error-page">
-  <header class="page-heading-smaller">
-    <h1>Page could not be found</h1>
-  </header>
-
-  <p>
-      Check you've entered the correct web address or start again on the Digital Marketplace homepage.
-  </p>
-  <p>
-      If you can't find what you're looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-  </p>
+    <div class="index-page grid-row">
+        <div class="column-two-thirds">
+          <header class="page-heading-smaller">
+            <h1>Page could not be found</h1>
+          </header>
+        
+          <p>
+              Check you've entered the correct web address or start again on the Digital Marketplace homepage.
+          </p>
+          <p>
+              If you can't find what you're looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+          </p>
+        </div>
+    </div>
 </div>
 
 {% endblock %}

--- a/app/templates/errors/404.html
+++ b/app/templates/errors/404.html
@@ -7,16 +7,15 @@
 <div class="error-page">
     <div class="index-page grid-row">
         <div class="column-two-thirds">
-          <header class="page-heading-smaller">
-            <h1>Page could not be found</h1>
-          </header>
-        
-          <p>
-              Check you've entered the correct web address or start again on the Digital Marketplace homepage.
-          </p>
-          <p>
-              If you can't find what you're looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-          </p>
+            <header class="page-heading-smaller">
+                <h1>Page could not be found</h1>
+            </header>
+            <p>
+                Check you've entered the correct web address or start again on the Digital Marketplace homepage.
+            </p>
+            <p>
+                If you can't find what you're looking for, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+            </p>
         </div>
     </div>
 </div>

--- a/app/templates/errors/410.html
+++ b/app/templates/errors/410.html
@@ -1,0 +1,20 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Service no longer available - Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="error-page">
+  <header class="page-heading-smaller">
+    <h1>Service no longer available</h1>
+  </header>
+
+  <p>
+      The requested service was on a framework that is no longer live and so it is no longer available through the Digital Marketplace.
+  </p>
+  <p>
+      If you need to see the details of this service for some reason, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Details%20of%20expired%20service" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+  </p>
+</div>
+
+{% endblock %}

--- a/app/templates/errors/410.html
+++ b/app/templates/errors/410.html
@@ -8,13 +8,13 @@
     <div class="index-page grid-row">
         <div class="column-two-thirds">
             <header class="page-heading-smaller">
-                <h1>Service no longer available</h1>
+                <h1>Page no longer available</h1>
             </header>
             <p>
-                The requested service was on a framework that is no longer live and so it is no longer available through the Digital Marketplace.
+                The page you requested is no longer available on the Digital Marketplace.
             </p>
             <p>
-                If you need to see the details of this service for some reason, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Details%20of%20expired%20service" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+                If you can't find what you're looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20page%20gone" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
             </p>
         </div>
     </div>

--- a/app/templates/errors/410.html
+++ b/app/templates/errors/410.html
@@ -14,7 +14,7 @@
                 The page you requested is no longer available on the Digital Marketplace.
             </p>
             <p>
-                If you can't find what you're looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20page%20gone" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+                If you can't find what you're looking for, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20page%20gone" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
             </p>
         </div>
     </div>

--- a/app/templates/errors/410.html
+++ b/app/templates/errors/410.html
@@ -5,16 +5,19 @@
 {% block main_content %}
 
 <div class="error-page">
-  <header class="page-heading-smaller">
-    <h1>Service no longer available</h1>
-  </header>
-
-  <p>
-      The requested service was on a framework that is no longer live and so it is no longer available through the Digital Marketplace.
-  </p>
-  <p>
-      If you need to see the details of this service for some reason, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Details%20of%20expired%20service" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-  </p>
+    <div class="index-page grid-row">
+        <div class="column-two-thirds">
+            <header class="page-heading-smaller">
+                <h1>Service no longer available</h1>
+            </header>
+            <p>
+                The requested service was on a framework that is no longer live and so it is no longer available through the Digital Marketplace.
+            </p>
+            <p>
+                If you need to see the details of this service for some reason, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Details%20of%20expired%20service" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+            </p>
+        </div>
+    </div>
 </div>
 
 {% endblock %}

--- a/app/templates/errors/410_service_gone.html
+++ b/app/templates/errors/410_service_gone.html
@@ -14,7 +14,7 @@
                 This service is on an old framework that is no longer available on the Digital Marketplace.
             </p>
             <p>
-                If you need to see the details of this service, contact us at
+                If you need to see the details of this service, email
                 <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Details%20of%20expired%20service" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
             </p>
         </div>

--- a/app/templates/errors/410_service_gone.html
+++ b/app/templates/errors/410_service_gone.html
@@ -11,7 +11,7 @@
                 <h1>Service no longer available</h1>
             </header>
             <p>
-                This service was on a framework that has ended. It is no longer available on the Digital Marketplace.
+                This service is on an old framework that is no longer available on the Digital Marketplace.
             </p>
             <p>
                 If you need to see the details of this service, contact us at

--- a/app/templates/errors/410_service_gone.html
+++ b/app/templates/errors/410_service_gone.html
@@ -1,0 +1,24 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Service no longer available - Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+<div class="error-page">
+    <div class="index-page grid-row">
+        <div class="column-two-thirds">
+            <header class="page-heading-smaller">
+                <h1>Service no longer available</h1>
+            </header>
+            <p>
+                This service was on a framework that has ended. It is no longer available on the Digital Marketplace.
+            </p>
+            <p>
+                If you need to see the details of this service, contact us at
+                <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Details%20of%20expired%20service" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+            </p>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/app/templates/errors/500.html
+++ b/app/templates/errors/500.html
@@ -5,12 +5,16 @@
 {% block main_content %}
 
 <div class="error-page">
-  <header class="page-heading-smaller">
-    <h1>Sorry, we're experiencing technical difficulties</h1>
-  </header>
-  <p>
-      Try again later.
-  </p>
+  <div class="index-page grid-row">
+    <div class="column-two-thirds">
+      <header class="page-heading-smaller">
+        <h1>Sorry, we're experiencing technical difficulties</h1>
+      </header>
+      <p>
+          Try again later.
+      </p>
+    </div>
+  </div>
 </div>
 
 {% endblock %}

--- a/tests/app/views/test_errors.py
+++ b/tests/app/views/test_errors.py
@@ -16,7 +16,7 @@ class TestErrors(BaseApplicationTest):
             "address or start again on the Digital Marketplace homepage."
             in res.get_data(as_text=True))
         assert_true(
-            "If you can't find what you're looking for, contact us at "
+            "If you can't find what you're looking for, email "
             "<a href=\"mailto:enquiries@digitalmarketplace.service.gov.uk?"
             "subject=Digital%20Marketplace%20feedback\" title=\"Please "
             "send feedback to enquiries@digitalmarketplace.service.gov.uk\">"


### PR DESCRIPTION
The API will soon return 410 ("Gone") responses for requests for services on an expired framework.

This shows users a nice error page if they request details of services on an expired framework.

See: https://www.pivotaltracker.com/story/show/107382498

This is related to, but not dependent on: https://github.com/alphagov/digitalmarketplace-api/pull/286

Looks like:
![screen shot 2015-11-04 at 12 17 47](https://cloud.githubusercontent.com/assets/6525554/10937910/24dd30d4-82ee-11e5-8188-a66751b3f06e.png)
