### PR TITLE
Showing `after_content` block should not be conditional on brief status

### DIFF
--- a/app/templates/buyers/_base_brief_summary_page.html
+++ b/app/templates/buyers/_base_brief_summary_page.html
@@ -67,7 +67,7 @@
       {% endcall %}
     </div>
 
-    {% if brief_data.status == "live": %}
+    {% if brief_data.status == "live" %}
     <div class="column-one-whole">
 
       {{ summary.heading("Clarification questions", id="clarification-questions") }}
@@ -85,10 +85,9 @@
           {{ summary.text(question.answer) }}
         {% endcall %}
       {% endcall %}
-
-      {% block after_sections %}{% endblock %}
+      
     </div>
     {% endif %}
-      
   </div>
+{% block after_sections %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
Previously the "Delete" and "Publish" buttons were not shown for draft briefs.  Now they will be.