### PR TITLE
[#114207705] Catalogue of briefs

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -50,3 +50,9 @@ em.search-result-highlighted-text {
     }
   }
 }
+
+.search-result-important-metadata {
+  li {
+    @include bold-19;
+  }
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -34,6 +34,7 @@ $path: "/static/images/";
 @import "toolkit/forms/_textboxes.scss";
 @import "toolkit/forms/_validation.scss";
 @import "toolkit/search/_search-result.scss";
+@import "toolkit/shared_scss/_lists.scss";
 
 /* Blocks shared between multiple selectors */
 @import "shared_placeholders/_temporary-messages.scss";

--- a/app/helpers/shared_helpers.py
+++ b/app/helpers/shared_helpers.py
@@ -8,14 +8,6 @@ def parse_link(links, label):
     return parse_qs(urlparse(links[label]).query) if label in links else None
 
 
-def process_page(page):
-    try:
-        int(page)
-        return page
-    except ValueError:
-        return "1"  # default
-
-
 def get_label_for_lot_param(lot_param):
     lots = {
         'saas': u'Software as a Service',

--- a/app/helpers/shared_helpers.py
+++ b/app/helpers/shared_helpers.py
@@ -1,3 +1,31 @@
+try:
+    from urlparse import urlparse, parse_qs
+except ImportError:
+    from urllib.parse import urlparse, parse_qs
+
+
+def parse_links(links):
+    pagination_links = {
+        "prev": None,
+        "next": None
+    }
+
+    if 'prev' in links:
+        pagination_links['prev'] = parse_qs(urlparse(links['prev']).query)
+    if 'next' in links:
+        pagination_links['next'] = parse_qs(urlparse(links['next']).query)
+
+    return pagination_links
+
+
+def process_page(page):
+    try:
+        int(page)
+        return page
+    except ValueError:
+        return "1"  # default
+
+
 def get_label_for_lot_param(lot_param):
     lots = {
         'saas': u'Software as a Service',

--- a/app/helpers/shared_helpers.py
+++ b/app/helpers/shared_helpers.py
@@ -4,18 +4,8 @@ except ImportError:
     from urllib.parse import urlparse, parse_qs
 
 
-def parse_links(links):
-    pagination_links = {
-        "prev": None,
-        "next": None
-    }
-
-    if 'prev' in links:
-        pagination_links['prev'] = parse_qs(urlparse(links['prev']).query)
-    if 'next' in links:
-        pagination_links['next'] = parse_qs(urlparse(links['next']).query)
-
-    return pagination_links
+def parse_link(links, label):
+    return parse_qs(urlparse(links[label]).query) if label in links else None
 
 
 def process_page(page):

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -83,20 +83,14 @@ def list_opportunities(framework_slug):
     if not framework:
         abort(404, "No framework {}".format(framework_slug))
 
-    try:
-        api_result = data_api_client.find_briefs(status='live,closed', framework=framework_slug, page=page)
+    api_result = data_api_client.find_briefs(status='live,closed', framework=framework_slug, page=page)
 
-        briefs = api_result["briefs"]
-        links = api_result["links"]
+    briefs = api_result["briefs"]
+    links = api_result["links"]
 
-        return render_template('briefs_catalogue.html',
-                               framework=framework,
-                               briefs=briefs,
-                               prev_link=parse_link(links, 'prev'),
-                               next_link=parse_link(links, 'next')
-                               )
-    except APIError as e:
-        if e.status_code == 404:
-            abort(404, "No briefs on page {}".format(page))
-        else:
-            raise e
+    return render_template('briefs_catalogue.html',
+                           framework=framework,
+                           briefs=briefs,
+                           prev_link=parse_link(links, 'prev'),
+                           next_link=parse_link(links, 'next')
+                           )

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -7,7 +7,7 @@ from dmapiclient import APIError
 from dmutils.content_loader import ContentNotFoundError
 
 from ...main import main
-from ...helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference, process_page, parse_link
+from ...helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference, parse_link
 
 from app import data_api_client, content_loader
 
@@ -77,7 +77,7 @@ def get_brief_by_id(framework_slug, brief_id):
 
 @main.route('/<framework_slug>/opportunities')
 def list_opportunities(framework_slug):
-    page = process_page(request.args.get('page', default=u"1"))
+    page = request.args.get('page', default=1, type=int)
     framework = data_api_client.get_framework(framework_slug)['frameworks']
 
     if not framework:

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -7,7 +7,7 @@ from dmapiclient import APIError
 from dmutils.content_loader import ContentNotFoundError
 
 from ...main import main
-from ...helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference, process_page, parse_links
+from ...helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference, process_page, parse_link
 
 from app import data_api_client, content_loader
 
@@ -92,8 +92,8 @@ def list_opportunities(framework_slug):
         return render_template('briefs_catalogue.html',
                                framework=framework,
                                briefs=briefs,
-                               prev_link=parse_links(links)['prev'],
-                               next_link=parse_links(links)['next']
+                               prev_link=parse_link(links, 'prev'),
+                               next_link=parse_link(links, 'next')
                                )
     except APIError as e:
         if e.status_code == 404:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -4,6 +4,7 @@ from app.main import main
 from flask import render_template, request, abort
 from app import data_api_client
 from dmapiclient import APIError
+from ...helpers.shared_helpers import process_page, parse_links
 import re
 
 try:
@@ -23,31 +24,9 @@ def process_prefix(prefix=None, format='view'):
     return u"A"  # default
 
 
-def process_page(page):
-    try:
-        int(page)
-        return page
-    except ValueError:
-        return "1"  # default
-
-
 def is_alpha(character):
     reg = "^[A-Za-z]{1}$"  # valid prefix
     return re.search(reg, character)
-
-
-def parse_links(links):
-    pagination_links = {
-        "prev": None,
-        "next": None
-    }
-
-    if 'prev' in links:
-        pagination_links['prev'] = parse_qs(urlparse(links['prev']).query)
-    if 'next' in links:
-        pagination_links['next'] = parse_qs(urlparse(links['next']).query)
-
-    return pagination_links
 
 
 @main.route('/g-cloud/suppliers')

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -4,7 +4,7 @@ from app.main import main
 from flask import render_template, request, abort
 from app import data_api_client
 from dmapiclient import APIError
-from ...helpers.shared_helpers import process_page, parse_links
+from ...helpers.shared_helpers import process_page, parse_link
 import re
 
 try:
@@ -48,8 +48,8 @@ def suppliers_list_by_prefix():
                                suppliers=suppliers,
                                nav=ascii_uppercase,
                                count=len(suppliers),
-                               prev_link=parse_links(links)['prev'],
-                               next_link=parse_links(links)['next'],
+                               prev_link=parse_link(links, 'prev'),
+                               next_link=parse_link(links, 'next'),
                                prefix=template_prefix
                                )
     except APIError as e:

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -4,7 +4,7 @@ from app.main import main
 from flask import render_template, request, abort
 from app import data_api_client
 from dmapiclient import APIError
-from ...helpers.shared_helpers import process_page, parse_link
+from ...helpers.shared_helpers import parse_link
 import re
 
 try:
@@ -37,7 +37,7 @@ def suppliers_list_by_prefix():
     template_prefix = process_prefix(
         prefix=request.args.get('prefix', default=u"A"),
         format='view')
-    page = process_page(request.args.get('page', default=u"1"))
+    page = request.args.get('page', default=1, type=int)
 
     try:
         api_result = data_api_client.find_suppliers(api_prefix, page, 'g-cloud')

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -16,4 +16,14 @@
   {% endcall %}
 {% endcall %}
 
-<a href="/suppliers/opportunities/{{ brief.id }}/ask-a-question">Log in to ask a question</a>
+{% if brief.status == 'live' and not brief.clarificationQuestionsAreClosed %}
+  <a href="/suppliers/opportunities/{{ brief.id }}/ask-a-question">
+    {% if current_user.is_authenticated() and current_user.role == 'supplier' %}
+      Ask a question
+    {% else %}
+      Log in to ask a question
+    {% endif %}
+  </a>
+{% elif brief.status == 'live' %}
+  The deadline for asking clarification questions was {{ brief.clarificationQuestionsClosedAt|dateformat }}.
+{% endif %}

--- a/app/templates/_briefs_list.html
+++ b/app/templates/_briefs_list.html
@@ -1,0 +1,34 @@
+{% for brief in briefs %}
+<div class="search-result">
+    <h2 class="search-result-title">
+        <a href="{{ url_for('.get_brief_by_id', framework_slug=framework.slug, brief_id=brief.id) }}">{{ brief.title }}</a>
+    </h2>
+    
+    <ul class="search-result-important-metadata">
+        <li class="search-result-metadata-item">
+            {{ brief.organisation }}
+        </li>
+        <li class="search-result-metadata-item">
+            {{ brief.location }}
+        </li>
+    </ul>
+    
+    <ul class="search-result-metadata">
+        <li class="search-result-metadata-item">
+            {{ brief.lotName }}
+        </li>
+        <li class="search-result-metadata-item">
+            {% if brief.status == 'closed' %}
+                Closed
+            {% else %}
+                Closing: {{ brief.applicationsClosedAt|dateformat }}
+            {% endif %}
+        </li>
+    </ul>
+    
+    <p class="search-result-excerpt">
+        {{ brief.backgroundInformation }}
+    </p>
+</div>
+
+{% endfor %}

--- a/app/templates/_briefs_pagination.html
+++ b/app/templates/_briefs_pagination.html
@@ -1,0 +1,19 @@
+<nav role="navigation">
+  <ul class="previous-next-navigation">
+    {% if prev_link %}
+      <li class="previous">
+          <a href="{{ url_for('.list_opportunities', framework_slug=framework.slug, page=prev_link['page']) }}">
+              Previous <span class="visuallyhidden">page</span>
+          </a>
+      </li>
+    {% endif %}
+
+    {% if next_link %}
+      <li class="next">
+          <a href="{{ url_for('.list_opportunities', framework_slug=framework.slug, page=next_link['page']) }}">
+              Next <span class="visuallyhidden">page</span>
+          </a>
+      </li>
+    {% endif %}
+  </ul>
+</nav>

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -18,6 +18,22 @@
 {% endblock %}
 
 {% block main_content %}
+
+{% if brief.status == 'closed' %}
+<div class="grid-row">
+  <div class="column-one-whole">
+    {%
+      with
+      type = "temporary-message",
+      heading = "This opportunity is closed for applications.",
+      message = "The deadline was {}.".format(brief.clarificationQuestionsClosedAt|dateformat)|safe
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  </div>
+</div>
+{% endif %}
+
 <div class="grid-row">
   <div class="column-two-thirds">
     <header class="page-heading-smaller">
@@ -36,6 +52,8 @@
     {% include '_brief_q_and_a.html' %}
   </div>
 </div>
+
+{% if brief.status == 'live' %}
 <div class="grid-row">
   <div class="column-one-whole">
     {% with 
@@ -46,4 +64,5 @@
     {% endwith %}
   </div>
 </div>
+{% endif %}
 {% endblock %}

--- a/app/templates/briefs_catalogue.html
+++ b/app/templates/briefs_catalogue.html
@@ -1,0 +1,32 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+    Supplier opportunities – {{ framework.name }} – Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+    {% with items = [
+        {
+        "link": url_for('.index'),
+        "label": "Digital Marketplace"
+        }
+    ]
+    %}
+    {% include "toolkit/breadcrumb.html" %}
+    {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+    {% with heading="Supplier opportunities" %}
+        {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+    
+    <div class="grid-row">
+        <section class="column-two-thirds">
+            {% include '_briefs_list.html' %}
+            {% include '_briefs_pagination.html' %}
+        </section>
+    </div>
+
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -91,29 +91,63 @@
     {% endwith %}
   </div>
     <div class="supplier-messages column-one-third">
-      {% if temporary_message or current_user.role == 'supplier' %}
-        <aside role="complementary" aria-labelledby="supplier-message-heading">
+      <aside role="complementary" aria-labelledby="supplier-message-heading">
+        
+      {% if temporary_message or current_user.role == 'supplier' or dos_is_live %}
           <h2 id="supplier-message-heading">Sell services</h2>
-          {% if temporary_message %}
-            {%
-              with
-                heading = temporary_message.heading,
-                subheading = temporary_message.subheading,
-                messages = temporary_message.messages,
-                message = temporary_message.message
-            %}
-              {% include "toolkit/{}.html".format(temporary_message.template_name) %}
-            {% endwith %}
-          {% endif %}
-          {% if current_user.role == 'supplier' %}
-            <p>
-              <a href="/suppliers" class="top-level-link">
-                View your services and account details
-              </a>
-            </p>
-          {% endif %}
-        </aside>
       {% endif %}
+        
+      {% if temporary_message %}
+        {%
+          with
+            heading = temporary_message.heading,
+            subheading = temporary_message.subheading,
+            messages = temporary_message.messages,
+            message = temporary_message.message
+        %}
+          {% include "toolkit/{}.html".format(temporary_message.template_name) %}
+        {% endwith %}
+      {% endif %}
+        
+      {% if dos_is_live %}
+        <div class="padding-bottom-small">
+          <p>
+            <a href="/digital-outcomes-and-specialists/opportunities" class="top-level-link">
+              View supplier opportunities
+            </a>
+          </p>
+          <p>Find published requirements for:</p>
+          <ul class="list-bullet">
+            <li>digital specialists</li>
+            <li>digital outcomes</li>
+            <li>user research participant recruitment</li>
+          </ul>  
+        </div>
+        
+        {% if current_user.role != 'supplier' %}
+        <div class="padding-bottom-small">
+          <p>
+            <a href="/suppliers/create" class="top-level-link">
+              Create a supplier account
+            </a>
+          </p>
+          <p>Receive updates about opportunities to sell on the Digital Marketplace.</p>
+        </div>
+        {% endif %}
+        
+      {% endif %}
+        
+      {% if current_user.role == 'supplier' %}
+        <div class="padding-bottom-small">
+          <p>
+            <a href="/suppliers" class="top-level-link">
+              View your services and account information
+            </a>
+          </p>
+        </div>
+      {% endif %}
+        
+      </aside>
     </div>
 </div>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -116,12 +116,14 @@
               View supplier opportunities
             </a>
           </p>
-          <p>Find published requirements for:</p>
-          <ul class="list-bullet">
-            <li>digital specialists</li>
-            <li>digital outcomes</li>
-            <li>user research participant recruitment</li>
-          </ul>  
+          <div class="explanation-list">
+            <p class="lead">Find published requirements for:</p>
+            <ul class="list-bullet">
+              <li>digital specialists</li>
+              <li>digital outcomes</li>
+              <li>user research participant recruitment</li>
+            </ul>  
+          </div>
         </div>
         
         {% if current_user.role != 'supplier' %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.4.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.5.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.20.2"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ inflection==0.2.1
 werkzeug==0.10.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@19.0.0#egg=digitalmarketplace-utils==19.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.4.0#egg=digitalmarketplace-apiclient==3.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.4.1#egg=digitalmarketplace-apiclient==3.4.1

--- a/tests/app/views/test_suppliers.py
+++ b/tests/app/views/test_suppliers.py
@@ -26,7 +26,7 @@ class TestSuppliersPage(BaseApplicationTest):
 
     def test_should_call_api_with_correct_params(self):
         self.client.get('/g-cloud/suppliers')
-        self._data_api_client.find_suppliers.assert_called_once_with('A', '1', 'g-cloud')
+        self._data_api_client.find_suppliers.assert_called_once_with('A', 1, 'g-cloud')
 
     def test_should_show_suppliers_prefixed_by_a_default(self):
         res = self.client.get('/g-cloud/suppliers')
@@ -37,7 +37,7 @@ class TestSuppliersPage(BaseApplicationTest):
 
     def test_should_show_suppliers_prefixed_by_a_param(self):
         res = self.client.get('/g-cloud/suppliers?prefix=M')
-        self._data_api_client.find_suppliers.assert_called_once_with('M', '1', 'g-cloud')
+        self._data_api_client.find_suppliers.assert_called_once_with('M', 1, 'g-cloud')
         assert_equal(200, res.status_code)
         assert_true(
             self._strip_whitespace('<li class="selected"><span class="visuallyhidden">Suppliers starting with </span><strong>M</strong></li>')  # noqa
@@ -52,7 +52,7 @@ class TestSuppliersPage(BaseApplicationTest):
 
     def test_should_use_default_if_invalid(self):
         res = self.client.get('/g-cloud/suppliers?prefix=+')
-        self._data_api_client.find_suppliers.assert_called_once_with('A', '1', 'g-cloud')
+        self._data_api_client.find_suppliers.assert_called_once_with('A', 1, 'g-cloud')
 
         assert_equal(200, res.status_code)
         assert_true(
@@ -61,7 +61,7 @@ class TestSuppliersPage(BaseApplicationTest):
 
     def test_should_use_default_if_multichar_prefix(self):
         res = self.client.get('/g-cloud/suppliers?prefix=Prefix')
-        self._data_api_client.find_suppliers.assert_called_once_with('A', '1', 'g-cloud')
+        self._data_api_client.find_suppliers.assert_called_once_with('A', 1, 'g-cloud')
 
         assert_equal(200, res.status_code)
 
@@ -71,7 +71,7 @@ class TestSuppliersPage(BaseApplicationTest):
 
     def test_should_use_number_range_prefix(self):
         res = self.client.get('/g-cloud/suppliers?prefix=other')
-        self._data_api_client.find_suppliers.assert_called_once_with(u'other', '1', 'g-cloud')
+        self._data_api_client.find_suppliers.assert_called_once_with(u'other', 1, 'g-cloud')
 
         assert_equal(200, res.status_code)
         assert_true(
@@ -168,7 +168,7 @@ class TestSuppliersPage(BaseApplicationTest):
     def test_should_show_next_nav_on_supplier_list(self):
         self._data_api_client.find_suppliers.return_value = self.suppliers_by_prefix_page_2  # noqa
         res = self.client.get('/g-cloud/suppliers?page=2')
-        self._data_api_client.find_suppliers.assert_called_once_with('A', '2', 'g-cloud')
+        self._data_api_client.find_suppliers.assert_called_once_with('A', 2, 'g-cloud')
 
         assert_equal(200, res.status_code)
         html_tag = '<li class="previous">'

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -1,0 +1,88 @@
+{
+  "briefs":[
+    {
+      "clarificationQuestionsAreClosed":true,
+      "status":"live",
+      "frameworkFramework":"dos",
+      "links":{
+        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists",
+        "self":"http://localhost:5000/briefs/17"
+      },
+      "clarificationQuestionsClosedAt":"2016-03-17T00:00:00.000000Z",
+      "frameworkStatus":"live",
+      "title":"I need Research Participants",
+      "organisation":"GDS",
+      "lotSlug":"user-research-participants",
+      "frameworkSlug":"digital-outcomes-and-specialists",
+      "applicationsClosedAt":"2016-03-24T00:00:00.000000Z",
+      "lotName":"User research participants",
+      "clarificationQuestions":[
+
+      ],
+      "backgroundInformation":"Here is the first requirements summary.",
+      "frameworkName":"Digital Outcomes and Specialists",
+      "location":"International (outside the UK)",
+      "lot":"user-research-participants",
+      "updatedAt":"2016-03-09T15:56:32.487141Z",
+      "publishedAt":"2016-03-09T16:02:51.591567Z",
+      "id":17,
+      "createdAt":"2016-03-09T15:23:48.328413Z"
+    },
+    {
+      "startDate":"29th March",
+      "links":{
+        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists",
+        "self":"http://localhost:5000/briefs/4"
+      },
+      "evaluationType":[
+        "provide a case study or evidence of previous work",
+        "presentation"
+      ],
+      "niceToHaveRequirements":[
+        "Nice people"
+      ],
+      "applicationsClosedAt":"2016-03-22T00:00:00.000000Z",
+      "essentialRequirements":[
+        "Can provide an outcome",
+        "Available from 29h March"
+      ],
+      "backgroundInformation":"We'd like to build a thing to do athing.",
+      "updatedAt":"2016-02-16T14:04:22.617017Z",
+      "id":4,
+      "createdAt":"2016-02-12T16:30:55.808730Z",
+      "clarificationQuestionsAreClosed":true,
+      "frameworkFramework":"dos",
+      "clarificationQuestionsClosedAt":"2016-03-15T00:00:00.000000Z",
+      "lotSlug":"digital-specialists",
+      "workingArrangements":"Work",
+      "organisation":"GDS",
+      "frameworkStatus":"live",
+      "lotName":"Digital specialists",
+      "location":"East of England",
+      "lot":"digital-specialists",
+      "status":"live",
+      "specialistRole":"business_analyst",
+      "importantDates":"29th March",
+      "contractLength":"3 Months",
+      "currentTechnologies":"Business Focus Plus",
+      "clarificationQuestions":[
+        {
+          "answer":"Because",
+          "question":"Why?",
+          "publishedAt":"2016-03-04T09:19:42.138442Z"
+        }
+      ],
+      "title":"Another requirement",
+      "frameworkSlug":"digital-outcomes-and-specialists",
+      "additionalTerms":"You'll never work in this town again.",
+      "frameworkName":"Digital Outcomes and Specialists",
+      "publishedAt":"2016-03-07T16:02:51.591567Z"
+    }
+  ],
+  "links":{
+    "prev":"http://localhost:5000/briefs?status=live%2Cclosed&framework=digital-outcomes-and-specialists&page=1",
+    "self":"http://localhost:5000/briefs?status=live%2Cclosed&framework=digital-outcomes-and-specialists&page=2",
+    "last":"http://localhost:5000/briefs?status=live%2Cclosed&framework=digital-outcomes-and-specialists&page=4",
+    "next":"http://localhost:5000/briefs?status=live%2Cclosed&framework=digital-outcomes-and-specialists&page=3"
+  }
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -86,8 +86,11 @@ class BaseApplicationTest(object):
         return BaseApplicationTest._get_fixture_data('g6_service_fixture.json')
 
     @staticmethod
-    def _get_dos_brief_fixture_data():
-        return BaseApplicationTest._get_fixture_data('dos_brief_fixture.json')
+    def _get_dos_brief_fixture_data(multi=False):
+        if multi:
+            return BaseApplicationTest._get_fixture_data('dos_multiple_briefs_fixture.json')
+        else:
+            return BaseApplicationTest._get_fixture_data('dos_brief_fixture.json')
 
     @staticmethod
     def _get_supplier_fixture_data():


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/114207705
Depends on:
 - [x] https://github.com/alphagov/digitalmarketplace-apiclient/pull/20

This adds a public catalogue of briefs page at `/digital-outcomes-and-specialists/opportunities`.

All briefs are listed in reverse order of publication date, both live and closed briefs:

![screen shot 2016-03-17 at 12 20 19](https://cloud.githubusercontent.com/assets/6525554/13845941/56dda8be-ec3b-11e5-9e1b-cae6ad530abd.png)

The view-an-individual-brief page has been modified to show a banner on closed briefs, and to remove the `clarification question` and `apply` links once clarifications and/or applications are closed:

![screen shot 2016-03-17 at 12 27 32](https://cloud.githubusercontent.com/assets/6525554/13845991/ae0c30ce-ec3b-11e5-8071-d07d9ab5c271.png)

Homepage sidebar links are also updated, see below.

LOGGED-IN, DOS LIVE:

![screen shot 2016-03-17 at 16 56 54](https://cloud.githubusercontent.com/assets/6525554/13854057/8c2fbd9c-ec61-11e5-92ae-9ed187ff05f3.png)

LOGGED-OUT, DOS LIVE:

![screen shot 2016-03-17 at 16 57 09](https://cloud.githubusercontent.com/assets/6525554/13854061/8f78f982-ec61-11e5-883c-d545db5293d8.png)
