### PR TITLE
Align orange BETA tag with the left-hand edge of `D` in homepage heading

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -85,6 +85,10 @@ $path: "/static/images/";
   
   .phase-banner {
     border-bottom: 0px;
+
+    .phase-tag {
+      margin-left: 3px;
+    }
   }
   
   .phase-banner p {


### PR DESCRIPTION
Thanks to the youthful eagle-eyes of @pcraig3 this was apparently an issue :stuck_out_tongue:

Before:
![screen shot 2016-02-26 at 07 08 19](https://cloud.githubusercontent.com/assets/6525554/13345708/de48b71e-dc58-11e5-9ecc-403b47cf1364.png)

After:
![screen shot 2016-02-26 at 07 09 06](https://cloud.githubusercontent.com/assets/6525554/13345712/e2782f7c-dc58-11e5-9e73-4e0552cc1d77.png)
