### PR TITLE
Buyer can post clarification questions when brief is `live`

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -8,10 +8,10 @@ from flask_login import current_user
 from app import data_api_client
 from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
-    count_suppliers_on_lot, get_framework_and_lot, is_brief_associated_with_user,
-    count_unanswered_questions, brief_can_be_edited, add_unanswered_counts_to_briefs,
-    clarification_questions_open, add_response_counts_to_briefs, counts_for_failed_and_eligible_brief_responses,
-    all_essentials_are_true, get_sorted_responses_for_brief)
+    add_response_counts_to_briefs, all_essentials_are_true, count_suppliers_on_lot,
+    counts_for_failed_and_eligible_brief_responses, get_framework_and_lot, get_sorted_responses_for_brief,
+    is_brief_associated_with_user, count_unanswered_questions, brief_can_be_edited, add_unanswered_counts_to_briefs
+)
 
 from dmapiclient import HTTPError
 
@@ -220,8 +220,7 @@ def view_brief_summary(framework_slug, lot_slug, brief_id):
         unanswered_required=unanswered_required,
         unanswered_optional=unanswered_optional,
         can_publish=not unanswered_required,
-        delete_requested=delete_requested,
-        clarification_questions_open=clarification_questions_open(brief)
+        delete_requested=delete_requested
     ), 200
 
 
@@ -347,9 +346,6 @@ def add_clarification_question(framework_slug, lot_slug, brief_id):
         abort(404)
 
     if brief["status"] != "live":
-        abort(404)
-
-    if not clarification_questions_open(brief):
         abort(404)
 
     content = content_loader.get_manifest(framework_slug, "clarification_question")

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -67,11 +67,6 @@ def add_response_counts_to_briefs(briefs, data_api_client):
     return briefs
 
 
-def clarification_questions_open(brief):
-    # TODO: Implement this properly
-    return True
-
-
 def counts_for_failed_and_eligible_brief_responses(brief_id, data_api_client):
     brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
     failed_count = 0

--- a/app/templates/buyers/brief_summary.html
+++ b/app/templates/buyers/brief_summary.html
@@ -95,7 +95,7 @@
     </div>
   {% endif %}
 
-  {% if brief_data.status == "live" and clarification_questions_open %}
+  {% if brief_data.status == "live" %}
   <a href="{{ url_for(".add_clarification_question", framework_slug=framework.slug, lot_slug=lot.slug, brief_id=brief_data.id) }}">Answer a clarification question</a>
   {% endif %}
 {% endblock %}

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -721,9 +721,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Clarification questions" not in page_html
             assert "Answer a clarification question" not in page_html
 
