### PR TITLE
[#114083869] Buyer views responses to a brief

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -21,6 +21,7 @@ $path: "/static/images/";
 @import "toolkit/_document.scss";
 @import "toolkit/_framework-notice.scss";
 @import "toolkit/_grids.scss";
+@import "toolkit/_instruction-list.scss";
 @import "toolkit/_link-button.scss";
 @import "toolkit/_notification-banners.scss";
 @import "toolkit/_page-headings.scss";

--- a/app/buyers/__init__.py
+++ b/app/buyers/__init__.py
@@ -6,6 +6,7 @@ buyers = Blueprint('buyers', __name__)
 
 content_loader = ContentLoader('app/content')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'briefs', 'edit_brief')
+content_loader.load_manifest('digital-outcomes-and-specialists', 'brief-responses', 'output_brief_response')
 content_loader.load_manifest('digital-outcomes-and-specialists', 'clarification_question', 'clarification_question')
 
 

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -11,7 +11,7 @@ from ...helpers.buyers_helpers import (
     count_suppliers_on_lot, get_framework_and_lot, is_brief_associated_with_user,
     count_unanswered_questions, brief_can_be_edited, add_unanswered_counts_to_briefs,
     clarification_questions_open, add_response_counts_to_briefs, counts_for_failed_and_eligible_brief_responses,
-    all_essentials_are_true)
+    all_essentials_are_true, get_sorted_responses_for_brief)
 
 from dmapiclient import HTTPError
 
@@ -256,12 +256,7 @@ def download_brief_responses(framework_slug, lot_slug, brief_id):
     if brief['status'] != "closed":
         abort(404)
 
-    brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
-    # Sort responses with those with the most nice-to-have requirements nearest the top
-    sorted_brief_responses = sorted(brief_responses,
-                                    key=lambda k: len([nice for nice in k['niceToHaveRequirements'] if nice is True]),
-                                    reverse=True
-                                    )
+    sorted_brief_responses = get_sorted_responses_for_brief(brief_id, data_api_client)
 
     content = content_loader.get_manifest(framework['slug'], 'output_brief_response').filter({'lot': lot['slug']})
     section = content.get_section('view-response-to-requirements')

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -181,8 +181,7 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id):
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>', methods=['GET'])
 def view_brief_summary(framework_slug, lot_slug, brief_id):
 
-    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
-                                           status='live', must_allow_brief=True)
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client, must_allow_brief=True)
 
     brief = data_api_client.get_brief(brief_id)["briefs"]
     if not is_brief_associated_with_user(brief, current_user.id):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -10,7 +10,8 @@ from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
     count_suppliers_on_lot, get_framework_and_lot, is_brief_associated_with_user,
     count_unanswered_questions, brief_can_be_edited, add_unanswered_counts_to_briefs,
-    clarification_questions_open, add_response_counts_to_briefs, classify_and_count_brief_responses)
+    clarification_questions_open, add_response_counts_to_briefs, classify_and_count_brief_responses,
+    all_essentials_are_true)
 
 from dmapiclient import HTTPError
 
@@ -274,15 +275,16 @@ def download_brief_responses(framework_slug, lot_slug, brief_id):
             column_headings.append(question.name)
     csv_rows.append(column_headings)
 
-    # Add a row for each response received
+    # Add a row for each eligible response received
     for brief_response in brief_responses:
-        row = []
-        for key in question_key_sequence:
-            if key in boolean_list_questions:
-                row.extend(brief_response.get(key))
-            else:
-                row.append(brief_response.get(key))
-        csv_rows.append(row)
+        if all_essentials_are_true(brief_response):
+            row = []
+            for key in question_key_sequence:
+                if key in boolean_list_questions:
+                    row.extend(brief_response.get(key))
+                else:
+                    row.append(brief_response.get(key))
+            csv_rows.append(row)
 
     def iter_csv(rows):
         class Line(object):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -10,7 +10,7 @@ from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
     count_suppliers_on_lot, get_framework_and_lot, is_brief_associated_with_user,
     count_unanswered_questions, brief_can_be_edited, add_unanswered_counts_to_briefs,
-    clarification_questions_open, add_response_counts_to_briefs, classify_and_count_brief_responses,
+    clarification_questions_open, add_response_counts_to_briefs, counts_for_failed_and_eligible_brief_responses,
     all_essentials_are_true)
 
 from dmapiclient import HTTPError
