### PR TITLE
Buyer can write a brief

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,12 +34,16 @@ def create_app(config_name):
 
     from .main import main as main_blueprint
     from .status import status as status_blueprint
+    from .buyers import buyers as buyers_blueprint
 
     application.register_blueprint(status_blueprint)
     application.register_blueprint(main_blueprint)
+    application.register_blueprint(buyers_blueprint)
+
     main_blueprint.config = {
         'BASE_TEMPLATE_DATA': application.config['BASE_TEMPLATE_DATA'],
     }
+    buyers_blueprint.config = main_blueprint.config
 
     login_manager.login_view = 'main.render_login'
     login_manager.login_message_category = "must_login"

--- a/app/assets/javascripts/_selection-buttons.js
+++ b/app/assets/javascripts/_selection-buttons.js
@@ -1,0 +1,16 @@
+(function(GOVUK, GDM) {
+
+  GDM.selectionButtons = function() {
+
+    if (!GOVUK.SelectionButtons) return;
+
+    new GOVUK.SelectionButtons('.selection-button input', {
+      'focusedClass' : 'selection-button-focused',
+      'selectedClass' : 'selection-button-selected'
+    });
+
+  };
+
+  GOVUK.GDM = GDM;
+
+}).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= include _analytics.js'
 //= include _onready.js'
+//= include _selection-buttons.js
 
 (function(GOVUK, GDM) {
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,68 @@
+/*
+  The following comments are parsed by Gulp include
+  (https://www.npmjs.com/package/gulp-include) which uses
+  Sprockets-style (https://github.com/sstephenson/sprockets)
+  directives to concatenate multiple Javascript files into one.
+*/
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/vendor/polyfills/bind.js
 //= include ../../../bower_components/jquery/dist/jquery.js
+//= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/option-select.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
+//= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= include _analytics.js'
 //= include _onready.js'
+
+(function(GOVUK, GDM) {
+
+  "use strict";
+
+  var module;
+
+  if(typeof console === 'undefined') {
+    console = {
+      log: function () {},
+      time: function () {},
+      timeEnd: function () {}
+    };
+  }
+
+  if (
+    (GDM.debug = !window.location.href.match(/gov.uk/) && !window.jasmine)
+  ) {
+    console.log(
+      "%cDebug mode %cON",
+      "color:#550; background:yellow; font-size: 11pt",
+      "color:yellow; background: #550;font-size:11pt"
+    );
+    console.time("Modules loaded");
+  }
+
+  // Initialise our modules
+  for (module in GDM) {
+
+    if (GDM.debug && module !== "debug") {
+      console.log(
+        "%cLoading module %c" + module,
+        "color:#6a6; background:#dfd; font-size: 11pt",
+        "color:#dfd; background:green; font-size: 11pt"
+      );
+    }
+
+    if ("function" === typeof GDM[module].init) {
+      // If a module has an init() method then we want that to be called here
+      GDM[module].init();
+    } else if ("function" === typeof GDM[module]) {
+      // If a module doesn't have an interface then call it directly
+      GDM[module]();
+    }
+
+  }
+
+  GOVUK.GDM = GDM;
+
+  if (GDM.debug) console.timeEnd("Modules loaded");
+
+}).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);

--- a/app/assets/scss/_brief_submission.scss
+++ b/app/assets/scss/_brief_submission.scss
@@ -1,0 +1,7 @@
+.last-edited {
+    margin: 10px 0 15px 0;
+}
+
+.ready-to-publish-hint {
+    color: $secondary-text-colour;
+}

--- a/app/assets/scss/_lists.scss
+++ b/app/assets/scss/_lists.scss
@@ -1,0 +1,73 @@
+// Lists
+// From: https://github.com/alphagov/govuk_elements/commit/7e60d575939e36b2788d9b8ba8876aae7509d559
+// ==========================================================================
+
+ul,
+ol {
+  list-style-type: none;
+  padding: 0;
+}
+
+// Bulleted lists
+.list-bullet {
+  list-style-type: disc;
+  padding-left: 20px;
+}
+
+// Numbered lists
+.list-number {
+  list-style-type: decimal;
+  padding-left: 20px;
+
+  @include ie-lte(7) {
+    padding-left: 28px;
+  }
+}
+
+.list-bullet,
+.list-number {
+  margin-top: 5px;
+}
+
+.list-number {
+  margin-bottom: 20px;
+}
+
+.list-bullet li,
+.list-number li {
+  margin-bottom: 5px;
+}
+
+// Styles specific to Digital Marketplace
+
+.check-list {
+  .lead {
+    margin-bottom: $gutter-half;
+  }
+
+  ul {
+    padding-bottom: 0;
+    margin-bottom: 20px;
+
+    @include media(tablet) {
+      padding-bottom: $gutter-half;
+    }
+
+    li {
+      margin-bottom: $gutter-half;
+
+      p {
+        margin: 0;
+      }
+
+      a {
+        word-wrap: break-word;
+      }
+    }
+  }
+}
+
+.unbulleted-item {
+  list-style-type: none;
+  margin-bottom: 10px;
+}

--- a/app/assets/scss/_reset.scss
+++ b/app/assets/scss/_reset.scss
@@ -1,0 +1,113 @@
+@import "typography";
+
+html,
+body,
+div,
+span,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+}
+
+main {
+  display: block;
+}
+
+ol,
+ul {
+  list-style: none;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+body {
+  @include core-19;
+}
+
+@include media(tablet) {
+
+  legend {
+    width: 100%;
+  }
+
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -67,7 +67,7 @@ $path: "/static/images/";
   background-color: $govuk-blue;
   width: 100%;
   margin: -10px 0 40px;
-  padding: 20px 0 10px;
+  padding: 0 0 20px;
   color: white;
 
   h1 {
@@ -76,4 +76,28 @@ $path: "/static/images/";
     padding-top: 7px;
     padding-bottom: 13px;
   }
+  
+  .phase-banner {
+    border-bottom: 0px;
+  }
+  
+  .phase-banner p {
+    margin: -6px 0 10px;
+    color: white;
+
+    a, a:visited {
+        color: $white;
+      }
+
+    a:hover, a:active {
+      color: $light-blue-50;
+    }
+  }
+}
+
+.marketplace-homepage-subheading {
+
+  @include bold-27;
+  padding-bottom: 30px;
+
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -108,6 +108,17 @@ $path: "/static/images/";
 
 }
 
+.marketplace-paragraph {
+
+  h2 {
+    @include bold-27;
+    padding-bottom: 10px;
+  }
+  p {
+    padding-bottom: 30px;
+  }
+}
+
 .padding-bottom-small {
   padding-bottom: 10px;
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -55,6 +55,7 @@ $path: "/static/images/";
 @import "_supplier-a-to-z.scss";
 @import "_atoz_navigation.scss";
 @import "_error-pages.scss";
+@import "_lists.scss";
 
 .return-to-top {
   display: block;
@@ -100,4 +101,8 @@ $path: "/static/images/";
   @include bold-27;
   padding-bottom: 30px;
 
+}
+
+.padding-bottom-small {
+  padding-bottom: 10px;
 }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -46,6 +46,7 @@ $path: "/static/images/";
 @import "toolkit/forms/_questions.scss";
 
 // Buyers app styles
+@import "_brief_submission.scss";
 @import "_footer.scss";
 @import "_forms.scss";
 @import "_table.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -7,23 +7,28 @@
 // Path to assets for use with file-url()
 $path: "/static/images/";
 
+@import "_reset.scss";
+
 // Digtial Marketplace Front-end toolkit styles
+@import "toolkit/_breadcrumb.scss";
+@import "toolkit/_browse-list.scss";
+@import "toolkit/_buttons.scss";
+@import "toolkit/_contact-details.scss";
+@import "toolkit/_document.scss";
+@import "toolkit/_framework-notice.scss";
 @import "toolkit/_grids.scss";
 @import "toolkit/_notification-banners.scss";
-@import "toolkit/_buttons.scss";
-@import "toolkit/_breadcrumb.scss";
 @import "toolkit/_page-headings.scss";
-@import "toolkit/_browse-list.scss";
-@import "toolkit/_document.scss";
-@import "toolkit/_contact-details.scss";
 @import "toolkit/_service-id.scss";
 @import "toolkit/_temporary-message.scss";
-@import "toolkit/_framework-notice.scss";
-@import "toolkit/search/_search-result.scss";
+@import "toolkit/forms/_hint.scss";
 @import "toolkit/forms/_option-select.scss";
+@import "toolkit/forms/_questions.scss";
+@import "toolkit/forms/_selection-buttons.scss";
 @import "toolkit/forms/_summary.scss";
 @import "toolkit/forms/_textboxes.scss";
 @import "toolkit/forms/_validation.scss";
+@import "toolkit/search/_search-result.scss";
 
 /* Blocks shared between multiple selectors */
 @import "shared_placeholders/_temporary-messages.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -7,6 +7,10 @@
 // Path to assets for use with file-url()
 $path: "/static/images/";
 
+// Digital Marketplace front end toolkit components
+@import "forms/word-counter";
+@import "forms/list-entry";
+
 @import "_reset.scss";
 
 // Digtial Marketplace Front-end toolkit styles

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -56,3 +56,19 @@ $path: "/static/images/";
   @include core-19;
   margin: (1.5 * $gutter) 0 (2 * $gutter);
 }
+
+.marketplace-homepage-heading {
+
+  background-color: $govuk-blue;
+  width: 100%;
+  margin: -10px 0 40px;
+  padding: 20px 0 10px;
+  color: white;
+
+  h1 {
+    @extend %site-width-container;
+    @include bold-48;
+    padding-top: 7px;
+    padding-bottom: 13px;
+  }
+}

--- a/app/buyers/__init__.py
+++ b/app/buyers/__init__.py
@@ -1,0 +1,21 @@
+from flask import Blueprint, current_app, flash
+from flask_login import current_user, login_required
+
+buyers = Blueprint('buyers', __name__)
+
+
+@buyers.before_request
+@login_required
+def require_login():
+    if current_user.is_authenticated() and current_user.role != 'buyer':
+        flash('buyer-role-required', 'error')
+        return current_app.login_manager.unauthorized()
+
+
+@buyers.after_request
+def add_cache_control(response):
+    response.cache_control.no_cache = True
+    return response
+
+from ..main import errors
+from .views import buyers as buyers_views

--- a/app/buyers/__init__.py
+++ b/app/buyers/__init__.py
@@ -1,7 +1,11 @@
 from flask import Blueprint, current_app, flash
 from flask_login import current_user, login_required
+from dmutils.content_loader import ContentLoader
 
 buyers = Blueprint('buyers', __name__)
+
+content_loader = ContentLoader('app/content')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
 
 
 @buyers.before_request

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -233,9 +233,6 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
     unanswered_required, unanswered_optional = count_unanswered_questions(sections)
     delete_requested = True if request.args.get('delete_requested') else False
 
-    # TODO: check validation errors(?)
-    validation_errors = None
-
     flattened_brief = []
     for section in sections:
         for question in section.questions:
@@ -252,7 +249,7 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
         flattened_brief=flattened_brief,
         unanswered_required=unanswered_required,
         unanswered_optional=unanswered_optional,
-        can_publish=not validation_errors and not unanswered_required,
+        can_publish=not unanswered_required,
         delete_requested=delete_requested,
         **dict(buyers.config['BASE_TEMPLATE_DATA'])
     ), 200
@@ -272,6 +269,7 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
         abort(404)
 
     if request.form.get('delete_confirmed'):
+        raise NotImplementedError
         # TODO: Delete the brief (once a DELETE endpoint exists in the API)
         flash({"requirements_deleted": brief.get("title")})
         return redirect(url_for('.buyer_dashboard'))

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -28,12 +28,8 @@ def buyer_dashboard():
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>', methods=['GET'])
 def info_page_for_starting_a_brief(framework_slug, lot_slug):
 