-    @mock.patch("app.buyers.views.buyers.clarification_questions_open")
-    def test_show_live_brief_summary_page(
-            self, clarification_questions_open, data_api_client):
+    def test_show_live_brief_summary_page(self, data_api_client):
         with self.app.app_context():
             self.login_as_buyer()
             data_api_client.get_framework.return_value = api_stubs.framework(
@@ -736,9 +734,8 @@ class TestBriefSummaryPage(BaseApplicationTest):
             brief_json = api_stubs.brief(status="live")
             brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
             brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
             data_api_client.get_brief.return_value = brief_json
-
-            clarification_questions_open.return_value = False
 
             res = self.client.get(
                 "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1"
@@ -755,11 +752,9 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
             assert "Clarification questions" in page_html
             assert "No clarification questions have been answered yet" in page_html
-            assert "Answer a clarification question" not in page_html
+            assert "Answer a clarification question" in page_html
 
-    @mock.patch("app.buyers.views.buyers.clarification_questions_open")
-    def test_show_live_brief_summary_with_clarification_questions_open(
-            self, clarification_questions_open, data_api_client):
+    def test_show_live_brief_summary_with_clarification_questions_open(self, data_api_client):
         with self.app.app_context():
             self.login_as_buyer()
             data_api_client.get_framework.return_value = api_stubs.framework(
@@ -772,9 +767,8 @@ class TestBriefSummaryPage(BaseApplicationTest):
             brief_json = api_stubs.brief(status="live")
             brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
             brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = False
             data_api_client.get_brief.return_value = brief_json
-
-            clarification_questions_open.return_value = True
 
             res = self.client.get(
                 "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1"
@@ -786,9 +780,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Clarification questions" in page_html
             assert "Answer a clarification question" in page_html
 
-    @mock.patch("app.buyers.views.buyers.clarification_questions_open")
-    def test_show_live_brief_summary_with_clarification_question(
-            self, clarification_questions_open, data_api_client):
+    def test_show_live_brief_summary_with_clarification_question(self, data_api_client):
         with self.app.app_context():
             self.login_as_buyer()
             data_api_client.get_framework.return_value = api_stubs.framework(
@@ -805,9 +797,8 @@ class TestBriefSummaryPage(BaseApplicationTest):
             ])
             brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
             brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
             data_api_client.get_brief.return_value = brief_json
-
-            clarification_questions_open.return_value = False
 
             res = self.client.get(
                 "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1"
@@ -858,9 +849,8 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
 
 @mock.patch("app.buyers.views.buyers.data_api_client")
-@mock.patch("app.buyers.views.buyers.clarification_questions_open")
 class TestAddBriefClarificationQuestion(BaseApplicationTest):
-    def test_show_brief_clarification_question_form(self, clarification_questions_open, data_api_client):
+    def test_show_brief_clarification_question_form(self, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug="digital-outcomes-and-specialists",
@@ -868,8 +858,9 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
             lots=[
                 api_stubs.lot(slug="digital-specialists", allows_brief=True)
             ])
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
-        clarification_questions_open.return_value = True
+        brief_json = api_stubs.brief(status="live")
+        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+        data_api_client.get_brief.return_value = brief_json
 
         res = self.client.get(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
@@ -877,7 +868,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         assert res.status_code == 200
 
-    def test_add_brief_clarification_question(self, clarification_questions_open, data_api_client):
+    def test_add_brief_clarification_question(self, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug="digital-outcomes-and-specialists",
@@ -885,8 +876,9 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
             lots=[
                 api_stubs.lot(slug="digital-specialists", allows_brief=True)
             ])
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
-        clarification_questions_open.return_value = True
+        brief_json = api_stubs.brief(status="live")
+        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+        data_api_client.get_brief.return_value = brief_json
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
@@ -900,7 +892,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
         data_api_client.add_brief_clarification_question.assert_called_with(
             "1234", "Why?", "Because", "buyer@email.com")
 
-    def test_404_if_framework_is_not_live(self, clarification_questions_open, data_api_client):
+    def test_404_if_framework_is_not_live(self, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug='digital-outcomes-and-specialists',
@@ -909,8 +901,9 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
                 api_stubs.lot(slug='digital-specialists', allows_brief=True),
             ]
         )
-        data_api_client.get_brief.return_value = api_stubs.brief()
-        clarification_questions_open.return_value = True
+        brief_json = api_stubs.brief()
+        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+        data_api_client.get_brief.return_value = brief_json
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
@@ -923,7 +916,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
         assert res.status_code == 404
         assert not data_api_client.add_brief_clarification_question.called
 
-    def test_404_if_framework_does_not_allow_brief(self, clarification_questions_open, data_api_client):
+    def test_404_if_framework_does_not_allow_brief(self, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug='digital-outcomes-and-specialists',
@@ -932,8 +925,9 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
                 api_stubs.lot(slug='digital-specialists', allows_brief=False),
             ]
         )
-        data_api_client.get_brief.return_value = api_stubs.brief()
-        clarification_questions_open.return_value = True
+        brief_json = api_stubs.brief()
+        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+        data_api_client.get_brief.return_value = brief_json
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
@@ -946,7 +940,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
         assert res.status_code == 404
         assert not data_api_client.add_brief_clarification_question.called
 
-    def test_404_if_brief_does_not_belong_to_user(self, clarification_questions_open, data_api_client):
+    def test_404_if_brief_does_not_belong_to_user(self, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug='digital-outcomes-and-specialists',
@@ -955,8 +949,9 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
                 api_stubs.lot(slug='digital-specialists', allows_brief=True),
             ]
         )
-        data_api_client.get_brief.return_value = api_stubs.brief(user_id=234)
-        clarification_questions_open.return_value = True
+        brief_json = api_stubs.brief(user_id=234)
+        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+        data_api_client.get_brief.return_value = brief_json
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
@@ -969,7 +964,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
         assert res.status_code == 404
         assert not data_api_client.add_brief_clarification_question.called
 
-    def test_404_if_brief_is_not_live(self, clarification_questions_open, data_api_client):
+    def test_404_if_brief_is_not_live(self, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug='digital-outcomes-and-specialists',
@@ -978,8 +973,9 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
                 api_stubs.lot(slug='digital-specialists', allows_brief=True),
             ]
         )
-        data_api_client.get_brief.return_value = api_stubs.brief(status="draft")
-        clarification_questions_open.return_value = True
+        brief_json = api_stubs.brief(status="draft")
+        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+        data_api_client.get_brief.return_value = brief_json
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
@@ -992,7 +988,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
         assert res.status_code == 404
         assert not data_api_client.add_brief_clarification_question.called
 
-    def test_404_if_clarification_questions_are_closed(self, clarification_questions_open, data_api_client):
+    def test_validation_error(self, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug="digital-outcomes-and-specialists",
@@ -1000,30 +996,9 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
             lots=[
                 api_stubs.lot(slug="digital-specialists", allows_brief=True)
             ])
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
-        clarification_questions_open.return_value = False
-
-        res = self.client.post(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/answer-question",
-            data={
-                "question": "Why?",
-                "answer": "Because",
-            })
-
-        assert res.status_code == 404
-        assert not data_api_client.add_brief_clarification_question.called
-
-    def test_validation_error(self, clarification_questions_open, data_api_client):
-        self.login_as_buyer()
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug="digital-outcomes-and-specialists",
-            status="live",
-            lots=[
-                api_stubs.lot(slug="digital-specialists", allows_brief=True)
-            ])
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
-        clarification_questions_open.return_value = True
+        brief_json = api_stubs.brief(status="live")
+        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+        data_api_client.get_brief.return_value = brief_json
         data_api_client.add_brief_clarification_question.side_effect = HTTPError(
             mock.Mock(status_code=400),
             {"question": "answer_required"})
@@ -1040,7 +1015,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
         assert res.status_code == 400
         assert len(document.cssselect("#error-question")) == 1
 
-    def test_api_error(self, clarification_questions_open, data_api_client):
+    def test_api_error(self, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
             slug="digital-outcomes-and-specialists",
@@ -1048,8 +1023,9 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
             lots=[
                 api_stubs.lot(slug="digital-specialists", allows_brief=True)
             ])
-        data_api_client.get_brief.return_value = api_stubs.brief(status="live")
-        clarification_questions_open.return_value = True
+        brief_json = api_stubs.brief(status="live")
+        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+        data_api_client.get_brief.return_value = brief_json
         data_api_client.add_brief_clarification_question.side_effect = HTTPError(
             mock.Mock(status_code=500))
 


### PR DESCRIPTION
This removes the now-unnecessary stubbed-out function that was going to check if clarification questions are open.  That information is included in the API response now, so no need to compute it in the front end.

Also removes the condition that clarificaton period should be open in order for buyers to submit a question/answer pair - buyers should be able to do this the whole time the brief is live.