### PR TITLE
[#115026147] Add dashboard link to homepage sidebar

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -38,8 +38,12 @@
 
   .supplier-messages {
     h2 {
+      @include bold-27;
+      margin-bottom: $gutter;
+    }
+
+    h3 {
       @include bold-24;
-      margin-bottom: $gutter-half;
     }
 
     p {

--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -36,9 +36,7 @@
 
   }
 
-  .framework-message {
-    margin-top: 45px;
-
+  .supplier-messages {
     h2 {
       @include bold-24;
       margin-bottom: $gutter-half;
@@ -75,8 +73,8 @@
     }
   }
 
-  /* `.framework-message p` overwrites the `margin-bottom` of paragraphs in the temporary message */
-  .framework-message .temporary-message-message {
+  /* `.supplier-message p` overwrites the `margin-bottom` of paragraphs in the temporary message */
+  .supplier-messages .temporary-message-message {
     margin-bottom: 5px;
   }
 

--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -59,6 +59,66 @@
         border-bottom: 1px solid $border-colour;
         padding-bottom: $gutter-half;
       }
+
+      a.top-level-link {
+        display: inline;
+        @include heading-24;
+        font-weight: bold;
+        text-decoration: none;
+        border-bottom: 1px solid; // No border colour, is inherited from text colour
+        position: relative;
+        top: -12px;
+
+        @include ie-lte(9) {
+          text-decoration: underline;
+          border-bottom: none;
+          top: 0;
+        }
+
+        span {
+
+          position: relative;
+          top: 12px;
+
+          @include ie-lte(9) {
+            top: 0;
+          }
+
+        }
+
+        &:visited {
+          color: $link-visited-colour;
+        }
+
+        &:hover {
+          color: $link-hover-colour;
+        }
+
+        &:active,
+        &:focus {
+
+          outline: none;
+          background: none;
+
+          @include ie-lte(9) {
+            background: $yellow;
+            outline: 3px solid $yellow;
+          }
+
+          span {
+
+            background: $yellow;
+            outline: 3px solid $yellow;
+
+            @include ie-lte(9) {
+              background: none;
+              outline: none;
+            }
+
+          }
+
+        }
+      }
     }
 
     nav {

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -16,7 +16,6 @@ from app import data_api_client, content_loader
 @main.route('/')
 def index():
     temporary_message = {}
-    logged_in = current_user.is_authenticated()
 
     try:
         frameworks = data_api_client.find_frameworks().get('frameworks')
@@ -43,15 +42,11 @@ def index():
             "framework {} status {}".format(framework.get('slug'), framework.get('status')))
         abort(500)
 
-    template_data = {
-        'frameworks': {framework['slug']: framework for framework in frameworks},
-        'temporary_message': temporary_message
-    }
-    if logged_in:
-        template_data['logged_in'] = True
     return render_template(
         'index.html',
-        **template_data
+        frameworks={framework['slug']: framework for framework in frameworks},
+        temporary_message=temporary_message,
+        logged_in=current_user.is_authenticated()
     )
 
 

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from flask import abort, render_template, current_app
+from flask_login import current_user
 
 from dmapiclient import APIError
 from dmutils.content_loader import ContentNotFoundError
@@ -15,6 +16,7 @@ from app import data_api_client, content_loader
 @main.route('/')
 def index():
     temporary_message = {}
+    logged_in = current_user.is_authenticated()
 
     try:
         frameworks = data_api_client.find_frameworks().get('frameworks')
@@ -41,10 +43,15 @@ def index():
             "framework {} status {}".format(framework.get('slug'), framework.get('status')))
         abort(500)
 
+    template_data = {
+        'frameworks': {framework['slug']: framework for framework in frameworks},
+        'temporary_message': temporary_message
+    }
+    if logged_in:
+        template_data['logged_in'] = True
     return render_template(
         'index.html',
-        frameworks={framework['slug']: framework for framework in frameworks},
-        temporary_message=temporary_message
+        **template_data
     )
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -86,7 +86,7 @@
       {% include "toolkit/browse-list.html" %}
     {% endwith %}
   </div>
-    <div class="framework-message column-one-third">
+    <div class="supplier-messages column-one-third">
       {% if temporary_message %}
         {%
           with

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -88,15 +88,17 @@
   </div>
     <div class="supplier-messages column-one-third">
       {% if temporary_message %}
-        {%
-          with
-            heading = temporary_message.heading,
-            subheading = temporary_message.subheading,
-            messages = temporary_message.messages,
-            message = temporary_message.message
-        %}
-          {% include "toolkit/{}.html".format(temporary_message.template_name) %}
-        {% endwith %}
+        <aside role="complementary">
+          {%
+            with
+              heading = temporary_message.heading,
+              subheading = temporary_message.subheading,
+              messages = temporary_message.messages,
+              message = temporary_message.message
+          %}
+            {% include "toolkit/{}.html".format(temporary_message.template_name) %}
+          {% endwith %}
+        </aside>
       {% endif %}
     </div>
 </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -87,17 +87,25 @@
     {% endwith %}
   </div>
     <div class="supplier-messages column-one-third">
-      {% if temporary_message %}
-        <aside role="complementary">
-          {%
-            with
-              heading = temporary_message.heading,
-              subheading = temporary_message.subheading,
-              messages = temporary_message.messages,
-              message = temporary_message.message
-          %}
-            {% include "toolkit/{}.html".format(temporary_message.template_name) %}
-          {% endwith %}
+      {% if temporary_message or logged_in %}
+        <aside role="complementary" aria-labelledby="supplier-message-heading">
+          <h2 id="supplier-message-heading">Sell services</h2>
+          {% if temporary_message %}
+            {%
+              with
+                heading = temporary_message.heading,
+                subheading = temporary_message.subheading,
+                messages = temporary_message.messages,
+                message = temporary_message.message
+            %}
+              {% include "toolkit/{}.html".format(temporary_message.template_name) %}
+            {% endwith %}
+          {% endif %}
+          {% if logged_in %}
+            <h3>
+              <a href="/suppliers">View your services and account details</a>
+            </h3>
+          {% endif %}
         </aside>
       {% endif %}
     </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -102,9 +102,11 @@
             {% endwith %}
           {% endif %}
           {% if logged_in %}
-            <h3>
-              <a href="/suppliers">View your services and account details</a>
-            </h3>
+            <p>
+              <a href="/suppliers" class="top-level-link">
+                <span>View your services and account details</span>
+              </a>
+            </p>
           {% endif %}
         </aside>
       {% endif %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.2.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.4.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.20.2"
   }

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -190,7 +190,6 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
             '//div[@class="supplier-messages column-one-third"]/aside/h3/a[text()="View your services and account details"]')  # noqa
 
         assert len(link_to_dashboard) == 1
-        
 
     def test_homepage_sidebar_message_doesnt_exist_without_frameworks(self):
         framework_slugs_and_statuses = [

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -187,7 +187,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         document = html.fromstring(response_data)
 
         link_to_dashboard = document.xpath(
-            '//div[@class="supplier-messages column-one-third"]/aside/h3/a[text()="View your services and account details"]')  # noqa
+            '//div[@class="supplier-messages column-one-third"]/aside/p/a/span[text()="View your services and account details"]')  # noqa
 
         assert len(link_to_dashboard) == 1
 

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -90,19 +90,17 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
     @staticmethod
     def _assert_message_container_is_empty(response_data):
-        empty_message_container = '<div class="supplier-messages column-one-third"></div>'
-        assert_in(
-            BaseApplicationTest._strip_whitespace(empty_message_container),
-            BaseApplicationTest._strip_whitespace(response_data),
-        )
+        document = html.fromstring(response_data)
+        message_container = document.xpath('//div[@class="supplier-messages column-one-third"]/aside')
+        assert len(message_container) == 0
 
     @staticmethod
     def _assert_message_container_is_not_empty(response_data):
-        empty_message_container = '<div class="supplier-messages column-one-third"></div>'
-        assert_not_in(
-            BaseApplicationTest._strip_whitespace(empty_message_container),
-            BaseApplicationTest._strip_whitespace(response_data),
-        )
+        document = html.fromstring(response_data)
+        message_container = document.xpath('//div[@class="supplier-messages column-one-third"]/aside')
+        assert len(message_container) == 1
+
+        assert message_container[0].xpath('h2/text()')[0].strip() == "Sell services"
 
     @mock.patch('app.main.views.marketplace.data_api_client')
     def _load_homepage(self, framework_slugs_and_statuses, framework_messages, data_api_client):
@@ -156,6 +154,43 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         ]
 
         self._load_homepage(framework_slugs_and_statuses, framework_messages)