-    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client)
-
-    if framework['status'] != 'live':
-        abort(404)
-    if not lot['allowsBrief']:
-        abort(404)
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
+                                           status='live', must_allow_brief=True)
 
     return render_template(
         "buyers/start_brief_info.html",
@@ -46,18 +42,9 @@ def info_page_for_starting_a_brief(framework_slug, lot_slug):
 
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/create', methods=['GET'])
 def start_new_brief(framework_slug, lot_slug):
-    """Page to kick off creation of a new brief."""
 
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
-    if framework['status'] != 'live':
-        abort(404)
-
-    try:
-        lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
-    except StopIteration:
-        abort(404)
-    if not lot['allowsBrief']:
-        abort(404)
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
+                                           status='live', must_allow_brief=True)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
         {'lot': lot['slug']}
@@ -76,16 +63,9 @@ def start_new_brief(framework_slug, lot_slug):
 
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/create', methods=['POST'])
 def create_new_brief(framework_slug, lot_slug):
-    framework = data_api_client.get_framework(framework_slug)["frameworks"]
-    if framework["status"] != "live":
-        abort(404)
 
-    try:
-        lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
-    except StopIteration:
-        abort(404)
-    if not lot['allowsBrief']:
-        abort(404)
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
+                                           status='live', must_allow_brief=True)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
         {'lot': lot['slug']}
@@ -129,16 +109,9 @@ def create_new_brief(framework_slug, lot_slug):
     '/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_id>',
     methods=['GET'])
 def edit_brief_submission(framework_slug, lot_slug, brief_id, section_id):
-    framework = data_api_client.get_framework(framework_slug)["frameworks"]
-    if framework["status"] != "live":
-        abort(404)
 
-    try:
-        lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
-    except StopIteration:
-        abort(404)
-    if not lot['allowsBrief']:
-        abort(404)
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
+                                           status='live', must_allow_brief=True)
 
     brief = data_api_client.get_brief(brief_id)["briefs"]
     if not is_brief_associated_with_user(brief, current_user.id) or not brief_can_be_edited(brief):
@@ -164,16 +137,9 @@ def edit_brief_submission(framework_slug, lot_slug, brief_id, section_id):
     '/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_id>',
     methods=['POST'])
 def update_brief_submission(framework_slug, lot_slug, brief_id, section_id):
-    framework = data_api_client.get_framework(framework_slug)["frameworks"]
-    if framework["status"] != "live":
-        abort(404)
 
-    try:
-        lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
-    except StopIteration:
-        abort(404)
-    if not lot['allowsBrief']:
-        abort(404)
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
+                                           status='live', must_allow_brief=True)
 
     brief = data_api_client.get_brief(brief_id)["briefs"]
     if not is_brief_associated_with_user(brief, current_user.id) or not brief_can_be_edited(brief):
@@ -215,12 +181,9 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id):
 
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>', methods=['GET'])
 def view_brief_summary(framework_slug, lot_slug, brief_id):
-    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client)
 
-    if framework['status'] != 'live':
-        abort(404)
-    if not lot['allowsBrief']:
-        abort(404)
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
+                                           status='live', must_allow_brief=True)
 
     brief = data_api_client.get_brief(brief_id)["briefs"]
     if not is_brief_associated_with_user(brief, current_user.id):
@@ -257,12 +220,9 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
 
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/delete', methods=['POST'])
 def delete_a_brief(framework_slug, lot_slug, brief_id):
-    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client)
 
-    if framework['status'] != 'live':
-        abort(404)
-    if not lot['allowsBrief']:
-        abort(404)
+    # Don't need the return values here; the call is just to test conditions on lot and framework
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
 
     brief = data_api_client.get_brief(brief_id)["briefs"]
     if not is_brief_associated_with_user(brief, current_user.id):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -149,7 +149,7 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id):
         {'lot': lot['slug']}
     )
     section = content.get_section(section_id)
-    if not section:
+    if section is None or not section.editable:
         abort(404)
 
     update_data = section.get_data(request.form)

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -3,6 +3,7 @@ from flask_login import current_user
 
 from app import data_api_client
 from .. import buyers, content_loader
+from ...helpers.buyers_helpers import count_suppliers_on_lot, get_framework_and_lot
 from ...helpers.search_helpers import get_template_data
 
 from dmapiclient import HTTPError
@@ -21,6 +22,25 @@ def buyer_dashboard():
         live_briefs=live_briefs,
         **template_data
     )
+
+
+@buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>', methods=['GET'])
+def info_page_for_starting_a_brief(framework_slug, lot_slug):
+
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug)
+
+    if framework['status'] != 'live':
+        abort(404)
+    if not lot['allowsBrief']:
+        abort(404)
+
+    return render_template(
+        "buyers/start_brief_info.html",
+        framework=framework,
+        lot=lot,
+        supplier_count=count_suppliers_on_lot(framework, lot),
+        **dict(buyers.config['BASE_TEMPLATE_DATA'])
+    ), 200
 
 
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/create', methods=['GET'])

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -121,7 +121,7 @@ def edit_brief_submission(framework_slug, lot_slug, brief_id, section_id):
         {'lot': lot['slug']}
     )
     section = content.get_section(section_id)
-    if not section:
+    if section is None or not section.editable:
         abort(404)
 
     return render_template(
@@ -200,6 +200,15 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
     for section in sections:
         for question in section.questions:
             question.section_id = section.id
+
+            # Look up display values for options that have different labels from values
+            options = question.get('options')
+            if options and question.value:
+                for option in options:
+                    if 'label' in option and 'value' in option and option['value'] == question.value:
+                        question.display_value = option['label']
+                        break
+
             flattened_brief.append(question)
 
     return render_template(

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -27,7 +27,7 @@ def buyer_dashboard():
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>', methods=['GET'])
 def info_page_for_starting_a_brief(framework_slug, lot_slug):
 
-    framework, lot = get_framework_and_lot(framework_slug, lot_slug)
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client)
 
     if framework['status'] != 'live':
         abort(404)

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -1,13 +1,21 @@
-from ...buyers import buyers
 from flask import render_template
+from flask_login import current_user
 
+from app import data_api_client
+from .. import buyers
 from ...helpers.search_helpers import get_template_data
 
 
 @buyers.route('/buyers')
 def buyer_dashboard():
     template_data = get_template_data(buyers, {})
+    user_briefs = data_api_client.find_briefs(current_user.id).get('briefs', [])
+    draft_briefs = [brief for brief in user_briefs if brief['status'] == 'draft']
+    live_briefs = [brief for brief in user_briefs if brief['status'] == 'live']
+
     return render_template(
         'buyers/dashboard.html',
+        draft_briefs=draft_briefs,
+        live_briefs=live_briefs,
         **template_data
     )

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -141,7 +141,7 @@ def edit_brief_submission(framework_slug, lot_slug, brief_id, section_id):
         abort(404)
 
     brief = data_api_client.get_brief(brief_id)["briefs"]
-    if not is_brief_associated_with_user(brief) or not brief_can_be_edited(brief):
+    if not is_brief_associated_with_user(brief, current_user.id) or not brief_can_be_edited(brief):
         abort(404)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
@@ -176,7 +176,7 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id):
         abort(404)
 
     brief = data_api_client.get_brief(brief_id)["briefs"]
-    if not is_brief_associated_with_user(brief) or not brief_can_be_edited(brief):
+    if not is_brief_associated_with_user(brief, current_user.id) or not brief_can_be_edited(brief):
         abort(404)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
@@ -223,7 +223,7 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
         abort(404)
 
     brief = data_api_client.get_brief(brief_id)["briefs"]
-    if not is_brief_associated_with_user(brief):
+    if not is_brief_associated_with_user(brief, current_user.id):
         abort(404)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
@@ -268,7 +268,7 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
         abort(404)
 
     brief = data_api_client.get_brief(brief_id)["briefs"]
-    if not is_brief_associated_with_user(brief):
+    if not is_brief_associated_with_user(brief, current_user.id):
         abort(404)
 
     if request.form.get('delete_confirmed'):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -101,7 +101,7 @@ def create_new_brief(framework_slug, lot_slug):
             current_user.id,
             update_data,
             updated_by=current_user.email_address,
-            page_questions=update_data.keys()
+            page_questions=section.get_field_names()
         )["briefs"]
     except HTTPError as e:
         update_data = section.unformat_data(update_data)
@@ -146,7 +146,6 @@ def edit_brief_submission(framework_slug, lot_slug, brief_id, section_id):
     brief = data_api_client.get_brief(brief_id)["briefs"]
     # TODO: cannot edit published brief
     # TODO: update dmutils
-    # TODO: fix javascript for lists
     section = content.get_section(section_id)
 
     return render_template(
@@ -188,7 +187,7 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id):
             brief_id,
             update_data,
             updated_by=current_user.email_address,
-            page_questions=update_data.keys()
+            page_questions=section.get_field_names()
         )["briefs"]
     except HTTPError as e:
         update_data = section.unformat_data(update_data)

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -114,7 +114,7 @@ def create_new_brief(framework_slug, lot_slug):
             section=section,
             errors=errors,
             **dict(buyers.config['BASE_TEMPLATE_DATA'])
-        ), 200
+        ), 400
 
     return redirect(
         url_for(".edit_brief_submission",

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -1,9 +1,11 @@
-from flask import abort, render_template
+from flask import abort, render_template, request
 from flask_login import current_user
 
 from app import data_api_client
 from .. import buyers, content_loader
 from ...helpers.search_helpers import get_template_data
+
+from dmapiclient import HTTPError
 
 
 @buyers.route('/buyers')
@@ -49,3 +51,38 @@ def start_new_brief(framework_slug, lot_slug):
         section=section,
         **dict(buyers.config['BASE_TEMPLATE_DATA'])
     ), 200
+
+
+@buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/create', methods=['POST'])
+def create_new_brief(framework_slug, lot_slug):
+    framework = data_api_client.get_framework(framework_slug)["frameworks"]
+    if framework["status"] != "live":
+        abort(404)
+
+    try:
+        lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
+    except StopIteration:
+        abort(404)
+    if not lot['allowsBrief']:
+        abort(404)
+
+    content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
+        {'lot': lot['slug']}
+    )
+
+    section = content.get_section(content.get_next_editable_section_id())
+
+    update_data = section.get_data(request.form)
+
+    try:
+        brief = data_api_client.create_brief(
+            framework_slug,
+            lot_slug,
+            current_user.id,
+            update_data,
+            updated_by=current_user.email_address,
+            page_questions=update_data.keys()
+        )["briefs"]
+    except HTTPError as e:
+        print("API ERROR ERROR ERROR: {}".format(e))
+        raise e

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -243,6 +243,12 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
     # TODO: check validation errors
     validation_errors = None
 
+    flattened_brief = []
+    for section in sections:
+        for question in section.questions:
+            question.section_id=section.id
+            flattened_brief.append(question)
+
     return render_template(
         "buyers/brief_summary.html",
         framework=framework,
@@ -250,10 +256,10 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
         brief_id=brief_id,
         brief_data=brief,
         last_edit=brief['updatedAt'],
-        sections=sections,
+        flattened_brief=flattened_brief,
         unanswered_required=unanswered_required,
         unanswered_optional=unanswered_optional,
-        can_publish=not validation_errors,
+        can_publish=not validation_errors and not unanswered_required,
         delete_requested=delete_requested,
         **dict(buyers.config['BASE_TEMPLATE_DATA'])
     ), 200

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -269,8 +269,7 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
         abort(404)
 
     if request.form.get('delete_confirmed'):
-        raise NotImplementedError
-        # TODO: Delete the brief (once a DELETE endpoint exists in the API)
+        data_api_client.delete_brief(brief_id, current_user.email_address)
         flash({"requirements_deleted": brief.get("title")})
         return redirect(url_for('.buyer_dashboard'))
     else:

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -4,7 +4,7 @@ from flask_login import current_user
 from app import data_api_client
 from .. import buyers, content_loader
 from ...helpers.buyers_helpers import count_suppliers_on_lot, get_framework_and_lot, is_brief_associated_with_user, \
-    count_unanswered_questions, brief_can_be_edited
+    count_unanswered_questions, brief_can_be_edited, add_unanswered_counts_to_briefs
 from ...helpers.search_helpers import get_template_data
 
 from dmapiclient import HTTPError
