### PR TITLE
Remove unused heading

### DIFF
--- a/app/templates/content/suppliers-guide-g-cloud.html
+++ b/app/templates/content/suppliers-guide-g-cloud.html
@@ -226,9 +226,6 @@
 
   <p>Follow the steps in ‘<a href="#how-to-apply">How to bid</a>’ to submit a new application. </p>
 
-  <h3 id="existing-suppliers">
-  <h3 Existing suppliers</h3>
-
   <p>You can make updates to the services you offer and make bids for supplying new services whenever a new version of the G-Cloud framework is released. You’ll get a 'contract notice' (formal notification telling all potential suppliers about a public sector contract opportunity) from the <abbr title="Office Journal of the European Union">OJEU</abbr> ahead of each new release of the framework.</p>
 
   <p>You’ll need to resubmit your tender before your framework agreement expires so you can continue to offer services. </p>


### PR DESCRIPTION
This heading should have been removed now G-Cloud 7 is closed (meaning there are only existing
suppliers).

The existing code was also breaking due to a malformed `<h3>` tag:

![image](https://cloud.githubusercontent.com/assets/87140/12170252/8c6c057e-b537-11e5-8494-35c9b556b5f9.png)

Note: requires review by @superroz 
