### PR TITLE
Fix filters accessibility issue

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -39,10 +39,14 @@ em.search-result-highlighted-text {
   }
 
   .filter-field-text {
-    @include core-16;
-    @include box-sizing(border-box);
-    width: 100%;
     padding: 5px;
-    border: 1px solid $border-colour;
+
+    input {
+      @include core-16;
+      @include box-sizing(border-box);
+      width: 100%;
+      padding: 5px;
+      border: 1px solid $border-colour;
+    }
   }
 }

--- a/app/templates/_search_filters.html
+++ b/app/templates/_search_filters.html
@@ -21,13 +21,13 @@
   {% endfor %}
   </ul>
 </div>
-<div class="govuk-option-select">
+<div class="govuk-option-select filter-field-text">
   <div class="container-head">
     <label class="option-select-label" for="keywords">
       Keywords
     </label>
   </div>
-  <input class="filter-field-text" type="text" name="q" id="keywords" value="{{ search_keywords }}" maxlength="200">
+  <input type="text" name="q" id="keywords" value="{{ search_keywords }}" maxlength="200">
 </div>
 {% if current_lot %}
 <input type="hidden" name="lot" value="{{ current_lot }}" />

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.5.3",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v13.5.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.14.2"
   }


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/105291876

![image](https://cloud.githubusercontent.com/assets/87140/11901926/2fa2b090-a5a6-11e5-9fa4-0f027d1b80b7.png)

### TLDR

If an option-select (which we use as the UI for our filters, shown above) was in the collapsed state you would assume that the hidden options would be removed from the tabbing order of the document. The design instead worked by keeping the options in the tabbing order and opening the parent option-select if they were tabbed to.

This brings in changes from the latest option-select govuk component which fixes this.