@@ -14,7 +14,7 @@ from dmapiclient import HTTPError
 def buyer_dashboard():
     template_data = get_template_data(buyers, {})
     user_briefs = data_api_client.find_briefs(current_user.id).get('briefs', [])
-    draft_briefs = [brief for brief in user_briefs if brief['status'] == 'draft']
+    draft_briefs = add_unanswered_counts_to_briefs([brief for brief in user_briefs if brief['status'] == 'draft'])
     live_briefs = [brief for brief in user_briefs if brief['status'] == 'live']
 
     return render_template(

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -1,0 +1,13 @@
+from ...buyers import buyers
+from flask import render_template
+
+from ...helpers.search_helpers import get_template_data
+
+
+@buyers.route('/buyers')
+def buyer_dashboard():
+    template_data = get_template_data(buyers, {})
+    return render_template(
+        'buyers/dashboard.html',
+        **template_data
+    )

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -189,12 +189,12 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id):
     update_data = section.get_data(request.form)
 
     try:
-        brief = data_api_client.update_brief(
+        data_api_client.update_brief(
             brief_id,
             update_data,
             updated_by=current_user.email_address,
             page_questions=section.get_field_names()
-        )["briefs"]
+        )
     except HTTPError as e:
         update_data = section.unformat_data(update_data)
         errors = section.get_error_messages(e.message, lot_slug)
@@ -208,16 +208,9 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id):
             **dict(buyers.config['BASE_TEMPLATE_DATA'])
         ), 200
 
-    next_section = content.get_next_editable_section_id(section.slug)
-    if next_section:
-        return redirect(
-            url_for(".edit_brief_submission",
-                    framework_slug=framework_slug,
-                    lot_slug=lot_slug,
-                    brief_id=brief['id'],
-                    section_id=next_section))
-    else:
-        return redirect(url_for(".buyer_dashboard"))
+    return redirect(
+        url_for(".view_brief_summary", framework_slug=framework_slug, lot_slug=lot_slug, brief_id=brief_id)
+    )
 
 
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>', methods=['GET'])
@@ -240,13 +233,13 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
     unanswered_required, unanswered_optional = count_unanswered_questions(sections)
     delete_requested = True if request.args.get('delete_requested') else False
 
-    # TODO: check validation errors
+    # TODO: check validation errors(?)
     validation_errors = None
 
     flattened_brief = []
     for section in sections:
         for question in section.questions:
-            question.section_id=section.id
+            question.section_id = section.id
             flattened_brief.append(question)
 
     return render_template(

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -26,9 +26,14 @@ def start_new_brief(framework_slug, lot_slug):
     """Page to kick off creation of a new brief."""
 
     framework = data_api_client.get_framework(framework_slug)['frameworks']
+    if framework['status'] != 'live':
+        abort(404)
+
     try:
         lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
     except StopIteration:
+        abort(404)
+    if not lot['allowsBrief']:
         abort(404)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -1,6 +1,8 @@
 from flask import abort
 from flask_login import current_user
 
+from ..buyers import content_loader
+
 
 def get_framework_and_lot(framework_slug, lot_slug, data_api_client):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
@@ -38,3 +40,16 @@ def count_unanswered_questions(brief_attributes):
                 unanswered_optional += 1
 
     return unanswered_required, unanswered_optional
+
+
+def add_unanswered_counts_to_briefs(briefs):
+    for brief in briefs:
+        content = content_loader.get_manifest(brief.get('frameworkSlug'), 'edit_brief').filter(
+            {'lot': brief.get('lotSlug')}
+        )
+        sections = content.summary(brief)
+        unanswered_required, unanswered_optional = count_unanswered_questions(sections)
+        brief['unanswered_required'] = unanswered_required
+        brief['unanswered_optional'] = unanswered_optional
+
+    return briefs

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -16,3 +16,22 @@ def count_suppliers_on_lot(framework, lot):
     # TODO: Implement this properly!
 
     return 987
+
+
+def is_brief_associated_with_user(brief):
+
+    # TODO: Implement this function!
+
+    return True
+
+
+def count_unanswered_questions(brief_attributes):
+    unanswered_required, unanswered_optional = (0, 0)
+    for section in brief_attributes:
+        for question in section.questions:
+            if question.answer_required:
+                unanswered_required += 1
+            elif question.value in ['', [], None]:
+                unanswered_optional += 1
+
+    return unanswered_required, unanswered_optional

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -1,5 +1,4 @@
 from flask import abort
-from flask_login import current_user
 
 from ..buyers import content_loader
 
@@ -21,9 +20,9 @@ def count_suppliers_on_lot(framework, lot):
     return 987
 
 
-def is_brief_associated_with_user(brief):
-    user_ids = [user.get('id') for user in brief.get('users')]
-    return current_user.id in user_ids
+def is_brief_associated_with_user(brief, current_user_id):
+    user_ids = [user.get('id') for user in brief.get('users', [])]
+    return current_user_id in user_ids
 
 
 def brief_can_be_edited(brief):

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -1,0 +1,20 @@
+from flask import abort
+
+from app import data_api_client
+
+
+def get_framework_and_lot(framework_slug, lot_slug):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    try:
+        lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
+    except StopIteration:
+        abort(404)
+
+    return framework, lot
+
+
+def count_suppliers_on_lot(framework, lot):
+
+    # TODO: Implement this properly!
+
+    return 987

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -3,11 +3,16 @@ from flask import abort
 from ..buyers import content_loader
 
 
-def get_framework_and_lot(framework_slug, lot_slug, data_api_client):
+def get_framework_and_lot(framework_slug, lot_slug, data_api_client, status=None, must_allow_brief=False):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     try:
         lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
     except StopIteration:
+        abort(404)
+
+    if status and framework['status'] != status:
+        abort(404)
+    if must_allow_brief and not lot['allowsBrief']:
         abort(404)
 
     return framework, lot

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -1,9 +1,7 @@
 from flask import abort
 
-from app import data_api_client
 
-
-def get_framework_and_lot(framework_slug, lot_slug):
+def get_framework_and_lot(framework_slug, lot_slug, data_api_client):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     try:
         lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -1,4 +1,5 @@
 from flask import abort
+from flask_login import current_user
 
 
 def get_framework_and_lot(framework_slug, lot_slug, data_api_client):
@@ -19,10 +20,12 @@ def count_suppliers_on_lot(framework, lot):
 
 
 def is_brief_associated_with_user(brief):
+    user_ids = [user.get('id') for user in brief.get('users')]
+    return current_user.id in user_ids
 
-    # TODO: Implement this function!
 
-    return True
+def brief_can_be_edited(brief):
+    return brief.get('status') == 'draft'
 
 
 def count_unanswered_questions(brief_attributes):

--- a/app/helpers/login_helpers.py
+++ b/app/helpers/login_helpers.py
@@ -17,7 +17,6 @@ def redirect_logged_in_user(next_url=None):
         if next_url and next_url.startswith('/'):
             return redirect(next_url)
         else:
-            # TODO: direct to buyer dashboard, once it exists
-            pass
+            return redirect(url_for('buyers.buyer_dashboard'))
 
     return redirect(url_for('.index'))

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -33,9 +33,9 @@ def index():
                 framework.get('status')
             )
 
-    # if no framework is found (should never happen), ditch the message and load the page
+    # if there is a problem with the API we should still show the home page
     except APIError:
-        pass
+        frameworks = []
     # if no message file is found (should never happen), throw a 500
     except ContentNotFoundError:
         current_app.logger.error(
@@ -45,6 +45,7 @@ def index():
 
     return render_template(
         'index.html',
+        frameworks={framework['slug']: framework for framework in frameworks},
         temporary_message=temporary_message,
         **template_data
     )

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -15,7 +15,9 @@
 {% endblock %}
 
 {% block content %}
-  {% include "_phase_banner.html" %}
+    {% block top_header %}
+    {% endblock %}
+  {# {% include "_phase_banner.html" %} #}
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -17,7 +17,9 @@
 {% block content %}
     {% block top_header %}
     {% endblock %}
-  {# {% include "_phase_banner.html" %} #}
+{% block phase_banner %}
+  {% include "_phase_banner.html" %}
+{% endblock %}
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -32,6 +32,11 @@
                 You are logged in as a buyer but the page you tried to access is for suppliers.<br />
                 Please log in with a supplier account to access that page.
               </p>
+            {% elif message == 'buyer-role-required' %}
+              <p class="banner-message">
+                  You are logged in as a supplier but the page you tried to access is for buyers.<br />
+                  Please log in with a buyer account to access that page.
+              </p>
             {% elif category != 'must_login' %}
               {{ message }}
             {% endif %}

--- a/app/templates/buyers/_base_brief_page.html
+++ b/app/templates/buyers/_base_brief_page.html
@@ -4,25 +4,6 @@
 
 {% block main_content %}
   <div class="grid-row">
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}
-        {% for category, message in messages %}
-          {% if category == 'error' %}
-            <div class="banner-destructive-without-action">
-          {% else %}
-            <div class="banner-success-without-action">
-          {% endif %}
-              <p class="banner-message">
-              {% if 'requirements_deleted' in message %}
-                Your requirements were deleted
-              {% else %}
-                {{ message }}
-              {% endif %}
-              </p>
-            </div>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
 
     {% block before_heading %}{% endblock %}
     <div class="column-two-thirds">

--- a/app/templates/buyers/_base_brief_page.html
+++ b/app/templates/buyers/_base_brief_page.html
@@ -32,60 +32,57 @@
       %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
+
+      <div class="marketplace-paragraph">
+        <h2>Overview of work</h2>
+        <p class="padding-bottom-large">Create an overview of the work to help suppliers decide whether to apply.</p>
+      </div>
     </div>
+              
     {% block before_sections %}{% endblock %}
+              
     <div class="column-one-whole">
+      
       {% import "toolkit/summary-table.html" as summary %}
-      {% for section in sections %}
-        {{ summary.heading(section.name, id=section.slug) }}
-        {% if section.editable %}
-          {% block edit_link scoped %}{% endblock %}
-        {% endif %}
-        {% if section.summary_page_description %}
-          {{ summary.description(section.summary_page_description) }}
-        {% endif %}
-        {% call(question) summary.list_table(
-          section.questions,
-          caption=section.name,
-          field_headings=[
-            "Requirements attribute name",
-            "Requirements attribute",
-            "Add or Edit"
-          ] if section.edit_questions else [
-            "Requirements attribute name",
-            "Requirements attribute",
-          ],
-          field_headings_visible=False
-        ) %}
-          {% call summary.row(complete=not question.answer_required) %}
-            {{ summary.field_name(question.label) }}
-            {% if question.answer_required %}
-              {% call summary.field() %}
-                {% if framework and framework.status == 'open' %}
-                    <a href="{{ url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, service_id=service_id, section_id=section.id, _anchor=question.id) }}">Answer required</a>
-                {% else %}
-                  Not answered
-                {% endif %}
+
+      {% call(question) summary.list_table(
+        flattened_brief,
+        field_headings=[
+          "Requirements attribute name",
+          "Requirements attribute",
+          "Action"
+        ],
+        field_headings_visible=False
+      ) %}
+      
+        {% call summary.row() %}
+          {{ summary.field_name(question.label) }}
+        
+          {% if question.answer_required or question.is_empty %}
+            {% call summary.field() %}
+              <a href="{{ url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_id, section_id=question.section_id, _anchor=question.id) }}">{{ question.empty_message or "Not answered" }}</a>
+            {% endcall %}
+          {% else %}
+            {{ summary[question.type](question.value) }}
+          {% endif %}
+    
+          {% if brief_data.get('status') == 'draft' %}
+            {% if question.is_empty and not question.answer_required %}
+              {% call summary.field(action=True) %}
+                Optional
               {% endcall %}
-            {% elif question.is_empty %}
-              {% call summary.field() %}
-                <span class="summary-item-field-answer-required">{{ question.empty_message }}</span>
-              {% endcall %}
+            {% elif not question.answer_required %}
+              {{ summary.edit_link("Edit", url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_id, section_id=question.section_id, _anchor=question.id)) }}
             {% else %}
-              {{ summary[question.type](question.value, question.assurance) }}
+              {% call summary.field() %}{% endcall %}
             {% endif %}
-            {% if section.edit_questions and framework.status == 'open' %}
-              {% if not question.is_empty %}
-                {{ summary.remove_link('Remove', '#') }}
-              {% else %}
-                {{ summary.text("") }}
-              {% endif %}
-              {{ summary.edit_link('Add' if question.is_empty else 'Edit', url_for(".edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
-            {% endif %}
-          {% endcall %}
+          {% endif %}
+        
         {% endcall %}
-      {% endfor %}
-    </div>
+      {% endcall %}
+
       {% block after_sections %}{% endblock %}
+    </div>
+      
   </div>
 {% endblock %}

--- a/app/templates/buyers/_base_brief_page.html
+++ b/app/templates/buyers/_base_brief_page.html
@@ -1,0 +1,91 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}{{ brief_data.title or brief_data.lotName }} – Digital Marketplace{% endblock %}
+
+{% block main_content %}
+  <div class="grid-row">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          {% if category == 'error' %}
+            <div class="banner-destructive-without-action">
+          {% else %}
+            <div class="banner-success-without-action">
+          {% endif %}
+              <p class="banner-message">
+              {% if 'requirements_deleted' in message %}
+                Your requirements were deleted
+              {% else %}
+                {{ message }}
+              {% endif %}
+              </p>
+            </div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    {% block before_heading %}{% endblock %}
+    <div class="column-two-thirds">
+      {% with
+        heading = brief_data.get('title', brief_data['lotName']),
+        smaller = true
+      %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+    </div>
+    {% block before_sections %}{% endblock %}
+    <div class="column-one-whole">
+      {% import "toolkit/summary-table.html" as summary %}
+      {% for section in sections %}
+        {{ summary.heading(section.name, id=section.slug) }}
+        {% if section.editable %}
+          {% block edit_link scoped %}{% endblock %}
+        {% endif %}
+        {% if section.summary_page_description %}
+          {{ summary.description(section.summary_page_description) }}
+        {% endif %}
+        {% call(question) summary.list_table(
+          section.questions,
+          caption=section.name,
+          field_headings=[
+            "Requirements attribute name",
+            "Requirements attribute",
+            "Add or Edit"
+          ] if section.edit_questions else [
+            "Requirements attribute name",
+            "Requirements attribute",
+          ],
+          field_headings_visible=False
+        ) %}
+          {% call summary.row(complete=not question.answer_required) %}
+            {{ summary.field_name(question.label) }}
+            {% if question.answer_required %}
+              {% call summary.field() %}
+                {% if framework and framework.status == 'open' %}
+                    <a href="{{ url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, service_id=service_id, section_id=section.id, _anchor=question.id) }}">Answer required</a>
+                {% else %}
+                  Not answered
+                {% endif %}
+              {% endcall %}
+            {% elif question.is_empty %}
+              {% call summary.field() %}
+                <span class="summary-item-field-answer-required">{{ question.empty_message }}</span>
+              {% endcall %}
+            {% else %}
+              {{ summary[question.type](question.value, question.assurance) }}
+            {% endif %}
+            {% if section.edit_questions and framework.status == 'open' %}
+              {% if not question.is_empty %}
+                {{ summary.remove_link('Remove', '#') }}
+              {% else %}
+                {{ summary.text("") }}
+              {% endif %}
+              {{ summary.edit_link('Add' if question.is_empty else 'Edit', url_for(".edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, service_id=service_id, section_id=section.id, question_slug=question.slug)) }}
+            {% endif %}
+          {% endcall %}
+        {% endcall %}
+      {% endfor %}
+    </div>
+      {% block after_sections %}{% endblock %}
+  </div>
+{% endblock %}

--- a/app/templates/buyers/_base_brief_summary_page.html
+++ b/app/templates/buyers/_base_brief_summary_page.html
@@ -40,9 +40,13 @@
           {{ summary.field_name(question.label) }}
         
           {% if question.answer_required or question.is_empty %}
-            {% call summary.field() %}
-              <a href="{{ url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_id, section_id=question.section_id, _anchor=question.id) }}">{{ question.empty_message or "Not answered" }}</a>
-            {% endcall %}
+            {% if brief_data.get('status') == 'draft' %}
+              {% call summary.field() %}
+                <a href="{{ url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_id, section_id=question.section_id, _anchor=question.id) }}">{{ question.empty_message or "Not answered" }}</a>
+              {% endcall %}
+            {% else %}
+              {{ summary.text("Not answered") }}
+            {% endif %}
           {% else %}
             {{ summary[question.type](question.value) }}
           {% endif %}

--- a/app/templates/buyers/_base_brief_summary_page.html
+++ b/app/templates/buyers/_base_brief_summary_page.html
@@ -48,7 +48,7 @@
               {{ summary.text("Not answered") }}
             {% endif %}
           {% else %}
-            {{ summary[question.type](question.value) }}
+            {{ summary[question.type](question.display_value or question.value) }}
           {% endif %}
     
           {% if brief_data.get('status') == 'draft' %}

--- a/app/templates/buyers/_base_edit_section_page.html
+++ b/app/templates/buyers/_base_edit_section_page.html
@@ -1,0 +1,53 @@
+{% extends "_base_page.html" %}
+{% import "macros/toolkit_forms.html" as forms %}
+
+{% block page_title %}{{ section.name }} – Digital Marketplace{% endblock %}
+
+{% block main_content %}
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      {% with
+        heading = section.name,
+        smaller = true
+      %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
+
+      {% if section.description %}
+        <div class="section-description">
+          {{ section.description|markdown }}
+        </div>
+      {% endif %}
+
+    </div>
+  </div>
+
+  {% if errors %}
+    {% with errors = errors.values() %}
+      {% include 'toolkit/forms/validation.html' %}
+    {% endwith %}
+  {% endif %}
+
+  <form method="post" enctype="multipart/form-data" action="{{ request.path }}">
+
+    <div class="grid-row">
+      <div class="column-two-thirds">
+
+          {% for question in section.questions %}
+            {% if errors and errors[question.id] %}
+              {{ forms[question.type](question, data, errors) }}
+            {% else %}
+              {{ forms[question.type](question, data, {}) }}
+            {% endif %}
+          {% endfor %}
+
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {% block save_button %}{% endblock %}
+
+      </div>
+    </div>
+
+  </form>
+{% endblock %}

--- a/app/templates/buyers/_complete_brief.html
+++ b/app/templates/buyers/_complete_brief.html
@@ -1,0 +1,9 @@
+<form action="#" method="POST">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+  {% with type = "save", label = "Ready to publish" %}
+    {% include "toolkit/button.html" %}
+  {% endwith %}
+</form>
+<p class="last-edited ready-to-publish-hint">
+  You will have a chance to review everything before this is published.
+</p>

--- a/app/templates/buyers/brief_summary.html
+++ b/app/templates/buyers/brief_summary.html
@@ -1,0 +1,96 @@
+{% extends "buyers/_base_brief_page.html" %}
+
+{% block page_title %}{{ brief_data.lotName }} requirements summary – Digital Marketplace{% endblock %}
+
+{% import "macros/submission.html" as submission %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block before_sections %}
+
+<div class="column-one-third align-with-heading">
+  <p class='last-edited hint'>
+    Last edited:
+    {{ last_edit|datetimeformat }}
+  </p>
+  {% if framework.status == 'live' %}
+    {% if unanswered_required or unanswered_optional %}
+      <p class="last-edited">
+        {{ submission.multiline_string(
+          submission.unanswered_required_text(unanswered_required, unanswered_optional),
+          submission.unanswered_optional_text(unanswered_required, unanswered_optional)
+        ) }}
+      </p>
+    {% endif %}
+  {% endif %}
+  {% if not can_publish and framework.status == 'live' %}
+  <p>
+    Once you’ve entered all the required information, you can publish the requirements.
+  </p>
+  {% endif %}
+  </div>
+{% endblock %}
+
+{% block before_heading %}
+  {% if delete_requested %}
+    <div class="column-one-whole">
+      <form action="#" method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="hidden" name="delete_confirmed" value="true" />
+        <div class="banner-destructive-with-action">
+          <p class="banner-message">
+            Are you sure you want to delete these requirements? }}?
+          </p>
+          <button type="submit" class="button-destructive banner-action">Yes, delete</button>
+        </div>
+      </form>
+    </div>
+  {% endif %}
+{% endblock %}
+
+
+{% block edit_link %}
+  {% if framework.status == 'live' %}
+    {{ summary.top_link("Edit", url_for(".edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_id, section_id=section.id)) }}
+  {% endif %}
+{% endblock %}
+
+
+{% block after_sections %}
+  {% if not delete_requested %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        &nbsp;
+      </div>
+      <div class="column-one-third delete-draft-button">
+        {% if brief_data.status == 'draft' and can_publish and framework.status == 'live' %}
+          <div class="space-underneath">
+            {% include "buyers/_complete_brief.html" %}
+          </div>
+        {% endif %}
+        {% if framework.status == 'live' and brief_data.status == 'draft' %}
+        <form action="#" method="POST">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {% with
+            type = "destructive",
+            label = "Delete"
+          %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+        </form>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/app/templates/buyers/brief_summary.html
+++ b/app/templates/buyers/brief_summary.html
@@ -63,10 +63,8 @@
 {% block after_sections %}
   {% if not delete_requested %}
     <div class="grid-row">
-      <div class="column-two-thirds">
-        &nbsp;
-      </div>
-      <div class="column-one-third delete-draft-button">
+
+      <div class="column-one-third">
         {% if brief_data.status == 'draft' and can_publish and framework.status == 'live' %}
           <div class="space-underneath">
             {% include "buyers/_complete_brief.html" %}
@@ -83,6 +81,9 @@
           {% endwith %}
         </form>
         {% endif %}
+      </div>
+      <div class="column-two-thirds">
+        &nbsp;
       </div>
     </div>
   {% endif %}

--- a/app/templates/buyers/brief_summary.html
+++ b/app/templates/buyers/brief_summary.html
@@ -45,12 +45,12 @@
 {% block before_heading %}
   {% if delete_requested %}
     <div class="column-one-whole">
-      <form action="#" method="POST">
+      <form action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=brief_data['lotSlug'], brief_id=brief_id) }}" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="delete_confirmed" value="true" />
         <div class="banner-destructive-with-action">
           <p class="banner-message">
-            Are you sure you want to delete these requirements? }}?
+            Are you sure you want to delete these requirements?
           </p>
           <button type="submit" class="button-destructive banner-action">Yes, delete</button>
         </div>
@@ -71,7 +71,7 @@
           </div>
         {% endif %}
         {% if framework.status == 'live' and brief_data.status == 'draft' %}
-        <form action="#" method="POST">
+        <form action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=brief_data['lotSlug'], brief_id=brief_id) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {% with
             type = "destructive",

--- a/app/templates/buyers/brief_summary.html
+++ b/app/templates/buyers/brief_summary.html
@@ -1,4 +1,4 @@
-{% extends "buyers/_base_brief_page.html" %}
+{% extends "buyers/_base_brief_summary_page.html" %}
 
 {% block page_title %}{{ brief_data.lotName }} requirements summary – Digital Marketplace{% endblock %}
 

--- a/app/templates/buyers/brief_summary.html
+++ b/app/templates/buyers/brief_summary.html
@@ -60,13 +60,6 @@
 {% endblock %}
 
 
-{% block edit_link %}
-  {% if framework.status == 'live' %}
-    {{ summary.top_link("Edit", url_for(".edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_id, section_id=section.id)) }}
-  {% endif %}
-{% endblock %}
-
-
 {% block after_sections %}
   {% if not delete_requested %}
     <div class="grid-row">

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "_base_page.html" %}
-
+{% import "toolkit/summary-table.html" as summary %}
 {% block page_title %}Your account - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
@@ -27,5 +27,46 @@
             {% endwith %}
         </div>
     </div>
+
+
+{{ summary.heading("Unpublished requirements", id="unpublished_requirements") }}
+{% call(item) summary.list_table(
+    draft_briefs,
+    caption="Unpublished requirements caption",
+    empty_message="You don’t have any unpublished requirements",
+    field_headings=[
+    "Brief name",
+    "Created",
+    "Unanswered questions",
+    ],
+    field_headings_visible=True
+) %}
+
+    {% call summary.row() %}
+        {{ summary.service_link(item.title, '#') }}
+        {{ summary.text(item.createdAt|dateformat) }}
+        {{ summary.text("Unanswered queston count?") }}
+    {% endcall %}
+{% endcall %}
+
+{{ summary.heading("Published requirements", id="published_requirements") }}
+{% call(item) summary.list_table(
+    live_briefs,
+    caption="Published requirements caption",
+    empty_message="You don’t have any published requirements",
+    field_headings=[
+    "Brief name",
+    "Published",
+    "Unanswered questions",
+    ],
+    field_headings_visible=True
+) %}
+
+    {% call summary.row() %}
+        {{ summary.service_link(item.title, '#') }}
+        {{ summary.text(item.publishedAt|dateformat) }}
+        {{ summary.text("Unanswered queston count?") }}
+    {% endcall %}
+{% endcall %}
 
 {% endblock %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -1,0 +1,31 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Your account - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+    {%
+        with items = [
+        {
+            "link": "/",
+            "label": "Digital Marketplace"
+        }
+        ]
+    %}
+    {% include "toolkit/breadcrumb.html" %}
+    {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+    <div class="grid-row">
+        <div class="column-two-thirds">
+            {% with
+                context = current_user.email_address,
+                heading = current_user.name
+            %}
+            {% include 'toolkit/page-heading.html' %}
+            {% endwith %}
+        </div>
+    </div>
+
+{% endblock %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -43,7 +43,7 @@
 ) %}
 
     {% call summary.row() %}
-        {{ summary.service_link(item.title, '#') }}
+        {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.createdAt|dateformat) }}
         {{ summary.text("Unanswered queston count?") }}
     {% endcall %}
@@ -63,7 +63,7 @@
 ) %}
 
     {% call summary.row() %}
-        {{ summary.service_link(item.title, '#') }}
+        {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id))) }}
         {{ summary.text(item.publishedAt|dateformat) }}
         {{ summary.text("Unanswered queston count?") }}
     {% endcall %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -18,6 +18,27 @@
 {% block main_content %}
 
     <div class="grid-row">
+
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                {% for category, message in messages %}
+                    {% if category == 'error' %}
+                        <div class="banner-destructive-without-action">
+                    {% else %}
+                        <div class="banner-success-without-action">
+                    {% endif %}
+                            <p class="banner-message">
+                    {% if 'requirements_deleted' in message %}
+                            Your requirements &lsquo;{{ message.get('requirements_deleted') }}&rsquo;were deleted
+                    {% else %}
+                        {{ message }}
+                    {% endif %}
+                            </p>
+                        </div>
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+        
         <div class="column-two-thirds">
             {% with
                 context = current_user.email_address,

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -65,8 +65,19 @@
 
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        
         {{ summary.text(item.createdAt|dateformat) }}
-        {{ summary.text("Unanswered queston count?") }}
+        
+        {% if item.unanswered_required > 0 and item.unanswered_optional > 0 %}
+            {{ summary.text("{} required<br>{} optional".format(item.unanswered_required, item.unanswered_optional)|safe) }}
+        {% elif item.unanswered_required > 0 %}
+            {{ summary.text("{} required".format(item.unanswered_required)) }}
+        {% elif item.unanswered_optional > 0 %}
+            {{ summary.text("{} optional".format(item.unanswered_optional)) }}
+        {% else %}
+            {{ summary.text() }}
+        {% endif %}
+        
     {% endcall %}
 {% endcall %}
 
@@ -78,7 +89,6 @@
     field_headings=[
     "Brief name",
     "Published",
-    "Unanswered questions",
     ],
     field_headings_visible=True
 ) %}
@@ -86,7 +96,6 @@
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.publishedAt|dateformat) }}
-        {{ summary.text("Unanswered queston count?") }}
     {% endcall %}
 {% endcall %}
 

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -63,7 +63,7 @@
 ) %}
 
     {% call summary.row() %}