@@ -234,7 +234,7 @@ def view_brief_responses(framework_slug, lot_slug, brief_id):
     if not is_brief_associated_with_user(brief, current_user.id):
         abort(404)
 
-    failed_count, eligible_count = classify_and_count_brief_responses(brief["id"], data_api_client)
+    failed_count, eligible_count = counts_for_failed_and_eligible_brief_responses(brief["id"], data_api_client)
 
     return render_template(
         "buyers/brief_responses.html",

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -6,8 +6,7 @@ from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
     count_suppliers_on_lot, get_framework_and_lot, is_brief_associated_with_user,
     count_unanswered_questions, brief_can_be_edited, add_unanswered_counts_to_briefs,
-    clarification_questions_open
-)
+    clarification_questions_open, add_response_counts_to_briefs)
 
 from dmapiclient import HTTPError
 
@@ -17,11 +16,16 @@ def buyer_dashboard():
     user_briefs = data_api_client.find_briefs(current_user.id).get('briefs', [])
     draft_briefs = add_unanswered_counts_to_briefs([brief for brief in user_briefs if brief['status'] == 'draft'])
     live_briefs = [brief for brief in user_briefs if brief['status'] == 'live']
+    closed_briefs = add_response_counts_to_briefs(
+        [brief for brief in user_briefs if brief['status'] == 'closed'],
+        data_api_client
+    )
 
     return render_template(
         'buyers/dashboard.html',
         draft_briefs=draft_briefs,
-        live_briefs=live_briefs
+        live_briefs=live_briefs,
+        closed_briefs=closed_briefs
     )
 
 

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -70,3 +70,19 @@ def add_response_counts_to_briefs(briefs, data_api_client):
 def clarification_questions_open(brief):
     # TODO: Implement this properly
     return True
+
+
+def classify_and_count_brief_responses(brief_id, data_api_client):
+    brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
+    failed_count = 0
+    eligible_count = 0
+    for brief_response in brief_responses:
+        if _all_essentials_are_true(brief_response):
+            eligible_count += 1
+        else:
+            failed_count += 1
+    return failed_count, eligible_count
+
+
+def _all_essentials_are_true(brief_response):
+    return len([essential for essential in brief_response['essentialRequirements'] if essential is False]) == 0

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -77,12 +77,12 @@ def classify_and_count_brief_responses(brief_id, data_api_client):
     failed_count = 0
     eligible_count = 0
     for brief_response in brief_responses:
-        if _all_essentials_are_true(brief_response):
+        if all_essentials_are_true(brief_response):
             eligible_count += 1
         else:
             failed_count += 1
     return failed_count, eligible_count
 
 
-def _all_essentials_are_true(brief_response):
+def all_essentials_are_true(brief_response):
     return len([essential for essential in brief_response['essentialRequirements'] if essential is False]) == 0

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -86,3 +86,11 @@ def counts_for_failed_and_eligible_brief_responses(brief_id, data_api_client):
 
 def all_essentials_are_true(brief_response):
     return all(brief_response['essentialRequirements'])
+
+
+def get_sorted_responses_for_brief(brief_id, data_api_client):
+    brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
+    return sorted(brief_responses,
+                  key=lambda k: len([nice for nice in k['niceToHaveRequirements'] if nice is True]),
+                  reverse=True
+                  )

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -85,4 +85,4 @@ def classify_and_count_brief_responses(brief_id, data_api_client):
 
 
 def all_essentials_are_true(brief_response):
-    return len([essential for essential in brief_response['essentialRequirements'] if essential is False]) == 0
+    return all(brief_response['essentialRequirements'])

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -59,6 +59,14 @@ def add_unanswered_counts_to_briefs(briefs):
     return briefs
 
 
+def add_response_counts_to_briefs(briefs, data_api_client):
+    for brief in briefs:
+        responses = data_api_client.find_brief_responses(brief_id=brief['id'])
+        brief['responses_count'] = len(responses)
+
+    return briefs
+
+
 def clarification_questions_open(brief):
     # TODO: Implement this properly
     return True

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -61,7 +61,7 @@ def add_unanswered_counts_to_briefs(briefs):
 
 def add_response_counts_to_briefs(briefs, data_api_client):
     for brief in briefs:
-        responses = data_api_client.find_brief_responses(brief_id=brief['id'])
+        responses = data_api_client.find_brief_responses(brief_id=brief['id'])["briefResponses"]
         brief['responses_count'] = len(responses)
 
     return briefs

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -72,7 +72,7 @@ def clarification_questions_open(brief):
     return True
 
 
