### PR TITLE
Doh don't mutate the base template data

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -40,11 +40,6 @@ def create_app(config_name):
     application.register_blueprint(main_blueprint)
     application.register_blueprint(buyers_blueprint)
 
-    main_blueprint.config = {
-        'BASE_TEMPLATE_DATA': application.config['BASE_TEMPLATE_DATA'],
-    }
-    buyers_blueprint.config = main_blueprint.config
-
     login_manager.login_view = 'main.render_login'
     login_manager.login_message_category = "must_login"
     csrf.init_app(application)

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -8,14 +8,12 @@ from ...helpers.buyers_helpers import (
     count_unanswered_questions, brief_can_be_edited, add_unanswered_counts_to_briefs,
     clarification_questions_open
 )
-from ...helpers.search_helpers import get_template_data
 
 from dmapiclient import HTTPError
 
 
 @buyers.route('/buyers')
 def buyer_dashboard():
-    template_data = get_template_data(buyers, {})
     user_briefs = data_api_client.find_briefs(current_user.id).get('briefs', [])
     draft_briefs = add_unanswered_counts_to_briefs([brief for brief in user_briefs if brief['status'] == 'draft'])
     live_briefs = [brief for brief in user_briefs if brief['status'] == 'live']
@@ -24,7 +22,7 @@ def buyer_dashboard():
         'buyers/dashboard.html',
         draft_briefs=draft_briefs,
         live_briefs=live_briefs,
-        **template_data
+        **dict(buyers.config['BASE_TEMPLATE_DATA'])
     )
 
 

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -21,8 +21,7 @@ def buyer_dashboard():
     return render_template(
         'buyers/dashboard.html',
         draft_briefs=draft_briefs,
-        live_briefs=live_briefs,
-        **dict(buyers.config['BASE_TEMPLATE_DATA'])
+        live_briefs=live_briefs
     )
 
 
@@ -36,8 +35,7 @@ def info_page_for_starting_a_brief(framework_slug, lot_slug):
         "buyers/start_brief_info.html",
         framework=framework,
         lot=lot,
-        supplier_count=count_suppliers_on_lot(framework, lot),
-        **dict(buyers.config['BASE_TEMPLATE_DATA'])
+        supplier_count=count_suppliers_on_lot(framework, lot)
     ), 200
 
 
@@ -57,8 +55,7 @@ def start_new_brief(framework_slug, lot_slug):
         "buyers/edit_brief_section.html",
         framework=framework,
         data={},
-        section=section,
-        **dict(buyers.config['BASE_TEMPLATE_DATA'])
+        section=section
     ), 200
 
 
@@ -94,8 +91,7 @@ def create_new_brief(framework_slug, lot_slug):
             framework=framework,
             data=update_data,
             section=section,
-            errors=errors,
-            **dict(buyers.config['BASE_TEMPLATE_DATA'])
+            errors=errors
         ), 400
 
     return redirect(
@@ -129,8 +125,7 @@ def edit_brief_submission(framework_slug, lot_slug, brief_id, section_id):
         "buyers/edit_brief_section.html",
         framework=framework,
         data=brief,
-        section=section,
-        **dict(buyers.config['BASE_TEMPLATE_DATA'])
+        section=section
     ), 200
 
 
@@ -171,8 +166,7 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id):
             framework=framework,
             data=update_data,
             section=section,
-            errors=errors,
-            **dict(buyers.config['BASE_TEMPLATE_DATA'])
+            errors=errors
         ), 200
 
     return redirect(
@@ -223,8 +217,7 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
         unanswered_optional=unanswered_optional,
         can_publish=not unanswered_required,
         delete_requested=delete_requested,
-        clarification_questions_open=clarification_questions_open(brief),
-        **dict(buyers.config['BASE_TEMPLATE_DATA'])
+        clarification_questions_open=clarification_questions_open(brief)
     ), 200
 
 
@@ -295,6 +288,5 @@ def add_clarification_question(framework_slug, lot_slug, brief_id):
         brief=brief,
         data=request.form,
         section=section,