-        {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id))) }}
+        {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.publishedAt|dateformat) }}
         {{ summary.text("Unanswered queston count?") }}
     {% endcall %}

--- a/app/templates/buyers/edit_brief_section.html
+++ b/app/templates/buyers/edit_brief_section.html
@@ -1,0 +1,27 @@
+{% extends "buyers/_base_edit_section_page.html" %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block save_button %}
+
+  {%
+    with
+    label="Save and continue",
+    type="save",
+    name = "return_to_overview"
+  %}
+    {% include "toolkit/button.html" %}
+  {% endwith %}
+
+{% endblock %}

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -1,0 +1,73 @@
+{% extends "_base_page.html" %}
+
+{% set title_text = "Find a team to provide an outcome" if lot.slug == 'digital-outcomes' else "Find an individual specialist" %}
+{% set supplier_type = "outcomes" if lot.slug == 'digital-outcomes' else "specialists" %}
+{% set button_text = "Choose location" if lot.slug == 'digital-outcomes' else "Choose specialist role" %}
+
+{% block page_title %}
+{{ title_text }} - Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="grid-row">
+    <div class="column-two-thirds large-paragraph">
+        {% with
+          smaller = true,
+          heading = title_text
+        %}
+        {% include 'toolkit/page-heading.html' %}
+        {% endwith %}
+    </div>
+
+    <div class="column-two-thirds large-paragraph">
+        <p class="padding-bottom-small">There are {{ supplier_count }} suppliers who provide {{ supplier_type }} on the Digital Marketplace.</p>
+        
+        <p>You need to write and publish your requirements so these suppliers can decide:</p>
+        <ul class="list-bullet padding-bottom-small">
+            <li>whether to apply for the work</li>
+            {% if lot.slug == 'digital-outcomes' %}
+              <li>what solution best meets your needs</li>
+            {% endif %}
+        </ul>
+        
+        <p>Once you’ve published your requirements, you’ll need to:</p>
+        <ul class="list-bullet padding-bottom-small">
+            <li>answer supplier questions</li>
+            <li>shortlist and evaluate supplier applications</li>
+            <li>award to the supplier that best meets your needs</li>
+        </ul>
+        
+        <p class="padding-bottom-small">
+            <a href="#">View published requirements</a><br />
+            <a href="#">View supplier A to Z</a><br />
+            <a href="#">Find out how suppliers are evaluated</a><br />
+            <a href="#">How to talk to suppliers before you start</a>
+        </p>
+        <p class="padding-bottom-small">The buying process should take around 1 month.</p>
+        <p class="padding-bottom-small">Read more about <a href="#">how to buy</a>.</p>
+    </div>
+    
+    <div class="column-two-thirds large-paragraph">
+        <form action="{{ url_for('buyers.start_new_brief', framework_slug=framework.slug, lot_slug=lot.slug) }}" method="get">
+            <button type="submit" class="button-save">
+                {{ button_text }}
+            </button>
+        </form>
+    </div>
+</div>
+
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,17 +4,20 @@
 
 {% block top_header %}
 <header class="marketplace-homepage-heading">
+  {% include "_phase_banner.html" %}
   <h1>
     Digital Marketplace
   </h1>
 </header>
 {% endblock %}
 
+{% block phase_banner %}{% endblock %}
+
 {% block main_content %}
 
 <div class="index-page grid-row">
   <div class="column-two-thirds">