-def classify_and_count_brief_responses(brief_id, data_api_client):
+def counts_for_failed_and_eligible_brief_responses(brief_id, data_api_client):
     brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
     failed_count = 0
     eligible_count = 0

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -90,7 +90,8 @@ def all_essentials_are_true(brief_response):
 
 def get_sorted_responses_for_brief(brief_id, data_api_client):
     brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
-    return sorted(brief_responses,
-                  key=lambda k: len([nice for nice in k['niceToHaveRequirements'] if nice is True]),
-                  reverse=True
-                  )
+    return sorted(
+        brief_responses,
+        key=lambda k: len([nice for nice in k['niceToHaveRequirements'] if nice is True]),
+        reverse=True
+    )

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -36,14 +36,24 @@
 <div class="grid-row">
     <div class="column-two-thirds">
         <div class="marketplace-paragraph">
-            <p>{{ responses_count }} supplier{% if responses_count != 1 %}s{% endif %} responded to your requirements. 
-                Of these, {{ response_counts['eligible'] }} meet all your essential requirements. 
-                
-                {% if response_counts['eligible'] > 0 %}
-                    You now need to respond to these eligible suppliers. 
-                    (Suppliers that did not meet all your essential requirements have already been told that they were unsuccessful.)
-                {% endif %}
-            </p>
+          <p>
+          {% if responses_count ==  1 %}
+              {{ responses_count }} supplier responded to your requirements.
+              They did {% if response_counts['eligible'] == 0 %} not{% endif %} meet all your essential requirements.
+          {% else %}
+              {{ responses_count }} suppliers responded to your requirements.
+              Of these, {{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential requirements.
+          {% endif %}
+
+          {% if response_counts['eligible'] > 0 %}
+            {% if response_counts['eligible'] == 1 %}
+              You now need to respond to this eligible supplier.
+            {% else %}
+              You now need to respond to these eligible suppliers.
+            {% endif %}
+              (Suppliers that did not meet all your essential requirements have already been told that they were unsuccessful.)
+          {% endif %}
+          </p>
         </div>
 
         {% if response_counts['eligible'] > 0 %}

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -19,6 +19,8 @@
     {% endwith %}
 {% endblock %}
 
+{% set responses_count = response_counts['failed'] + response_counts['eligible'] %}
+
 {% block main_content %}
 <div class="grid-row">
     <div class="column-two-thirds">
@@ -34,7 +36,7 @@
 <div class="grid-row">
     <div class="column-two-thirds">
         <div class="marketplace-paragraph">
-            <p>{{ response_counts['failed'] + response_counts['eligible'] }} suppliers responded to your requirements. 
+            <p>{{ responses_count }} supplier{% if responses_count != 1 %}s{% endif %} responded to your requirements. 
                 Of these, {{ response_counts['eligible'] }} meet all your essential requirements. 
                 
                 {% if response_counts['eligible'] > 0 %}

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -1,0 +1,93 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Responses to {{ brief_data.title or brief_data.lotName }} – Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+    {%
+        with items = [
+        {
+            "link": "/",
+            "label": "Digital Marketplace"
+        },
+        {
+            "link": "/buyers",
+            "label": "Your Requirements"
+        }
+        ]
+    %}
+        {% include "toolkit/breadcrumb.html" %}
+    {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+<div class="grid-row">
+    <div class="column-two-thirds">
+        {% with
+        heading = ("Responses to &lsquo;" + brief_data.get('title', brief_data['lotName']) + "&rsquo;")|safe,
+        smaller = true
+        %}
+        {% include "toolkit/page-heading.html" %}
+        {% endwith %}
+    </div>
+</div>
+
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <div class="marketplace-paragraph">
+            <p>{{ response_counts['failed'] + response_counts['eligible'] }} suppliers responded to your requirements. 
+                Of these, {{ response_counts['eligible'] }} meet all your essential requirements. 
+                
+                {% if response_counts['eligible'] > 0 %}
+                    You now need to respond to these eligible suppliers. 
+                    (Suppliers that did not meet all your essential requirements have already been told that they were unsuccessful.)
+                {% endif %}
+            </p>
+        </div>
+
+        {% if response_counts['eligible'] > 0 %}
+            {%
+            with
+            items = [
+                {
+                "body": "Download the file of responses from eligible suppliers:",
+                "documents": [
+                {
+                    "title": ("Supplier responses to &lsquo;" + brief_data.get('title', brief_data['lotName']) + "&rsquo;")|safe,
+                    "link": url_for('buyers.download_brief_responses', framework_slug=framework.slug, lot_slug=lot.slug, brief_id=brief_data.id),
+                    "file_type": "CSV",
+                    "download": "True"
+                }
+                ]
+                } if brief_data.get("status") == "closed"
+                  else { "body": "Download the file of responses from eligible suppliers (it will be available here once applications have closed)." },
+                {
+                "body": "Sort the eligible suppliers by availabilty, price and whatever other factors you specified in the brief.",
+                "extra": "The file is already sorted with suppliers with the most nice-to-haves at the top."
+                },
+                {
+                "body": "Pick your favourite that you're going to award the contract to"
+                },
+                {
+                "body": "Send emails to all the eligible suppliers",
+                "important": "You must respond to all suppliers listed to let them know if they were successful or not"
+                }
+            ]
+            %}
+                {% include "toolkit/instruction-list.html" %}
+            {% endwith %}
+        
+        {% else %}
+        
+        <div class="marketplace-paragraph">
+            <p>
+                You did not receive any eligible responses so you'll have to try again.
+            </p>
+            <p>
+                MASSIVE TODO: DON'T FORGET TO GET NEW COPY FOR THIS PART OF THE PAGE TOO.
+            </p>
+        </div>
+        
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -117,7 +117,7 @@
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.applicationsClosedAt|dateformat) }}
-        {{ summary.text("{} responses".format(item.responses_count)) }}
+        {{ summary.link("{} responses".format(item.responses_count), url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}
 {% endblock %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -89,6 +89,7 @@
     field_headings=[
     "Brief name",
     "Published",
+    "Closing",
     ],
     field_headings_visible=True
 ) %}
@@ -96,7 +97,27 @@
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.publishedAt|dateformat) }}
+        {{ summary.text(item.applicationsClosedAt|dateformat) }}
     {% endcall %}
 {% endcall %}