-        errors=errors,
-        **dict(buyers.config["BASE_TEMPLATE_DATA"])
+        errors=errors
     ), status_code

--- a/app/helpers/search_helpers.py
+++ b/app/helpers/search_helpers.py
@@ -6,16 +6,6 @@ from werkzeug.datastructures import MultiDict
 from dmutils.formats import lot_to_lot_case
 
 
-def get_template_data(blueprint, view_data):
-    """Returns a single object holding the base template data with the view
-       data added"""
-
-    template_data = blueprint.config['BASE_TEMPLATE_DATA']
-    for key in view_data:
-        template_data[key] = view_data[key]
-    return template_data
-
-
 def get_lot_from_request(request):
     return request.args.get('lot', None)
 

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -1,8 +1,7 @@
 # coding=utf-8
 
-from flask import render_template, current_app, request
+from flask import render_template
 from . import main
-from ..helpers.search_helpers import get_template_data
 from dmapiclient import APIError
 
 
@@ -34,6 +33,7 @@ def _render_error_page(status_code, error_message=None):
     }
     if status_code not in templates:
         status_code = 500
-    template_data = get_template_data(main, {})
 
-    return render_template(templates[status_code], error_message=error_message, **template_data), status_code
+    return render_template(templates[status_code],
+                           error_message=error_message,
+                           **dict(main.config['BASE_TEMPLATE_DATA'])), status_code

--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -34,6 +34,7 @@ def _render_error_page(status_code, error_message=None):
     if status_code not in templates:
         status_code = 500
 
-    return render_template(templates[status_code],
-                           error_message=error_message,
-                           **dict(main.config['BASE_TEMPLATE_DATA'])), status_code
+    return render_template(
+        templates[status_code],
+        error_message=error_message
+    ), status_code

--- a/app/main/views/crown_hosting.py
+++ b/app/main/views/crown_hosting.py
@@ -8,14 +8,12 @@ from ...main import main
 @main.route('/crown-hosting')
 def index_crown_hosting():
     return render_template(
-        'content/index-crown-hosting.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
+        'content/index-crown-hosting.html'
     )
 
 
 @main.route('/crown-hosting/framework')
 def framework_crown_hosting():
     return render_template(
-        'content/framework-crown-hosting.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
+        'content/framework-crown-hosting.html'
     )

--- a/app/main/views/crown_hosting.py
+++ b/app/main/views/crown_hosting.py
@@ -2,19 +2,20 @@
 from __future__ import unicode_literals
 
 from flask import render_template
-from ...helpers.search_helpers import get_template_data
 from ...main import main
 
 
 @main.route('/crown-hosting')
 def index_crown_hosting():
-    template_data = get_template_data(main, {})
-    return render_template('content/index-crown-hosting.html', **template_data)
+    return render_template(
+        'content/index-crown-hosting.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
+    )
 
 
 @main.route('/crown-hosting/framework')
 def framework_crown_hosting():
-    template_data = get_template_data(main, {})
     return render_template(
-        'content/framework-crown-hosting.html', **template_data
+        'content/framework-crown-hosting.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
     )

--- a/app/main/views/digital_services_framework.py
+++ b/app/main/views/digital_services_framework.py
@@ -8,6 +8,5 @@ from ...main import main
 @main.route('/digital-services/framework')
 def framework_digital_services():
     return render_template(
-        'content/framework-digital-services.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
+        'content/framework-digital-services.html'
     )

--- a/app/main/views/digital_services_framework.py
+++ b/app/main/views/digital_services_framework.py
@@ -2,13 +2,12 @@
 from __future__ import unicode_literals
 
 from flask import render_template
-from ...helpers.search_helpers import get_template_data
 from ...main import main
 
 
 @main.route('/digital-services/framework')
 def framework_digital_services():
-    template_data = get_template_data(main, {})
     return render_template(
-        'content/framework-digital-services.html', **template_data
+        'content/framework-digital-services.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
     )

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -28,26 +28,17 @@ from app import search_api_client, data_api_client, content_loader
 
 @main.route('/g-cloud')
 def index_g_cloud():
