### PR TITLE
Buyer publishes clarification questions and answers

### DIFF
--- a/app/buyers/__init__.py
+++ b/app/buyers/__init__.py
@@ -6,6 +6,7 @@ buyers = Blueprint('buyers', __name__)
 
 content_loader = ContentLoader('app/content')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'clarification_question', 'clarification_question')
 
 
 @buyers.before_request

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -272,6 +272,7 @@ def add_clarification_question(framework_slug, lot_slug, brief_id):
     section = content.get_section(content.get_next_editable_section_id())
 
     errors = {}
+    status_code = 200
 
     if request.method == "POST":
         try:
@@ -287,6 +288,7 @@ def add_clarification_question(framework_slug, lot_slug, brief_id):
             if e.status_code != 400:
                 raise
             errors = section.get_error_messages(e.message, None)
+            status_code = 400
 
     return render_template(
         "buyers/answer_question.html",
@@ -297,4 +299,4 @@ def add_clarification_question(framework_slug, lot_slug, brief_id):
         section=section,
         errors=errors,
         **dict(buyers.config["BASE_TEMPLATE_DATA"])
-    ), 200
+    ), status_code

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -246,3 +246,24 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
             url_for('.view_brief_summary', framework_slug=framework_slug, lot_slug=lot_slug,
                     brief_id=brief_id, delete_requested=True)
         )
+
+
+@buyers.route("/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/add-clarification-question",
+              methods=["POST"])
+def add_clarification_question(framework_slug, lot_slug, brief_id):
+
+    # Don't need the return values here; the call is just to test conditions on lot and framework
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status="live", must_allow_brief=True)
+
+    brief = data_api_client.get_brief(brief_id)["briefs"]
+    if not is_brief_associated_with_user(brief, current_user.id):
+        abort(404)
+
+    data_api_client.add_clarification_question(brief_id,
+                                               request.form.get("question", ""),
+                                               request.form.get("answer", ""),
+                                               current_user.email_address)
+
+    return redirect(
+        url_for('.view_brief_summary', framework_slug=framework_slug, lot_slug=lot_slug,
+                brief_id=brief_id))

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -57,3 +57,8 @@ def add_unanswered_counts_to_briefs(briefs):
         brief['unanswered_optional'] = unanswered_optional
 
     return briefs
+
+
+def clarification_questions_open(brief):
+    # TODO: Implement this properly
+    return True

--- a/app/templates/buyers/_base_brief_summary_page.html
+++ b/app/templates/buyers/_base_brief_summary_page.html
@@ -42,7 +42,7 @@
           {% if question.answer_required or question.is_empty %}
             {% if brief_data.get('status') == 'draft' %}
               {% call summary.field() %}
-                <a href="{{ url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_id, section_id=question.section_id, _anchor=question.id) }}">{{ question.empty_message or "Not answered" }}</a>
+                <a href="{{ url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_data.id, section_id=question.section_id, _anchor=question.id) }}">{{ question.empty_message or "Not answered" }}</a>
               {% endcall %}
             {% else %}
               {{ summary.text("Not answered") }}
@@ -57,17 +57,38 @@
                 Optional
               {% endcall %}
             {% elif not question.answer_required %}
-              {{ summary.edit_link("Edit", url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_id, section_id=question.section_id, _anchor=question.id)) }}
+              {{ summary.edit_link("Edit", url_for("buyers.edit_brief_submission", framework_slug=framework.slug, lot_slug=brief_data.lot, brief_id=brief_data.id, section_id=question.section_id, _anchor=question.id)) }}
             {% else %}
               {% call summary.field() %}{% endcall %}
             {% endif %}
           {% endif %}
-        
+
+        {% endcall %}
+      {% endcall %}
+    </div>
+
+    {% if brief_data.status == "live": %}
+    <div class="column-one-whole">
+
+      {{ summary.heading("Clarification questions", id="clarification-questions") }}
+      {% call(question) summary.list_table(
+        brief_data.clarificationQuestions,
+        field_headings=[
+          "Question",
+          "Answer"
+        ],
+        field_headings_visible=False
+      ) %}
+
+        {% call summary.row() %}
+          {{ summary.field_name(question.question) }}
+          {{ summary.text(question.answer) }}
         {% endcall %}
       {% endcall %}
 
       {% block after_sections %}{% endblock %}
     </div>
+    {% endif %}
       
   </div>
 {% endblock %}

--- a/app/templates/buyers/answer_question.html
+++ b/app/templates/buyers/answer_question.html
@@ -1,4 +1,5 @@
 {% extends "_base_page.html" %}
+{% import "macros/toolkit_forms.html" as forms %}
 
 {% block page_title %}Answer a Clarification Question{% endblock %}
 
