### PR TITLE
Fix specialist role display on brief page

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -195,15 +195,6 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
     for section in sections:
         for question in section.questions:
             question.section_id = section.id
-
-            # Look up display values for options that have different labels from values
-            options = question.get('options')
-            if options and question.value:
-                for option in options:
-                    if 'label' in option and 'value' in option and option['value'] == question.value:
-                        question.display_value = option['label']
-                        break
-
             flattened_brief.append(question)
 
     brief['clarificationQuestions'] = [

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.5.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.20.2"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.21.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ Flask-WTF==0.12
 inflection==0.2.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.0.0#egg=digitalmarketplace-utils==19.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.1.0#egg=digitalmarketplace-utils==19.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.4.1#egg=digitalmarketplace-apiclient==3.4.1

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -661,7 +661,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
                 ]
             )
             brief_json = api_stubs.brief(status="draft")
-            brief_json['briefs']['specialistRole'] = 'communications_manager'
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
             data_api_client.get_brief.return_value = brief_json
 
             res = self.client.get(
@@ -680,7 +680,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             hint = document.cssselect('span.move-to-complete-hint')
             assert hint[0].text_content().strip() == "12 unanswered questions"
 
-            assert 'communications_manager' not in page_html
+            assert 'communicationsManager' not in page_html
             assert 'Communications manager' in page_html
 
             assert "Clarification questions" not in page_html
@@ -700,7 +700,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             )
             brief_json = api_stubs.brief(status="live")
             brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-            brief_json['briefs']['specialistRole'] = 'communications_manager'
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
             data_api_client.get_brief.return_value = brief_json
 
             clarification_questions_open.return_value = False
@@ -736,7 +736,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             )
             brief_json = api_stubs.brief(status="live")
             brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-            brief_json['briefs']['specialistRole'] = 'communications_manager'
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
             data_api_client.get_brief.return_value = brief_json
 
             clarification_questions_open.return_value = True
@@ -769,7 +769,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
                  "publishedAt": "2016-01-01T00:00:00.000000Z"}
             ])
             brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-            brief_json['briefs']['specialistRole'] = 'communications_manager'
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
             data_api_client.get_brief.return_value = brief_json
 
             clarification_questions_open.return_value = False

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -391,6 +391,13 @@ class TestBriefPage(BaseApplicationTest):
         apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/create"]'.format(brief_id))
         assert len(apply_links) == 0
 
+    def test_dos_brief_specialist_role_displays_label(self):
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+
+        assert 'qualityAssurance' not in res.get_data(as_text=True)
+        assert 'Quality assurance analyst' in res.get_data(as_text=True)
+
 
 class TestCatalogueOfBriefsPage(BaseApplicationTest):
     def setup(self):

--- a/tests/fixtures/dos_brief_fixture.json
+++ b/tests/fixtures/dos_brief_fixture.json
@@ -30,7 +30,7 @@
     ],
     "organisation": "ByteMe IT",
     "publishedAt": "2016-02-25T11:08:28.054129Z",
-    "specialistRole": "quality_assurance_analyst",
+    "specialistRole": "qualityAssurance",
     "startDate": "01/03/2016",
     "status": "live",
     "title": "QA tester for next-gen web project",

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -61,7 +61,7 @@
       "location":"East of England",
       "lot":"digital-specialists",
       "status":"live",
-      "specialistRole":"business_analyst",
+      "specialistRole":"businessAnalyst",
       "importantDates":"29th March",
       "contractLength":"3 Months",
       "currentTechnologies":"Business Focus Plus",


### PR DESCRIPTION
### Use value label lookup from dmutils
Removes label lookup code from the brief summary view since the label is now returned by question_summary.value if there's a matching option.

Fixes test specialistRole values to match the new content values and adds a test for label display on the brief page.