-    return render_template(
-        'index-g-cloud.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
-    )
+    return render_template('index-g-cloud.html')
 
 
 @main.route('/g-cloud/framework')
 def framework_g_cloud():
-    return render_template(
-        'content/framework-g-cloud.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
-    )
+    return render_template('content/framework-g-cloud.html')
 
 
 @main.route('/buyers-guide')
 def buyers_guide():
-    return render_template(
-        'content/buyers-guide.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
-    )
+    return render_template('content/buyers-guide.html')
 
 
 @main.route('/suppliers-guide')
@@ -57,18 +48,12 @@ def suppliers_guide():
 
 @main.route('/g-cloud/buyers-guide')
 def buyers_guide_g_cloud():
-    return render_template(
-        'content/buyers-guide-g-cloud.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
-    )
+    return render_template('content/buyers-guide-g-cloud.html')
 
 
 @main.route('/g-cloud/suppliers-guide')
 def suppliers_guide_g_cloud():
-    return render_template(
-        'content/suppliers-guide-g-cloud.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
-    )
+    return render_template('content/suppliers-guide-g-cloud.html')
 
 
 @main.route('/g-cloud/services/<service_id>')
@@ -118,9 +103,7 @@ def get_service_by_id(service_id):
             service=service_view_data,
             service_unavailability_information=service_unavailability_information,
             lot=service_view_data.lot.lower(),
-            lot_label=get_label_for_lot_param(service_view_data.lot.lower()),
-            **dict(main.config['BASE_TEMPLATE_DATA'])
-        ), status_code
+            lot_label=get_label_for_lot_param(service_view_data.lot.lower())), status_code
     except AuthException:
         abort(500, "Application error")
     except KeyError:
@@ -170,6 +153,5 @@ def search():
         services=search_results_obj.search_results,
         summary=search_summary.markup(),
         title='Search results',