+        
+{{ summary.heading("Closed requirements", id="closed_requirements") }}
+{% call(item) summary.list_table(
+    closed_briefs,
+    caption="Closed requirements caption",
+    empty_message="You don’t have any requirements that are closed",
+    field_headings=[
+    "Brief name",
+    "Closed",
+    "Number of responses",
+    ],
+    field_headings_visible=True
+) %}
 
+    {% call summary.row() %}
+        {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        {{ summary.text(item.applicationsClosedAt|dateformat) }}
+        {{ summary.text("{} responses".format(item.responses_count)) }}
+    {% endcall %}
+{% endcall %}
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.5.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.21.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.22.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.1.0#egg=digitalmarketplace-utils==19.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.3.0#egg=digitalmarketplace-utils==19.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.4.1#egg=digitalmarketplace-apiclient==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 inflection==0.2.1
+unicodecsv==0.14.1
 werkzeug==0.10.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@19.1.0#egg=digitalmarketplace-utils==19.1.0

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -785,24 +785,6 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "No clarification questions have been answered yet" not in page_html
             assert "Why is my question a question?" in page_html
 
-    def test_404_if_framework_is_not_live(self, data_api_client):
-        with self.app.app_context():
-            self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='pending',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                ]
-            )
-            data_api_client.get_brief.return_value = api_stubs.brief()
-
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1"
-            )
-
-            assert res.status_code == 404
-
     def test_404_if_framework_does_not_allow_brief(self, data_api_client):
         with self.app.app_context():
             self.login_as_buyer()

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -40,6 +40,38 @@ class TestBuyerDashboard(BaseApplicationTest):
             assert live_row[0] == "A live brief"
             assert live_row[1] == "Thursday 04 February 2016"
 
+    def test_closed_brief_response_count(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.find_briefs.return_value = {
+                "briefs": [
+                    {"status": "closed",
+                     "id": 12,
+                     "title": "A closed brief",
+                     "createdAt": "2016-02-01T00:00:00.000000Z",
+                     "publishedAt": "2016-02-04T12:00:00.000000Z",
+                     "frameworkSlug": "digital-outcomes-and-specialists"},
+                ]
+            }
+            data_api_client.find_brief_responses.return_value = {
+                "links": [],
+                "briefResponses": [
+                    {"empty": "empty"},
+                ]
+            }
+
+            res = self.client.get("/buyers")
+            document = html.fromstring(res.get_data(as_text=True))
+
+            assert res.status_code == 200
+
+            cell = document.xpath(
+                "//caption[contains(text(), 'Closed requirements')]"
+                "//following-sibling::tbody/tr[1]/td[last()]"
+            )[0]
+
+            assert "1 responses" in cell.text_content()
+
 
 @mock.patch('app.buyers.views.buyers.data_api_client')
 class TestStartNewBrief(BaseApplicationTest):

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -109,20 +109,20 @@ class TestBuyersHelpers(unittest.TestCase):
         }
         ]
 
