### PR TITLE
Make notification message less shouty for services whose frameworks have expired.

### DIFF
--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -33,8 +33,11 @@
       {%
         with
         type = "temporary-message",
-        heading = "This " + service.frameworkName + " service is no longer available to buy. The " + service.frameworkName + " framework expired on " + service_unavailability_information.date + ".",
-        message = "Any existing contracts with " + service.supplierName + " are still valid."
+        heading = "This {} service is no longer available to buy.".format(service.frameworkName),
+        message = " The {} framework expired on {}. Any existing contracts with {} are still valid.".format(
+            service.frameworkName,
+            service_unavailability_information.date,
+            service.supplierName)
       %}
         {% include "toolkit/notification-banner.html" %}
       {% endwith %}
@@ -42,7 +45,8 @@
       {%
         with
         type = "temporary-message",
-        heading = service.supplierName + " stopped offering this service on " + service_unavailability_information.date + ".",
+        heading = "{} stopped offering this service on {}.".format(
+          service.supplierName, service_unavailability_information.date),
         message = "Any existing contracts for this service are still valid."
       %}
         {% include "toolkit/notification-banner.html" %}

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.0.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.0.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.15.1"
   }

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -312,15 +312,17 @@ class TestServicePage(BaseApplicationTest):
         assert_true(unavailable_banner.exists)
         assert_equal(
             unavailable_banner.heading_text(),
-            'This {} service is no longer available to buy. The {} framework expired on {}.'.format(
-                self.service['services']['frameworkName'],
-                self.service['services']['frameworkName'],
-                'Tuesday 05 January 2016'
+            'This {} service is no longer available to buy.'.format(
+                self.service['services']['frameworkName']
             )
         )
         assert_equal(
             unavailable_banner.body_text(),
-            'Any existing contracts with {} are still valid.'.format(self.service['services']['supplierName'])
+            'The {} framework expired on {}. Any existing contracts with {} are still valid.'.format(
+                self.service['services']['frameworkName'],
+                'Tuesday 05 January 2016',
+                self.service['services']['supplierName']
+            )
         )
 
     def test_pre_live_framework_causes_404(self):


### PR DESCRIPTION
Basically what the title says.  The really long heading when a service's framework has expired [looks pretty aggressive](https://preview.development.digitalmarketplace.service.gov.uk/g-cloud/services/5-G5-0625-218), so this pull request demotes some of the copy from the notification heading to the notification body.

Already got a thumbs up from @ralph-hawkins in real life, so.

***

### ~~OLDEST~~ 💀💀💀
![screen shot 2016-01-25 at 16 43 59](https://cloud.githubusercontent.com/assets/2454380/12557565/588e518a-c383-11e5-9a10-c043218c14c9.png)

### ~~OLD~~ 💀
![screen shot 2016-01-25 at 16 44 17](https://cloud.githubusercontent.com/assets/2454380/12557571/5c306a6c-c383-11e5-9cf7-1ae985ece8d7.png)

### NEW 😆😃😀
![screen shot 2016-01-26 at 17 49 14](https://cloud.githubusercontent.com/assets/2454380/12589388/583a7e0c-c455-11e5-9b69-e9a22fee578d.png)