-        total=search_results_obj.total,
-        **dict(main.config['BASE_TEMPLATE_DATA'])
+        total=search_results_obj.total
     )

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -16,7 +16,7 @@ from ...presenters.search_results import SearchResults
 from ...presenters.search_summary import SearchSummary
 from ...presenters.service_presenters import Service
 from ...helpers.search_helpers import (
-    get_keywords_from_request, get_template_data, pagination,
+    get_keywords_from_request, pagination,
     get_page_from_request, query_args_for_pagination,
     get_lot_from_request, build_search_query,
     clean_request_args
@@ -28,20 +28,26 @@ from app import search_api_client, data_api_client, content_loader
 
 @main.route('/g-cloud')
 def index_g_cloud():
-    template_data = get_template_data(main, {})
-    return render_template('index-g-cloud.html', **template_data)
+    return render_template(
+        'index-g-cloud.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
+    )
 
 
 @main.route('/g-cloud/framework')
 def framework_g_cloud():
-    template_data = get_template_data(main, {})
-    return render_template('content/framework-g-cloud.html', **template_data)
+    return render_template(
+        'content/framework-g-cloud.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
+    )
 
 
 @main.route('/buyers-guide')
 def buyers_guide():
-    template_data = get_template_data(main, {})
-    return render_template('content/buyers-guide.html', **template_data)
+    return render_template(
+        'content/buyers-guide.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
+    )
 
 
 @main.route('/suppliers-guide')
@@ -51,17 +57,17 @@ def suppliers_guide():
 
 @main.route('/g-cloud/buyers-guide')
 def buyers_guide_g_cloud():
-    template_data = get_template_data(main, {})
     return render_template(
-        'content/buyers-guide-g-cloud.html', **template_data
+        'content/buyers-guide-g-cloud.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
     )
 
 
 @main.route('/g-cloud/suppliers-guide')
 def suppliers_guide_g_cloud():
-    template_data = get_template_data(main, {})
     return render_template(
-        'content/suppliers-guide-g-cloud.html', **template_data
+        'content/suppliers-guide-g-cloud.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
     )
 
 
@@ -107,13 +113,14 @@ def get_service_by_id(service_id):
             # mark the resource as unavailable in the headers
             status_code = 410
 
-        template_data = get_template_data(main, {
-            'service': service_view_data,
-            'service_unavailability_information': service_unavailability_information,
-            'lot': service_view_data.lot.lower(),
-            'lot_label': get_label_for_lot_param(service_view_data.lot.lower())
-        })
-        return render_template('service.html', **template_data), status_code
+        return render_template(
+            'service.html',
+            service=service_view_data,
+            service_unavailability_information=service_unavailability_information,
+            lot=service_view_data.lot.lower(),
+            lot_label=get_label_for_lot_param(service_view_data.lot.lower()),
+            **dict(main.config['BASE_TEMPLATE_DATA'])
+        ), status_code
     except AuthException:
         abort(500, "Application error")
     except KeyError:
@@ -151,19 +158,18 @@ def search():
     set_filter_states(filters, request)
     current_lot = get_lot_from_request(request)
 
-    template_data = get_template_data(main, {
-        'title': 'Search results',
-        'current_lot': current_lot,
-        'lots': LOTS,
-        'search_keywords': get_keywords_from_request(request),
-        'services': search_results_obj.search_results,
-        'total': search_results_obj.total,
-        'search_query': query_args_for_pagination(request.args),
-        'pagination': pagination_config,
-        'summary': search_summary.markup(),
-        'filters': filters,
-    })
-    if current_lot:
-        template_data['current_lot_label'] = get_label_for_lot_param(current_lot)
-
-    return render_template('search.html', **template_data)
+    return render_template(
+        'search.html',
+        current_lot=current_lot,
+        current_lot_label=get_label_for_lot_param(current_lot) if current_lot else None,
+        filters=filters,
+        lots=LOTS,
+        pagination=pagination_config,
+        search_keywords=get_keywords_from_request(request),
+        search_query=query_args_for_pagination(request.args),
+        services=search_results_obj.search_results,
+        summary=search_summary.markup(),
+        title='Search results',
+        total=search_results_obj.total,
+        **dict(main.config['BASE_TEMPLATE_DATA'])
+    )

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -3,19 +3,17 @@ from __future__ import unicode_literals
 
 from flask import abort, render_template, current_app
 
-from dmapiclient import APIError, HTTPError
+from dmapiclient import APIError
 from dmutils.content_loader import ContentNotFoundError
 
 from ...main import main
 from ...helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference
-from ...helpers.search_helpers import get_template_data
 
 from app import data_api_client, content_loader
 
 
 @main.route('/')
 def index():
-    template_data = get_template_data(main, {})
     temporary_message = {}
 
     try:
@@ -47,29 +45,28 @@ def index():
         'index.html',
         frameworks={framework['slug']: framework for framework in frameworks},
         temporary_message=temporary_message,
-        **template_data
+        **dict(main.config['BASE_TEMPLATE_DATA'])
     )
 
 
 @main.route('/cookies')
 def cookies():
-    template_data = get_template_data(main, {})
     return render_template(
-        'content/cookies.html', **template_data
+        'content/cookies.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
     )
 
 
 @main.route('/terms-and-conditions')
 def terms_and_conditions():
-    template_data = get_template_data(main, {})
     return render_template(
-        'content/terms-and-conditions.html', **template_data
+        'content/terms-and-conditions.html',
+        **dict(main.config['BASE_TEMPLATE_DATA'])
     )
 
 
 @main.route('/<framework_slug>/opportunities/<brief_id>')
 def get_brief_by_id(framework_slug, brief_id):
-    template_data = get_template_data(main, {})
     temporary_message = {}
 
     briefs = data_api_client.get_brief(brief_id)
@@ -80,5 +77,5 @@ def get_brief_by_id(framework_slug, brief_id):
     return render_template(
         'brief.html',
         brief=brief,
-        **template_data
+        **dict(main.config['BASE_TEMPLATE_DATA'])
     )

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -44,31 +44,22 @@ def index():
     return render_template(
         'index.html',
         frameworks={framework['slug']: framework for framework in frameworks},
-        temporary_message=temporary_message,
-        **dict(main.config['BASE_TEMPLATE_DATA'])
+        temporary_message=temporary_message
     )
 
 
 @main.route('/cookies')
 def cookies():