-    <h2>Find specialist or cloud services</h2>
+    <h2 class="marketplace-homepage-subheading">Find digital services for public sector projects</h2>
     {% if frameworks.get('digital-outcomes-and-specialists', {}).status == "live" %}
     {% set
       dos_items = [

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,12 +22,12 @@
     {% set
       dos_items = [
         {
-          "link": url_for("buyers.start_new_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-specialists'),
+          "link": url_for("buyers.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-specialists'),
           "title": "Find an individual specialist",
           "body": "eg a developer or user researcher",
         },
         {
-          "link": url_for("buyers.start_new_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-outcomes'),
+          "link": url_for("buyers.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-outcomes'),
           "title": "Find a team to provide an outcome",
           "body": "eg a booking system or accessibility audit",
         },
@@ -37,7 +37,7 @@
           "body": "eg people from a specific user group to test your service",
         },
         {
-          "link": "/omewhere",
+          "link": "/somewhere",
           "title": "Find a user research lab",
           "body": "eg a room to conduct research sessions",
         },

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -19,17 +19,17 @@
     {% set
       dos_items = [
         {
-          "link": "/omewhere",
+          "link": url_for("buyers.start_new_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-specialists'),
           "title": "Find an individual specialist",
           "body": "eg a developer or user researcher",
         },
         {
-          "link": "/omewhere",
+          "link": url_for("buyers.start_new_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-outcomes'),
           "title": "Find a team to provide an outcome",
           "body": "eg a booking system or accessibility audit",
         },
         {
-          "link": "/omewhere",
+          "link": url_for("buyers.start_new_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='user-research-participants'),
           "title": "Find user research participants",
           "body": "eg people from a specific user group to test your service",
         },

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,26 +14,65 @@
         Find technology or people for digital projects in the public sector
       </p>
     </header>
-    {% with
-      items = [
+    {% if frameworks.get('digital-outcomes-and-specialists', {}).status == "live" %}
+    {% set
+      dos_items = [
         {
-          "link": "/g-cloud",
-          "title": "Find cloud technology and support",
-          "body": "eg web hosting or IT health checks",
-          "subtext": "Procurement framework: <a href='/g-cloud/framework'>G&#8209;Cloud</a>"
+          "link": "/omewhere",
+          "title": "Find an individual specialist",
+          "body": "eg a developer or user researcher",
         },
         {
-          "link": "/crown-hosting",
-          "title": "Buy physical datacentre space for legacy systems",
-          "subtext": "Procurement framework: <a href='/crown-hosting/framework'>Crown Hosting Data Centres</a>"
+          "link": "/omewhere",
+          "title": "Find a team to provide an outcome",
+          "body": "eg a booking system or accessibility audit",
         },
+        {
+          "link": "/omewhere",
+          "title": "Find user research participants",
+          "body": "eg people from a specific user group to test your service",
+        },
+        {
+          "link": "/omewhere",
+          "title": "Find a user research lab",
+          "body": "eg a room to conduct research sessions",
+        },
+      ]
+    %}
+    {% set dss_items = [] %}
+    {% set buyer_dashboard = [
+        {
+          "link": "/buyers",
+          "title": "View your briefs and supplier responses",
+        },
+      ]
+    %}
+    {% else %}
+    {% set dos_items = [] %}
+    {% set dss_items = [
         {
           "link": "https://digitalservicesstore.service.gov.uk/",
           "title": "Find specialists to work on digital projects",
           "body": "eg technical architects and user researchers",
-          "subtext": "Procurement framework: <a href='/digital-services/framework'>Digital Services</a>"
         }
       ]
+    %}
+    {% set buyer_dashboard = [] %}
+    {% endif %}
+
+    {% with
+      items = dos_items + [
+        {
+          "link": "/g-cloud",
+          "title": "Find cloud software and support",
+          "body": "eg web hosting or IT health checks",
+        },
+        {
+          "link": "/crown-hosting",
+          "title": "Buy physical datacentre space for legacy systems",
+          "body": "eg for services that can’t be migrated to the cloud yet"
+        },
+      ] + dss_items + buyer_dashboard
     %}
       {% include "toolkit/browse-list.html" %}
     {% endwith %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -15,10 +15,12 @@
 
 {% block main_content %}
 
+{% set dos_is_live = frameworks.get('digital-outcomes-and-specialists', {}).status == "live" %}
+
 <div class="index-page grid-row">
   <div class="column-two-thirds">
-    <h2 class="marketplace-homepage-subheading">Find digital services for public sector projects</h2>
-    {% if frameworks.get('digital-outcomes-and-specialists', {}).status == "live" %}
+    <h2 class="marketplace-homepage-subheading">Find technology or people for digital projects in the public sector</h2>
+    {% if dos_is_live %}
     {% set
       dos_items = [
         {
@@ -58,6 +60,7 @@
           "link": "https://digitalservicesstore.service.gov.uk/",
           "title": "Find specialists to work on digital projects",
           "body": "eg technical architects and user researchers",
+          "subtext": "Procurement framework: <a href='/digital-services/framework'>Digital Services</a>"
         }
       ]
     %}
@@ -68,13 +71,15 @@
       items = dos_items + [
         {
           "link": "/g-cloud",
-          "title": "Find cloud software and support",
+          "title": "Find cloud technology and support",
           "body": "eg web hosting or IT health checks",
+          "subtext": "Procurement framework: <a href='/g-cloud/framework'>G&#8209;Cloud</a>" if not dos_is_live else None
         },
         {
           "link": "/crown-hosting",
           "title": "Buy physical datacentre space for legacy systems",
-          "body": "eg for services that can’t be migrated to the cloud yet"
+          "body": "eg for services that can’t be migrated to the cloud yet",
+          "subtext": "Procurement framework: <a href='/crown-hosting/framework'>Crown Hosting Data Centres</a>" if not dos_is_live else None
         },
       ] + dss_items + buyer_dashboard
     %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,18 +2,19 @@
 
 {% block page_title %}Digital Marketplace{% endblock %}
 
+{% block top_header %}
+<header class="marketplace-homepage-heading">
+  <h1>
+    Digital Marketplace
+  </h1>
+</header>
+{% endblock %}
+
 {% block main_content %}
 
 <div class="index-page grid-row">
   <div class="column-two-thirds">
-    <header class="page-heading">
-      <h1>
-        Digital Marketplace
-      </h1>
-      <p class="lead">
-        Find technology or people for digital projects in the public sector
-      </p>
-    </header>
+    <h2>Find specialist or cloud services</h2>
     {% if frameworks.get('digital-outcomes-and-specialists', {}).status == "live" %}
     {% set
       dos_items = [

--- a/app/templates/macros/submission.html
+++ b/app/templates/macros/submission.html
@@ -1,0 +1,42 @@
+{% macro multiline_string() %}
+  {% for arg in varargs %}
+    {% if arg|trim %}
+      {{ arg }}{% if not loop.last %}<br />{% endif %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
+
+{% macro unanswered_required_text(unanswered_required, unanswered_optional) %}
+  {% if unanswered_required %}
+    <span class="move-to-complete-hint">
+    {% with unanswered_total = unanswered_required + unanswered_optional %}
+      {% if unanswered_total == 1 %}
+      {{ unanswered_total }} unanswered question
+      {% else %}
+        {{ unanswered_total }} unanswered questions
+      {% endif %}
+    {% endwith %}
+    </span>
+  {% endif %}
+{% endmacro %}
+
+
+{% macro can_be_completed_text(unanswered_required, g7_status) %}
+  {% if unanswered_required == 0 and g7_status == 'open' %}
+    Service can be marked as complete
+  {% endif %}
+{% endmacro %}
+
+
+{% macro unanswered_optional_text(unanswered_required, unanswered_optional) %}
+  {% if not unanswered_required and unanswered_optional %}
+    <span class="move-to-complete-hint">
+      {% if unanswered_optional == 1 %}
+        {{ unanswered_optional }} optional question unanswered
+      {% else %}
+        {{ unanswered_optional }} optional questions unanswered
+      {% endif %}
+    </span>
+  {% endif %}
+{% endmacro %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -1,0 +1,131 @@
+{% macro text(question_content, data, errors) -%}
+  {%
+    with
+    question=question_content.question|markdown,
+    hint=(question_content.hint or '')|markdown,
+    name=question_content.id,
+    value=data[question_content.id],
+    error=errors.get(question_content.id)['message']
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
+{%- endmacro %}
+
+{% macro textbox_large(question_content, data, errors) -%}
+  {%
+    with
+    question=question_content.question|markdown,
+    hint=(question_content.hint or '')|markdown,
+    name=question_content.id,
+    value=data[question_content.id],
+    large=True,
+    max_length_in_words=question_content.max_length_in_words,
+    error=errors.get(question_content.id)['message']
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
+{%- endmacro %}
+
+{% macro list(question_content, data, errors) -%}
+  {%
+    with
+    name=question_content.id,
+    number_of_items=10,
+    question=question_content.question|markdown,
+    hint=(question_content.hint or '')|markdown,
+    values=data[question_content.id],
+    id=question_content.id,
+    error=errors.get(question_content.id)['message']
+  %}
+    {% include "toolkit/forms/list-entry.html" %}
+  {% endwith %}
+{%- endmacro %}
+
+{% macro checkboxes(question_content, data, errors) -%}
+  {%
+    with
+    name=question_content.id,
+    question=question_content.question|markdown,
+    hint=(question_content.hint or '')|markdown,
+    value=data[question_content.id],
+    id=question_content.id,
+    options=question_content.options,
+    type='checkbox',
+    error=errors.get(question_content.id)['message'],
+    question_number=question_number
+  %}
+    {% include "toolkit/forms/selection-buttons.html" %}
+  {% endwith %}
+{%- endmacro %}
+
+{% macro radios(question_content, data, errors) -%}
+  {%
+    with
+    name=question_content.id,
+    question=question_content.question|markdown,
+    hint=(question_content.hint or '')|markdown,
+    hint_underneath=(question_content.hint_underneath or False),
+    value=data[question_content.id],
+    id=question_content.id,
+    options=question_content.options,
+    type='radio',
+    error=errors.get(question_content.id)['message'],
+    question_number=question_number
+  %}
+    {% include "toolkit/forms/selection-buttons.html" %}
+  {% endwith %}
+{%- endmacro %}
+
+{% macro boolean(question_content, data, errors) -%}
+  {%
+    with
+    name=question_content.id,
+    question=question_content.question|markdown,
+    hint=(question_content.hint or '')|markdown,
+    value=data[question_content.id],
+    id=question_content.id,
+    type='boolean',
+    error=errors.get(question_content.id)['message'],
+    question_number=question_number
+  %}
+    {% include "toolkit/forms/selection-buttons.html" %}
+  {% endwith %}
+{%- endmacro %}
+
+{% macro pricing(question_content, data, errors) -%}
+  {%
+    with
+    name=question_content.id,
+    question=question_content.question,
+    fields=question_content.fields,
+    optional_fields=question_content.optional_fields,
+    minimum_price=data.get(question_content.fields.minimum_price),
+    maximum_price=data.get(question_content.fields.maximum_price),
+    price_unit=data.get(question_content.fields.price_unit),
+    price_interval=data.get(question_content.fields.price_interval),
+    hours_for_price=data.get(question_content.fields.hours_for_price),
+    hint=(question_content.hint or '')|markdown,
+    id=question_content.id,
+    error=errors.get(question_content.id)['message'],
+    question_number=question_number
+  %}
+    {% include "toolkit/forms/pricing.html" %}
+  {% endwith %}
+{%- endmacro %}
+
+{% macro percentage(question_content, data, errors) -%}
+  {%
+    with
+    unit_in_full="percent",
+    unit_position="after",
+    unit="%",
+    question=question_content.question|markdown,
+    hint=(question_content.hint or '')|markdown,
+    name=question_content.id,
+    value=data[question_content.id],
+    error=errors.get(question_content.id)['message'],
+    question_number=question_number
+  %}
+    {% include "toolkit/forms/textbox.html" %}
+  {% endwith %}
+{%- endmacro %}

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,8 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.2",
+    "hogan": "3.0.2",
+    "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.1.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.16.0"

--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
     "jquery": "1.11.2",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.1.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.15.1"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.16.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.1.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.16.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.16.5"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ inflection==0.2.1
 werkzeug==0.10.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@16.3.0#egg=digitalmarketplace-utils==16.3.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.0.0#egg=digitalmarketplace-apiclient==2.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.1.0#egg=digitalmarketplace-apiclient==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ inflection==0.2.1
 werkzeug==0.10.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@17.2.0#egg=digitalmarketplace-utils==17.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.3.1#egg=digitalmarketplace-apiclient==2.3.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.3.2#egg=digitalmarketplace-apiclient==2.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ Flask-WTF==0.12
 inflection==0.2.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@16.3.0#egg=digitalmarketplace-utils==16.3.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.1.0#egg=digitalmarketplace-apiclient==2.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@17.2.0#egg=digitalmarketplace-utils==17.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.3.1#egg=digitalmarketplace-apiclient==2.3.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -6,6 +6,7 @@ pep8==1.5.7
 nose==1.3.4
 mock==1.0.1
 lxml==3.4.4
+cssselect==0.9.1
 watchdog==0.8.3
 
 coverage==3.7.1

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1,4 +1,5 @@
 from ...helpers import BaseApplicationTest
+from dmapiclient import api_stubs
 import mock
 from lxml import html
 
@@ -33,3 +34,56 @@ class TestBuyerDashboard(BaseApplicationTest):
             live_row = [cell.text_content().strip() for cell in tables[1].xpath('.//tbody/tr/td')]
             assert live_row[0] == "A live brief"
             assert live_row[1] == "Thursday 04 February 2016"
+
+
+class TestStartNewBrief(BaseApplicationTest):
+    @mock.patch('app.buyers.views.buyers.data_api_client')
+    def test_show_start_brief_page(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/create")
+
+            assert res.status_code == 200
+
+    @mock.patch('app.buyers.views.buyers.data_api_client')
+    def test_404_if_lot_does_not_allow_brief(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=False)
+                ]
+            )
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/create")
+
+            assert res.status_code == 404
+
+    @mock.patch('app.buyers.views.buyers.data_api_client')
+    def test_404_if_framework_status_is_not_live(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='open',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/create")
+
+            assert res.status_code == 404

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1,0 +1,35 @@
+from ...helpers import BaseApplicationTest
+import mock
+from lxml import html
+
+
+class TestBuyerDashboard(BaseApplicationTest):
+    @mock.patch('app.buyers.views.buyers.data_api_client')
+    def test_buyer_dashboard(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.find_briefs.return_value = {
+                "briefs": [
+                    {"status": "draft",
+                     "title": "A draft brief",
+                     "createdAt": "2016-02-02T00:00:00.000000Z"},
+                    {"status": "live",
+                     "title": "A live brief",
+                     "createdAt": "2016-02-01T00:00:00.000000Z",
+                     "publishedAt": "2016-02-04T12:00:00.000000Z"},
+                ]
+            }
+
+            res = self.client.get("/buyers")
+            document = html.fromstring(res.get_data(as_text=True))
+
+            assert res.status_code == 200
+
+            tables = document.xpath('//table')
+            draft_row = [cell.text_content().strip() for cell in tables[0].xpath('.//tbody/tr/td')]
+            assert draft_row[0] == "A draft brief"
+            assert draft_row[1] == "Tuesday 02 February 2016"
+
+            live_row = [cell.text_content().strip() for cell in tables[1].xpath('.//tbody/tr/td')]
+            assert live_row[0] == "A live brief"
+            assert live_row[1] == "Thursday 04 February 2016"

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1,3 +1,4 @@
+from unittest import TestCase
 from ...helpers import BaseApplicationTest
 from dmapiclient import api_stubs, HTTPError
 import mock
@@ -512,15 +513,19 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
         )
         data_api_client.get_brief.return_value = api_stubs.brief()
 
-        res = self.client.post(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
-            "digital-specialists/1234/delete",
-            data={"delete_confirmed": True})
+        try:
+            res = self.client.post(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                "digital-specialists/1234/delete",
+                data={"delete_confirmed": True})
+        except Exception as e:
+            assert type(e) == NotImplementedError
 
-        assert res.status_code == 302
-        # TODO: [When API method exists] data_api_client.delete_brief.assert_called_with(brief_id=1234)
-        assert res.location == "http://localhost/buyers"
-        self.assert_flashes('requirements_deleted')
+        # TODO: [When API method exists] uncomment this
+        # data_api_client.delete_brief.assert_called_with(brief_id=1234)
+        # assert res.status_code == 302
+        # assert res.location == "http://localhost/buyers"
+        # self.assert_flashes('requirements_deleted')
 
     def test_404_if_framework_is_not_live(self, data_api_client):
         self.login_as_buyer()

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -569,7 +569,7 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
             data={})
 
         assert res.status_code == 302
-        # TODO: [When API method exists] assert not data_api_client.delete_brief.called
+        assert not data_api_client.delete_brief.called
         assert res.location == "http://localhost/buyers/frameworks/digital-outcomes-and-specialists/requirements/" \
                                "digital-specialists/1234?delete_requested=True"
 
@@ -584,19 +584,15 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
         )
         data_api_client.get_brief.return_value = api_stubs.brief()
 
-        try:
-            res = self.client.post(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
-                "digital-specialists/1234/delete",
-                data={"delete_confirmed": True})
-        except Exception as e:
-            assert type(e) == NotImplementedError
+        res = self.client.post(
+            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+            "digital-specialists/1234/delete",
+            data={"delete_confirmed": True})
 
-        # TODO: [When API method exists] uncomment this
-        # data_api_client.delete_brief.assert_called_with(brief_id=1234)
-        # assert res.status_code == 302
-        # assert res.location == "http://localhost/buyers"
-        # self.assert_flashes('requirements_deleted')
+        data_api_client.delete_brief.assert_called_with('1234', 'buyer@email.com')
+        assert res.status_code == 302
+        assert res.location == "http://localhost/buyers"
+        self.assert_flashes('requirements_deleted')
 
     def test_404_if_framework_is_not_live(self, data_api_client):
         self.login_as_buyer()

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -913,3 +913,28 @@ class TestCreateUser(BaseApplicationTest):
                 }
             )
             assert res.status_code == 503
+
+
+class TestBuyerRoleRequired(BaseApplicationTest):
+    def test_login_required_for_buyer_pages(self):
+        with self.app.app_context():
+            res = self.client.get('/buyers')
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/login?next=%2Fbuyers'
+
+    def test_supplier_cannot_access_buyer_pages(self):
+        with self.app.app_context():
+            self.login()
+            res = self.client.get('/buyers')
+            assert res.status_code == 302
+            assert res.location == 'http://localhost/login?next=%2Fbuyers'
+            self.assert_flashes('buyer-role-required', expected_category='error')
+
+    def test_buyer_pages_ok_if_logged_in_as_buyer(self):
+        with self.app.app_context():
+            self.login_as_buyer()
+            res = self.client.get('/buyers')
+            page_text = res.get_data(as_text=True)
+            assert res.status_code == 200
+            assert 'buyer@email.com' in page_text
+            assert 'Some Buyer' in page_text

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -930,7 +930,8 @@ class TestBuyerRoleRequired(BaseApplicationTest):
             assert res.location == 'http://localhost/login?next=%2Fbuyers'
             self.assert_flashes('buyer-role-required', expected_category='error')
 
-    def test_buyer_pages_ok_if_logged_in_as_buyer(self):
+    @mock.patch('app.buyers.views.buyers.data_api_client')
+    def test_buyer_pages_ok_if_logged_in_as_buyer(self, data_api_client):
         with self.app.app_context():
             self.login_as_buyer()
             res = self.client.get('/buyers')

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -56,7 +56,7 @@ class TestLogin(BaseApplicationTest):
         assert 'Secure;' in res.headers['Set-Cookie']
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_should_redirect_to_index_on_buyer_login(self, data_api_client):
+    def test_should_redirect_to_buyer_dashboard_on_buyer_login(self, data_api_client):
         with self.app.app_context():
             data_api_client.authenticate_user.return_value = self.user(123, "email@email.com", None, None, 'Name')
             res = self.client.post("/login", data={
@@ -64,7 +64,7 @@ class TestLogin(BaseApplicationTest):
                 'password': '1234567890'
             })
             assert res.status_code == 302
-            assert res.location == 'http://localhost/'
+            assert res.location == 'http://localhost/buyers'
             assert 'Secure;' in res.headers['Set-Cookie']
 
     def test_should_redirect_logged_in_supplier_to_supplier_dashboard(self):
@@ -73,11 +73,11 @@ class TestLogin(BaseApplicationTest):
         assert res.status_code == 302
         assert res.location == 'http://localhost/suppliers'
 
-    def test_should_redirect_logged_in_buyer_to_index(self):
+    def test_should_redirect_logged_in_buyer_to_buyer_dashboard(self):
         self.login_as_buyer()
         res = self.client.get("/login")
         assert res.status_code == 302
-        assert res.location == 'http://localhost/'
+        assert res.location == 'http://localhost/buyers'
 
     def test_should_redirect_logged_in_supplier_to_next_url_if_supplier_app(self):
         self.login()
@@ -137,7 +137,7 @@ class TestLogin(BaseApplicationTest):
         assert res.location == 'http://localhost/suppliers'
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_bad_next_url_takes_buyer_user_to_dashboard(self, data_api_client):
+    def test_bad_next_url_takes_buyer_user_to_buyer_dashboard(self, data_api_client):
         with self.app.app_context():
             data_api_client.authenticate_user.return_value = self.user(123, "email@email.com", None, None, 'Name')
             res = self.client.post("/login?next=http://badness.com",
@@ -146,7 +146,7 @@ class TestLogin(BaseApplicationTest):
                                        'password': '1234567890'
                                    })
         assert res.status_code == 302
-        assert res.location == 'http://localhost/'
+        assert res.location == 'http://localhost/buyers'
 
     def test_should_have_cookie_on_redirect(self):
         with self.app.app_context():

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -42,8 +42,9 @@ class TestHomepageBrowseList(BaseApplicationTest):
             assert res.status_code == 200
 
             link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
-            assert link_texts[0] == "Find cloud software and support"
-            assert link_texts[-1] == "Find specialists to work on digital projects"
+            assert link_texts[0] == "Find cloud technology and support"
+            assert link_texts[-2] == "Find specialists to work on digital projects"
+            assert link_texts[-1] == "Digital Services"
 
     @mock.patch('app.main.views.marketplace.data_api_client')
     def test_dos_links_are_shown_when_dos_is_live(self, data_api_client):

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -2,6 +2,7 @@
 
 import mock
 from nose.tools import assert_equal, assert_true, assert_in, assert_not_in
+from lxml import html
 from ...helpers import BaseApplicationTest
 from dmapiclient import APIError
 
@@ -24,6 +25,43 @@ class TestApplication(BaseApplicationTest):
             '<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>'
             in res.get_data(as_text=True)
         )
+
+
+class TestHomepageBrowseList(BaseApplicationTest):
+    @mock.patch('app.main.views.marketplace.data_api_client')
+    def test_dos_links_not_shown_when_dos_is_pending(self, data_api_client):
+        with self.app.app_context():
+            data_api_client.find_frameworks.return_value = {"frameworks": [
+                {"slug": "digital-outcomes-and-specialists",
+                 "status": "pending"}
+            ]}
+
+            res = self.client.get("/")
+            document = html.fromstring(res.get_data(as_text=True))
+
+            assert res.status_code == 200
+
+            link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
+            assert link_texts[0] == "Find cloud software and support"
+            assert link_texts[-1] == "Find specialists to work on digital projects"
+
+    @mock.patch('app.main.views.marketplace.data_api_client')
+    def test_dos_links_are_shown_when_dos_is_live(self, data_api_client):
+        with self.app.app_context():
+            data_api_client.find_frameworks.return_value = {"frameworks": [
+                {"slug": "digital-outcomes-and-specialists",
+                 "status": "live"}
+            ]}
+
+            res = self.client.get("/")
+            document = html.fromstring(res.get_data(as_text=True))
+
+            assert res.status_code == 200
+
+            link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
+            assert link_texts[0] == "Find an individual specialist"
+            assert link_texts[-1] == "View your briefs and supplier responses"
+            assert "Find specialists to work on digital projects" not in link_texts
 
 
 class TestHomepageSidebarMessage(BaseApplicationTest):

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -184,3 +184,24 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         data_api_client.find_frameworks.return_value = self._find_frameworks(framework_slugs_and_statuses)
         res = self.client.get('/')
         assert_equal(500, res.status_code)
+
+
+class TestStaticMarketplacePages(BaseApplicationTest):
+    def setup(self):
+        super(TestStaticMarketplacePages, self).setup()
+
+    def test_cookie_page(self):
+        res = self.client.get('/cookies')
+        assert_equal(200, res.status_code)
+        assert_true(
+            '<h1>Cookies</h1>'
+            in self._strip_whitespace(res.get_data(as_text=True))
+        )
+
+    def test_cookie_page(self):
+        res = self.client.get('/terms-and-conditions')
+        assert_equal(200, res.status_code)
+        assert_true(
+            '<h1>Termsandconditions</h1>'
+            in self._strip_whitespace(res.get_data(as_text=True))
+        )

--- a/tests/fixtures/content/frameworks/dos/manifests/edit_brief.yml
+++ b/tests/fixtures/content/frameworks/dos/manifests/edit_brief.yml
@@ -1,0 +1,13 @@
+-
+  name: Section 1
+  questions:
+    - required1
+    - optional1
+-
+  name: Section 2
+  questions:
+    - required2
+-
+  name: Section 4
+  questions:
+    - optional2

--- a/tests/fixtures/content/frameworks/dos/questions/data/optional1.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/data/optional1.yml
@@ -1,0 +1,7 @@
+depends:
+  - "on": "lot"
+    being: ['digital-specialists']
+type: boolean
+filterLabel: 'Optional 1'
+question: 'Optional 1'
+optional: true

--- a/tests/fixtures/content/frameworks/dos/questions/data/optional2.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/data/optional2.yml
@@ -1,0 +1,7 @@
+depends:
+  - "on": "lot"
+    being: ['digital-specialists']
+type: boolean
+filterLabel: 'Optional 2'
+question: 'Optional 2'
+optional: true

--- a/tests/fixtures/content/frameworks/dos/questions/data/required1.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/data/required1.yml
@@ -1,0 +1,10 @@
+depends:
+  - "on": "lot"
+    being: ['digital-specialists']
+type: boolean
+filterLabel: 'Required 1'
+validations:
+  -
+    name: answer_required
+    message: 'This question requires an answer.'
+question: 'Required 1'

--- a/tests/fixtures/content/frameworks/dos/questions/data/required2.yml
+++ b/tests/fixtures/content/frameworks/dos/questions/data/required2.yml
@@ -1,0 +1,10 @@
+depends:
+  - "on": "lot"
+    being: ['digital-specialists']
+type: boolean
+filterLabel: 'Required 2'
+validations:
+  -
+    name: answer_required
+    message: 'This question requires an answer.'
+question: 'Required 2'

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -117,7 +117,7 @@ class BaseApplicationTest(object):
         if self.get_user_patch is not None:
             self.get_user_patch.stop()
 
-    def login(self):
+    def login_as_supplier(self):
         with patch('app.main.views.login.data_api_client') as login_api_client:
             login_api_client.authenticate_user.return_value = self.user(
                 123, "email@email.com", 1234, 'Supplier Name', 'Name', role='supplier')
@@ -140,12 +140,32 @@ class BaseApplicationTest(object):
     def login_as_buyer(self):
         with patch('app.main.views.login.data_api_client') as login_api_client:
             login_api_client.authenticate_user.return_value = self.user(
-                123, "email@email.com", None, None, 'Name')
+                123, "buyer@email.com", None, None, 'Name')
 
             self.get_user_patch = patch.object(
                 data_api_client,
                 'get_user',
                 return_value=self.user(123, "buyer@email.com", None, None, 'Some Buyer')
+            )
+            self.get_user_patch.start()
+
+            self.client.post("/login", data={
+                'email_address': 'valid@email.com',
+                'password': '1234567890'
+            })
+
+            login_api_client.authenticate_user.assert_called_once_with(
+                "valid@email.com", "1234567890")
+
+    def login_as_admin(self):
+        with patch('app.main.views.login.data_api_client') as login_api_client:
+            login_api_client.authenticate_user.return_value = self.user(
+                123, "admin@email.com", None, None, 'Name', role='admin')
+
+            self.get_user_patch = patch.object(
+                data_api_client,
+                'get_user',
+                return_value=self.user(123, "admin@email.com", None, None, 'Some Admin', role='admin')
             )
             self.get_user_patch.start()
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -145,7 +145,7 @@ class BaseApplicationTest(object):
             self.get_user_patch = patch.object(
                 data_api_client,
                 'get_user',
-                return_value=self.user(123, "email@email.com", None, None, 'Name')
+                return_value=self.user(123, "buyer@email.com", None, None, 'Some Buyer')
             )
             self.get_user_patch.start()
 
@@ -169,3 +169,13 @@ class BaseApplicationTest(object):
     def strip_all_whitespace(content):
         pattern = re.compile(r'\s+')
         return re.sub(pattern, '', content)
+
+    # Method to test flashes taken from http://blog.paulopoiati.com/2013/02/22/testing-flash-messages-in-flask/
+    def assert_flashes(self, expected_message, expected_category='message'):
+        with self.client.session_transaction() as session:
+            try:
+                category, message = session['_flashes'][0]
+            except KeyError:
+                raise AssertionError('nothing flashed')
+            assert expected_message in message
+            assert expected_category == category

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -1,4 +1,7 @@
 import mock
+import unittest
+from werkzeug.exceptions import NotFound
+
 import app.helpers as helpers
 from dmutils.content_loader import ContentLoader
 
@@ -9,76 +12,99 @@ content_loader.load_manifest('dos', 'data', 'edit_brief')
 questions_builder = content_loader.get_builder('dos', 'edit_brief')
 
 
-def test_get_framework_and_lot():
-    data_api_client = mock.Mock()
-    data_api_client.get_framework.return_value = api_stubs.framework(
-        slug='digital-outcomes-and-specialists',
-        status='live',
-        lots=[
-            api_stubs.lot(slug='digital-specialists', allows_brief=True)
-        ]
-    )
+class TestBuyersHelpers(unittest.TestCase):
+    def test_get_framework_and_lot(self):
+        data_api_client = mock.Mock()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
 
-    framework, lot = helpers.buyers_helpers.get_framework_and_lot('digital-outcomes-and-specialists',
-                                                                  'digital-specialists',
-                                                                  data_api_client)
+        framework, lot = helpers.buyers_helpers.get_framework_and_lot('digital-outcomes-and-specialists',
+                                                                      'digital-specialists',
+                                                                      data_api_client)
 
-    assert framework['status'] == "live"
-    assert framework['name'] == 'Digital Outcomes and Specialists'
-    assert framework['slug'] == 'digital-outcomes-and-specialists'
-    assert framework['clarificationQuestionsOpen'] is True
-    assert lot == {'slug': 'digital-specialists',
-                   'oneServiceLimit': False,
-                   'allowsBrief': True,
-                   'id': 1,
-                   'name': 'Digital Specialists',
-                   }
+        assert framework['status'] == "live"
+        assert framework['name'] == 'Digital Outcomes and Specialists'
+        assert framework['slug'] == 'digital-outcomes-and-specialists'
+        assert framework['clarificationQuestionsOpen'] is True
+        assert lot == {'slug': 'digital-specialists',
+                       'oneServiceLimit': False,
+                       'allowsBrief': True,
+                       'id': 1,
+                       'name': 'Digital Specialists',
+                       }
 
+    def test_get_framework_and_lot_404s_for_wrong_framework_status(self):
+        data_api_client = mock.Mock()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='open',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
 
-def test_is_brief_associated_with_user():
-    brief = api_stubs.brief(user_id=123)['briefs']
-    assert helpers.buyers_helpers.is_brief_associated_with_user(brief, 123) is True
-    assert helpers.buyers_helpers.is_brief_associated_with_user(brief, 234) is False
+        self.assertRaises(NotFound, helpers.buyers_helpers.get_framework_and_lot, 'digital-outcomes-and-specialists',
+                          'digital-specialists', data_api_client, {'status': 'live'})
 
+    def test_get_framework_and_lot_404s_if_allows_brief_required(self):
+        data_api_client = mock.Mock()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=False)
+            ]
+        )
 
-def test_brief_can_be_edited():
-    assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='draft')['briefs']) is True
-    assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='live')['briefs']) is False
+        self.assertRaises(NotFound, helpers.buyers_helpers.get_framework_and_lot, 'digital-outcomes-and-specialists',
+                          'digital-specialists', data_api_client, {'must_allow_brief': True})
 
+    def test_is_brief_associated_with_user(self):
+        brief = api_stubs.brief(user_id=123)['briefs']
+        assert helpers.buyers_helpers.is_brief_associated_with_user(brief, 123) is True
+        assert helpers.buyers_helpers.is_brief_associated_with_user(brief, 234) is False
 
-def test_count_unanswered_questions():
-    brief = {
-        'status': 'draft',
-        'frameworkSlug': 'dos',
-        'lotSlug': 'digital-specialists',
-        'required1': True,
+    def test_brief_can_be_edited(self):
+        assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='draft')['briefs']) is True
+        assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='live')['briefs']) is False
+
+    def test_count_unanswered_questions(self):
+        brief = {
+            'status': 'draft',
+            'frameworkSlug': 'dos',
+            'lotSlug': 'digital-specialists',
+            'required1': True,
+            }
+        content = content_loader.get_manifest('dos', 'edit_brief').filter(
+            {'lot': 'digital-specialists'}
+        )
+        sections = content.summary(brief)
+
+        unanswered_required, unanswered_optional = helpers.buyers_helpers.count_unanswered_questions(sections)
+        assert unanswered_required == 1
+        assert unanswered_optional == 2
+
+    def test_add_unanswered_counts_to_briefs(self):
+        briefs = [{
+            'status': 'draft',
+            'frameworkSlug': 'dos',
+            'lotSlug': 'digital-specialists',
+            'required1': True,
+        }]
+
+        helpers.buyers_helpers.content_loader = content_loader
+
+        assert helpers.buyers_helpers.add_unanswered_counts_to_briefs(briefs) == [{
+            'status': 'draft',
+            'frameworkSlug': 'dos',
+            'lotSlug': 'digital-specialists',
+            'required1': True,
+            'unanswered_required': 1,
+            'unanswered_optional': 2
         }
-    content = content_loader.get_manifest('dos', 'edit_brief').filter(
-        {'lot': 'digital-specialists'}
-    )
-    sections = content.summary(brief)
-
-    unanswered_required, unanswered_optional = helpers.buyers_helpers.count_unanswered_questions(sections)
-    assert unanswered_required == 1
-    assert unanswered_optional == 2
-
-
-def test_add_unanswered_counts_to_briefs():
-    briefs = [{
-        'status': 'draft',
-        'frameworkSlug': 'dos',
-        'lotSlug': 'digital-specialists',
-        'required1': True,
-    }]
-
-    helpers.buyers_helpers.content_loader = content_loader
-
-    assert helpers.buyers_helpers.add_unanswered_counts_to_briefs(briefs) == [{
-        'status': 'draft',
-        'frameworkSlug': 'dos',
-        'lotSlug': 'digital-specialists',
-        'required1': True,
-        'unanswered_required': 1,
-        'unanswered_optional': 2
-    }
-    ]
+        ]

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -1,0 +1,84 @@
+import mock
+import app.helpers as helpers
+from dmutils.content_loader import ContentLoader
+
+from dmapiclient import api_stubs
+
+content_loader = ContentLoader('tests/fixtures/content')
+content_loader.load_manifest('dos', 'data', 'edit_brief')
+questions_builder = content_loader.get_builder('dos', 'edit_brief')
+
+
+def test_get_framework_and_lot():
+    data_api_client = mock.Mock()
+    data_api_client.get_framework.return_value = api_stubs.framework(
+        slug='digital-outcomes-and-specialists',
+        status='live',
+        lots=[
+            api_stubs.lot(slug='digital-specialists', allows_brief=True)
+        ]
+    )
+
+    framework, lot = helpers.buyers_helpers.get_framework_and_lot('digital-outcomes-and-specialists',
+                                                                  'digital-specialists',
+                                                                  data_api_client)
+
+    assert framework['status'] == "live"
+    assert framework['name'] == 'Digital Outcomes and Specialists'
+    assert framework['slug'] == 'digital-outcomes-and-specialists'
+    assert framework['clarificationQuestionsOpen'] is True
+    assert lot == {'slug': 'digital-specialists',
+                   'oneServiceLimit': False,
+                   'allowsBrief': True,
+                   'id': 1,
+                   'name': 'Digital Specialists',
+                   }
+
+
+def test_is_brief_associated_with_user():
+    brief = api_stubs.brief(user_id=123)['briefs']
+    assert helpers.buyers_helpers.is_brief_associated_with_user(brief, 123) is True
+    assert helpers.buyers_helpers.is_brief_associated_with_user(brief, 234) is False
+
+
+def test_brief_can_be_edited():
+    assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='draft')['briefs']) is True
+    assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='live')['briefs']) is False
+
+
+def test_count_unanswered_questions():
+    brief = {
+        'status': 'draft',
+        'frameworkSlug': 'dos',
+        'lotSlug': 'digital-specialists',
+        'required1': True,
+        }
+    content = content_loader.get_manifest('dos', 'edit_brief').filter(
+        {'lot': 'digital-specialists'}
+    )
+    sections = content.summary(brief)
+
+    unanswered_required, unanswered_optional = helpers.buyers_helpers.count_unanswered_questions(sections)
+    assert unanswered_required == 1
+    assert unanswered_optional == 2
+
+
+def test_add_unanswered_counts_to_briefs():
+    briefs = [{
+        'status': 'draft',
+        'frameworkSlug': 'dos',
+        'lotSlug': 'digital-specialists',
+        'required1': True,
+    }]
+
+    helpers.buyers_helpers.content_loader = content_loader
+
+    assert helpers.buyers_helpers.add_unanswered_counts_to_briefs(briefs) == [{
+        'status': 'draft',
+        'frameworkSlug': 'dos',
+        'lotSlug': 'digital-specialists',
+        'required1': True,
+        'unanswered_required': 1,
+        'unanswered_optional': 2
+    }
+    ]


