### PR TITLE
Prevent indexing of search results pages in Google

### DIFF
--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -1,7 +1,11 @@
-
 {% extends "_base_page.html" %}
 
 {% block page_title %}Search - Digital Marketplace{% endblock %}
+
+{% block head %}
+  <meta name="robots" content="noindex">
+  {{ super() }}
+{% endblock %}
 
 {% block breadcrumb %}
   {% with %}


### PR DESCRIPTION
Robots will be allowed on search results pages through the robots.txt. This change explicitly prevents them from being indexed in search engines.

This will allow the service pages to be discovered by crawlers while preventing search results pages appearing in Google search results.

See:
- https://support.google.com/webmasters/answer/93710?hl=en
- https://github.com/alphagov/digitalmarketplace-aws/pull/163
- https://github.com/alphagov/digitalmarketplace-aws/pull/162