@@ -36,23 +37,9 @@
       <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-        {% with
-            large = true,
-            max_length_in_words = 100,
-            question = "Question",
-            name = "question"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
-
-        {% with
-            large = true,
-            max_length_in_words = 100,
-            question = "Answer",
-            name = "answer"
-        %}
-          {% include "toolkit/forms/textbox.html" %}
-        {% endwith %}
+        {% for question in section.questions %}
+          {{ forms[question.type](question, data, errors or {}) }}
+        {% endfor %}
 
         {% with
             type = "save",

--- a/app/templates/buyers/answer_question.html
+++ b/app/templates/buyers/answer_question.html
@@ -1,0 +1,66 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Answer a Clarification Question{% endblock %}
+
+{% block breadcrumb %}
+  {% with
+      items = [
+        {
+          "link": "/",
+          "label": "Digital Marketplace"
+        },
+        {
+          "link": url_for(".buyer_dashboard"),
+          "label": "Your requirements"
+        },
+        {
+          "link": url_for(".view_brief_summary", framework_slug=framework.slug, lot_slug=lot.slug, brief_id=brief.id),
+          "label": brief.title
+        }
+      ]
+  %}
+  {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  <div class="grid-row">
+    {% with
+        context = brief.title,
+        heading = "Answer a clarification question"
+    %}
+    {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+
+    <div class="column-two-thirds">
+      <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+
+        {% with
+            large = true,
+            max_length_in_words = 100,
+            question = "Question",
+            name = "question"
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+
+        {% with
+            large = true,
+            max_length_in_words = 100,
+            question = "Answer",
+            name = "answer"
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+
+        {% with
+            type = "save",
+            label = "Publish clarification question"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/templates/buyers/brief_summary.html
+++ b/app/templates/buyers/brief_summary.html
@@ -20,11 +20,18 @@
 {% block before_sections %}
 
 <div class="column-one-third align-with-heading">
-  <p class='last-edited hint'>
-    Last edited:
-    {{ last_edit|datetimeformat }}
-  </p>
-  {% if framework.status == 'live' %}
+  {% if brief_data.status == "draft" %}
+    <p class='last-edited hint'>
+      Last edited:
+      {{ brief_data.updatedAt|datetimeformat }}
+    </p>
+  {% elif brief_data.status == "live" %}
+    <p class='last-edited hint'>
+      Published:
+      {{ brief_data.publishedAt|datetimeformat }}
+    </p>
+  {% endif %}
+  {% if framework.status == "live" %}
     {% if unanswered_required or unanswered_optional %}
       <p class="last-edited">
         {{ submission.multiline_string(
@@ -45,7 +52,7 @@
 {% block before_heading %}
   {% if delete_requested %}
     <div class="column-one-whole">
-      <form action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=brief_data['lotSlug'], brief_id=brief_id) }}" method="POST">
+      <form action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=lot.slug, brief_id=brief_data.id) }}" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="delete_confirmed" value="true" />
         <div class="banner-destructive-with-action">
@@ -71,7 +78,7 @@
           </div>
         {% endif %}
         {% if framework.status == 'live' and brief_data.status == 'draft' %}
-        <form action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=brief_data['lotSlug'], brief_id=brief_id) }}" method="POST">
+        <form action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=lot.slug, brief_id=brief_data.id) }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {% with
             type = "destructive",
@@ -86,5 +93,9 @@
         &nbsp;
       </div>
     </div>
+  {% endif %}
+
+  {% if brief_data.status == "live" %}
+  <a href="{{ url_for(".clarification_question", framework_slug=framework.slug, lot_slug=lot.slug, brief_id=brief_data.id) }}">Answer a clarification question</a>
   {% endif %}
 {% endblock %}

--- a/app/templates/buyers/brief_summary.html
+++ b/app/templates/buyers/brief_summary.html
@@ -95,7 +95,7 @@
     </div>
   {% endif %}
 
-  {% if brief_data.status == "live" %}
-  <a href="{{ url_for(".clarification_question", framework_slug=framework.slug, lot_slug=lot.slug, brief_id=brief_data.id) }}">Answer a clarification question</a>
+  {% if brief_data.status == "live" and clarification_questions_open %}
+  <a href="{{ url_for(".add_clarification_question", framework_slug=framework.slug, lot_slug=lot.slug, brief_id=brief_data.id) }}">Answer a clarification question</a>
   {% endif %}
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.1.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.16.5"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.18.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ inflection==0.2.1
 werkzeug==0.10.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@17.2.0#egg=digitalmarketplace-utils==17.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@2.3.2#egg=digitalmarketplace-apiclient==2.3.2
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.2.0#egg=digitalmarketplace-apiclient==3.2.0

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -686,7 +686,6 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Clarification questions" not in page_html
             assert "Answer a clarification question" not in page_html
 
-
     @mock.patch("app.buyers.views.buyers.clarification_questions_open")
     def test_show_live_brief_summary_page(
             self, clarification_questions_open, data_api_client):
@@ -750,7 +749,6 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
             assert "Clarification questions" in page_html
             assert "Answer a clarification question" in page_html
-
 
     def test_404_if_framework_is_not_live(self, data_api_client):
         with self.app.app_context():


### PR DESCRIPTION
[#112340959](https://www.pivotaltracker.com/story/show/112340959)

## Depends on
- [x] https://github.com/alphagov/digitalmarketplace-api/pull/354
- [x] https://github.com/alphagov/digitalmarketplace-apiclient/pull/16
- [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/201

This adds clarification questions and answering clarification questions into the buyer view of briefs.

## Show publish timestamp on live briefs
Draft:
![screen shot 2016-02-26 at 14 08 59](https://cloud.githubusercontent.com/assets/14287/13354376/8e99d902-dc92-11e5-8443-1f79583a61da.png)

Live:
![screen shot 2016-02-26 at 14 10 16](https://cloud.githubusercontent.com/assets/14287/13354404/baa162e0-dc92-11e5-95d4-8d2da1b32615.png)

## Show clarification questions on live briefs
Draft:
![screen shot 2016-02-26 at 14 11 16](https://cloud.githubusercontent.com/assets/14287/13354424/da403f18-dc92-11e5-8874-d248924e260c.png)

Live:
![screen shot 2016-02-26 at 14 12 09](https://cloud.githubusercontent.com/assets/14287/13354442/f9c8715c-dc92-11e5-96ae-1cc6e1db7e51.png)