+
+    @mock.patch('app.main.views.marketplace.data_api_client')
+    @mock.patch('app.main.views.marketplace.current_user')
+    def test_homepage_sidebar_no_log_in_message_if_logged_out(self, data_api_client, current_user):
+        data_api_client.find_frameworks.return_value = self._find_frameworks([
+            ('digital-outcomes-and-specialists', 'live')
+        ])
+        current_user.is_authenticated.return_value = True
+        res = self.client.get('/')
+        assert res.status_code == 200
+        response_data = res.get_data(as_text=True)
+
+        document = html.fromstring(response_data)
+
+        link_to_dashboard = document.xpath(
+            '//div[@class="supplier-messages column-one-third"]/aside/h3/a[text()="View your services and account details"]')  # noqa
+
+        assert len(link_to_dashboard) == 0
+
+    @mock.patch('app.main.views.marketplace.data_api_client')
+    @mock.patch('app.main.views.marketplace.current_user')
+    def test_homepage_sidebar_no_log_in_message_if_logged_out(self, data_api_client, current_user):
+        data_api_client.find_frameworks.return_value = self._find_frameworks([
+            ('digital-outcomes-and-specialists', 'live')
+        ])
+        current_user.is_authenticated.return_value = True
+        res = self.client.get('/')
+        assert res.status_code == 200
+        response_data = res.get_data(as_text=True)
+
+        document = html.fromstring(response_data)
+
+        link_to_dashboard = document.xpath(
+            '//div[@class="supplier-messages column-one-third"]/aside/h3/a[text()="View your services and account details"]')  # noqa
+
+        assert len(link_to_dashboard) == 1
+        
 
     def test_homepage_sidebar_message_doesnt_exist_without_frameworks(self):
         framework_slugs_and_statuses = [

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -90,7 +90,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
     @staticmethod
     def _assert_message_container_is_empty(response_data):
-        empty_message_container = '<div class="framework-message column-one-third"></div>'
+        empty_message_container = '<div class="supplier-messages column-one-third"></div>'
         assert_in(
             BaseApplicationTest._strip_whitespace(empty_message_container),
             BaseApplicationTest._strip_whitespace(response_data),
@@ -98,7 +98,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
     @staticmethod
     def _assert_message_container_is_not_empty(response_data):
-        empty_message_container = '<div class="framework-message column-one-third"></div>'
+        empty_message_container = '<div class="supplier-messages column-one-third"></div>'
         assert_not_in(
             BaseApplicationTest._strip_whitespace(empty_message_container),
             BaseApplicationTest._strip_whitespace(response_data),


### PR DESCRIPTION
Currently if suppliers log in and then click the 'Digital Marketplace' link to the home page they cannot return to their dashboard without hacking the URL.

(Described in [story #115026147](https://www.pivotaltracker.com/story/show/115026147).

This adds a link going back to the supplier dashboard to the sidebar. It requires the following changes to be merged in the toolkit: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/227

It also contains changes to the sidebar HTML to allow it to contain multiple message modules. After talking with @ralph-hawkins it was decided the sidebar should be an area for messages to suppliers (as the main area is one for those to buyers) so the new HTML reflects this.