### PR DESCRIPTION
This adds the ability for a logged-in buyer user to create and edit briefs. 

There are several new pages; all except the updated home page follow the newly introduced `buyers` blueprint, which requires a buyer-user to be logged in before the page can be viewed:

1. New home page before DOS goes live:
![screen shot 2016-02-22 at 10 36 31](https://cloud.githubusercontent.com/assets/6525554/13215965/f20fbe42-d950-11e5-8c18-fa9d40a3150d.png)

2. Home page once DOS is live (new links for DOS lots and buyer dashboard):
![screen shot 2016-02-22 at 10 36 18](https://cloud.githubusercontent.com/assets/6525554/13215973/f8249956-d950-11e5-9795-1da31a097b84.png)

3. Buyer dashboard showing draft and published briefs (briefs can not be published as part of this story - the published briefs here are only from hacking local data):
![screen shot 2016-02-17 at 10 31 38](https://cloud.githubusercontent.com/assets/6525554/13107225/7217f1b8-d564-11e5-8927-8d1f4c65a077.png)

4. "How to" introductory pages exist for specialists and outcomes:
![screen shot 2016-02-17 at 10 52 17](https://cloud.githubusercontent.com/assets/6525554/13107248/9b0939ce-d564-11e5-8a2f-1d59b3529726.png)

5. There are flows of question pages for adding requirements details:
![screen shot 2016-02-17 at 10 53 19](https://cloud.githubusercontent.com/assets/6525554/13107275/c2e8957a-d564-11e5-9519-4390f8602114.png)

6. There is a "requirements summary" page (the "Delete" button does not work yet; there is a separate story in Pivotal for the API part of deleting a brief):
![screen shot 2016-02-17 at 10 32 49](https://cloud.githubusercontent.com/assets/6525554/13107283/cee6592a-d564-11e5-8db4-17ef46733034.png)

7. A "Ready to publish" button appears if all required questions have been answered:
![screen shot 2016-02-17 at 10 46 37](https://cloud.githubusercontent.com/assets/6525554/13107320/f7d532fc-d564-11e5-9213-63754f352d74.png)