-    def test__all_essentials_are_true(self):
-        assert helpers.buyers_helpers._all_essentials_are_true(
+    def test_all_essentials_are_true(self):
+        assert helpers.buyers_helpers.all_essentials_are_true(
             {"essentialRequirements": [True, True, True, True, True]}
         ) is True
 
-        assert helpers.buyers_helpers._all_essentials_are_true(
+        assert helpers.buyers_helpers.all_essentials_are_true(
             {"essentialRequirements": [True, True, False, True, True]}
         ) is False
 
-        assert helpers.buyers_helpers._all_essentials_are_true(
+        assert helpers.buyers_helpers.all_essentials_are_true(
             {"essentialRequirements": [False, False, False, False, False]}
         ) is False
 
-        assert helpers.buyers_helpers._all_essentials_are_true(
+        assert helpers.buyers_helpers.all_essentials_are_true(
             {"essentialRequirements": [True, True, True, True, False]}
         ) is False
 

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -149,6 +149,7 @@ class TestBuyersHelpers(unittest.TestCase):
                 {"id": "three", "niceToHaveRequirements": [True, True, False, False, True]},
                 {"id": "five", "niceToHaveRequirements": [True, True, True, True, True]},
                 {"id": "four", "niceToHaveRequirements": [True, True, True, True, False]},
+                {"id": "one", "niceToHaveRequirements": [False, False, False, True, False]},
                 {"id": "four", "niceToHaveRequirements": [True, True, True, True, False]},
             ]
         }
@@ -159,5 +160,6 @@ class TestBuyersHelpers(unittest.TestCase):
             {'id': 'four', 'niceToHaveRequirements': [True, True, True, True, False]},
             {'id': 'four', 'niceToHaveRequirements': [True, True, True, True, False]},
             {'id': 'three', 'niceToHaveRequirements': [True, True, False, False, True]},
+            {"id": "one", "niceToHaveRequirements": [False, False, False, True, False]},
             {'id': 'zero', 'niceToHaveRequirements': [False, False, False, False, False]}
         ]

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -139,3 +139,25 @@ class TestBuyersHelpers(unittest.TestCase):
         }
 
         assert helpers.buyers_helpers.counts_for_failed_and_eligible_brief_responses(1, data_api_client) == (3, 2)
+
+    def test_get_sorted_responses_for_brief(self):
+        data_api_client = mock.Mock()
+        data_api_client.find_brief_responses.return_value = {
+            "briefResponses": [
+                {"id": "five", "niceToHaveRequirements": [True, True, True, True, True]},
+                {"id": "zero", "niceToHaveRequirements": [False, False, False, False, False]},
+                {"id": "three", "niceToHaveRequirements": [True, True, False, False, True]},
+                {"id": "five", "niceToHaveRequirements": [True, True, True, True, True]},
+                {"id": "four", "niceToHaveRequirements": [True, True, True, True, False]},
+                {"id": "four", "niceToHaveRequirements": [True, True, True, True, False]},
+            ]
+        }
+
+        assert helpers.buyers_helpers.get_sorted_responses_for_brief(1, data_api_client) == [
+            {'id': 'five', 'niceToHaveRequirements': [True, True, True, True, True]},
+            {'id': 'five', 'niceToHaveRequirements': [True, True, True, True, True]},
+            {'id': 'four', 'niceToHaveRequirements': [True, True, True, True, False]},
+            {'id': 'four', 'niceToHaveRequirements': [True, True, True, True, False]},
+            {'id': 'three', 'niceToHaveRequirements': [True, True, False, False, True]},
+            {'id': 'zero', 'niceToHaveRequirements': [False, False, False, False, False]}
+        ]

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -126,7 +126,7 @@ class TestBuyersHelpers(unittest.TestCase):
             {"essentialRequirements": [True, True, True, True, False]}
         ) is False
 
