### PR TITLE
Use a single UA code for Buyer App analytics

### DIFF
--- a/app/assets/javascripts/analytics/_init.js
+++ b/app/assets/javascripts/analytics/_init.js
@@ -1,7 +1,7 @@
 (function() {
   "use strict";
   var cookieDomain = (document.domain === 'www.digitalmarketplace.service.gov.uk') ? '.digitalmarketplace.service.gov.uk' : document.domain;
-  var property = (document.domain === 'www.digitalmarketplace.service.gov.uk') ? 'UA-49258698-1' : 'UA-49258698-3';
+  var property = 'UA-49258698-1';
 
   GOVUK.Analytics.load();
   GOVUK.analytics = new GOVUK.Analytics({


### PR DESCRIPTION
Missed out of this story (which only changed the Supplier App):

https://www.pivotaltracker.com/story/show/106115458