-    return render_template(
-        'content/cookies.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
-    )
+    return render_template('content/cookies.html')
 
 
 @main.route('/terms-and-conditions')
 def terms_and_conditions():
-    return render_template(
-        'content/terms-and-conditions.html',
-        **dict(main.config['BASE_TEMPLATE_DATA'])
-    )
+    return render_template('content/terms-and-conditions.html')
 
 
 @main.route('/<framework_slug>/opportunities/<brief_id>')
 def get_brief_by_id(framework_slug, brief_id):
-    temporary_message = {}
-
     briefs = data_api_client.get_brief(brief_id)
     brief = briefs.get('briefs')
     if brief['status'] != 'live':
@@ -76,6 +67,5 @@ def get_brief_by_id(framework_slug, brief_id):
 
     return render_template(
         'brief.html',
-        brief=brief,
-        **dict(main.config['BASE_TEMPLATE_DATA'])
+        brief=brief
     )

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -2,7 +2,6 @@
 from string import ascii_uppercase
 from app.main import main
 from flask import render_template, request, abort
-from app.helpers.search_helpers import get_template_data
 from app import data_api_client
 from dmapiclient import APIError
 import re
@@ -66,8 +65,6 @@ def suppliers_list_by_prefix():
         suppliers = api_result["suppliers"]
         links = api_result["links"]
 
-        template_data = get_template_data(main, {})
-
         return render_template('suppliers_list.html',
                                suppliers=suppliers,
                                nav=ascii_uppercase,
@@ -75,7 +72,7 @@ def suppliers_list_by_prefix():
                                prev_link=parse_links(links)['prev'],
                                next_link=parse_links(links)['next'],
                                prefix=template_prefix,
-                               **template_data)
+                               **dict(main.config['BASE_TEMPLATE_DATA']))
     except APIError as e:
         if e.status_code == 404:
             abort(404, "No suppliers for prefix {} page {}".format(api_prefix, page))
@@ -95,10 +92,9 @@ def suppliers_details(supplier_id):
     else:
         prefix = u"other"
 
-    template_data = get_template_data(main, {})
-
     return render_template(
         'suppliers_details.html',
         supplier=supplier,
         prefix=prefix,
-        **template_data)
+        **dict(main.config['BASE_TEMPLATE_DATA'])
+    )

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -71,8 +71,8 @@ def suppliers_list_by_prefix():
                                count=len(suppliers),
                                prev_link=parse_links(links)['prev'],
                                next_link=parse_links(links)['next'],
-                               prefix=template_prefix,
-                               **dict(main.config['BASE_TEMPLATE_DATA']))
+                               prefix=template_prefix
+                               )
     except APIError as e:
         if e.status_code == 404:
             abort(404, "No suppliers for prefix {} page {}".format(api_prefix, page))
@@ -95,6 +95,5 @@ def suppliers_details(supplier_id):
     return render_template(
         'suppliers_details.html',
         supplier=supplier,
-        prefix=prefix,
-        **dict(main.config['BASE_TEMPLATE_DATA'])
+        prefix=prefix
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ Flask-WTF==0.12
 inflection==0.2.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@17.2.0#egg=digitalmarketplace-utils==17.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@17.4.0#egg=digitalmarketplace-utils==17.4.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.2.0#egg=digitalmarketplace-apiclient==3.2.0


### PR DESCRIPTION
The `get_template_data` method was mutating the base template data.  We've been lucky up until now that no name clashes or unexpected effects showed up.  But the new info page for creating a brief has a `lot` keyword argument, and it was possible to get a name clash if the base data had previously been updated with a `lot` from elsewhere.

Everywhere else we just pass in keyword args directly to the templates, so rather than fix the method to make a copy of the base data before adding keys I've removed it altogether and passed in parameters to the template as we do elsewhere.