-    def test_classify_and_count_brief_responses(self):
+    def test_counts_for_failed_and_eligible_brief_responses(self):
         data_api_client = mock.Mock()
         data_api_client.find_brief_responses.return_value = {
             "briefResponses": [
@@ -138,4 +138,4 @@ class TestBuyersHelpers(unittest.TestCase):
             ]
         }
 
-        assert helpers.buyers_helpers.classify_and_count_brief_responses(1, data_api_client) == (3, 2)
+        assert helpers.buyers_helpers.counts_for_failed_and_eligible_brief_responses(1, data_api_client) == (3, 2)

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -108,3 +108,34 @@ class TestBuyersHelpers(unittest.TestCase):
             'unanswered_optional': 2
         }
         ]
+
+    def test__all_essentials_are_true(self):
+        assert helpers.buyers_helpers._all_essentials_are_true(
+            {"essentialRequirements": [True, True, True, True, True]}
+        ) is True
+
+        assert helpers.buyers_helpers._all_essentials_are_true(
+            {"essentialRequirements": [True, True, False, True, True]}
+        ) is False
+
+        assert helpers.buyers_helpers._all_essentials_are_true(
+            {"essentialRequirements": [False, False, False, False, False]}
+        ) is False
+
+        assert helpers.buyers_helpers._all_essentials_are_true(
+            {"essentialRequirements": [True, True, True, True, False]}
+        ) is False
+
+    def test_classify_and_count_brief_responses(self):
+        data_api_client = mock.Mock()
+        data_api_client.find_brief_responses.return_value = {
+            "briefResponses": [
+                {"essentialRequirements": [True, True, True, True, True]},
+                {"essentialRequirements": [True, False, True, True, True]},
+                {"essentialRequirements": [True, True, False, False, True]},
+                {"essentialRequirements": [True, True, True, True, True]},
+                {"essentialRequirements": [True, True, True, True, False]},
+            ]
+        }
+
+        assert helpers.buyers_helpers.classify_and_count_brief_responses(1, data_api_client) == (3, 2)


### PR DESCRIPTION
Completes this story: https://www.pivotaltracker.com/story/show/114083869

Depends on new content:
- [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/213

Once that is merged it should all work. (At least everything works locally and all tests pass).

Things it does:
 * Adds closing date to live briefs on the buyer dashboard
 * Shows closed briefs on the buyer dashboard, along with the number of responses received these link to...
 * A new page where buyers can read instructions about what to do next and download a csv file of eligible responses:
![screen shot 2016-03-24 at 18 33 29](https://cloud.githubusercontent.com/assets/6525554/14027393/504a5cf4-f1ef-11e5-8a2b-1f341121c596.png)
 * The link to download the csv downloads a csv with a header row and then a row for each eligible response, sorted in order with the most nice-to-haves at the top of the file

Things that still would be nice to be done (please if someone can pick this up after Easter while I'm away):
 - [ ] Content of the brief responses page needs a serious overhaul (what's there is just a placeholder not proper at all) - I know @roz and @ralph-hawkins have plans for it.  If they have the words then should be an easy fix-up.
 - [x] Re-generate new schemas for the brief responses to include the new email field, and put them in the API (sorry, I forgot to do this right away because the story wasn't really about inputting responses)
    **DONE:** https://github.com/alphagov/digitalmarketplace-api/pull/372
 - [x] Validation of the new email address field - i.e. that it looks like a real email address (don't know if this can this be done in the generated schema - might need something custom).  If it isn't straightforward then I'd be tempted to leave it out of this story and add to Pivotal to do later (as this isn't really a story about inputting brief responses).
    **DONE:** https://github.com/alphagov/digitalmarketplace-frameworks/pull/215
 - [x] Generating the csv all the logic is all in one big lump in the view - it might be nice to break out one or two bits of logic (e.g. the sorting of responses) into helper methods that can be unit tested, but I haven't had time to do that.  **NOTE**: I lost a lot of time trying to push the logic of matching responses to "boolean list" questions to their respective questions back into the ContentLoader.  It was ugly and hard and while it seems like the best place for it at first, believe me I think we should just stick with doing it in the view (or a helper method if you like).  Unless you really want to get involved.  But I really advise against it.
 - [x] More tests for the csv - e.g. one with a bunch of all the stupid characters in (commas, single and double quotes, fancy quotes, etc.)
 - [x] Some of the failure modes for the new page and csv download aren't tested - would be nice to get some more tests in (e.g. different framework states, brief states, etc.)

So it's just a bit of tidying up really :) Good luck, and thanks x