### PR TITLE
Add brief clarification question numbers

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -206,6 +206,11 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
 
             flattened_brief.append(question)
 
+    brief['clarificationQuestions'] = [
+        dict(question, number=index+1)
+        for index, question in enumerate(brief['clarificationQuestions'])
+    ]
+
     return render_template(
         "buyers/brief_summary.html",
         framework=framework,

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -65,6 +65,11 @@ def get_brief_by_id(framework_slug, brief_id):
     if brief['status'] not in ['live', 'closed']:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
 
+    brief['clarificationQuestions'] = [
+        dict(question, number=index+1)
+        for index, question in enumerate(brief['clarificationQuestions'])
+    ]
+
     brief_content = content_loader.get_builder('digital-outcomes-and-specialists', 'display_brief').filter(
         brief
     )

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -11,7 +11,10 @@
     empty_message="No questions have been answered yet"
 ) %}
   {% call summary.row() %}
-    {{ summary.field_name(question.question) }}
+    {% call summary.field(first=True, wide=False) -%} 
+      <span aria-label="question">{{ question.number }}.</span>
+      {{ question.question }}
+    {%- endcall %}
     {{ summary.text(question.answer) }}
   {% endcall %}
 {% endcall %}

--- a/app/templates/buyers/_base_brief_summary_page.html
+++ b/app/templates/buyers/_base_brief_summary_page.html
@@ -82,7 +82,10 @@
       ) %}
 
         {% call summary.row() %}
-          {{ summary.field_name(question.question) }}
+          {% call summary.field(first=True, wide=False) -%} 
+            <span aria-label="question">{{ question.number }}.</span>
+            {{ question.question }}
+          {%- endcall %}
           {{ summary.text(question.answer) }}
         {% endcall %}
       {% endcall %}

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -345,14 +345,16 @@ class TestBriefPage(BaseApplicationTest):
         xpath = '//h2[@id="clarification-questions"]/following-sibling::table/tbody/tr'
         clarification_questions = document.xpath(xpath)
 
-        question = clarification_questions[0].xpath('td[1]/span/text()')
-        answer = clarification_questions[0].xpath('td[2]/span/text()')
+        number = clarification_questions[0].xpath('td[1]/span/span/text()')[0].strip()
+        question = clarification_questions[0].xpath('td[1]/span/text()')[0].strip()
+        answer = clarification_questions[0].xpath('td[2]/span/text()')[0].strip()
         qa_link_text = document.xpath('//a[@href="/suppliers/opportunities/{}/ask-a-question"]/text()'
-                                      .format(brief_id))[0]
+                                      .format(brief_id))[0].strip()
 
-        assert_equal(question[0], "Why?")
-        assert_equal(answer[0], "Because")
-        assert_equal(qa_link_text.strip(), "Log in to ask a question")
+        assert_equal(number, "1.")
+        assert_equal(question, "Why?")
+        assert_equal(answer, "Because")
+        assert_equal(qa_link_text, "Log in to ask a question")
 
     def test_dos_brief_has_different_link_text_for_logged_in_supplier(self):
         self.login_as_supplier()


### PR DESCRIPTION
[#115944077](https://www.pivotaltracker.com/story/show/115944077)

Numbers are needed in the buyer and public view of the clarification questions so that later questions can easily refer to earlier questions.

The fact that summary tables are done with macros makes it more difficult to just use Jinja2's `loop.counter` variable. The simplest way of getting a counter actually seems to be to pass it in to the template. While this number could be generated in the API it is just for display, ideally it would be generated in the view but that is not easy because of how we use macros.