### PR TITLE
[#116130103] Participants start page

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -8,10 +8,9 @@ from flask_login import current_user
 from app import data_api_client
 from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
-    add_response_counts_to_briefs, add_unanswered_counts_to_briefs, all_essentials_are_true, brief_can_be_edited,
-    count_unanswered_questions, counts_for_failed_and_eligible_brief_responses, get_framework_and_lot,
-    get_sorted_responses_for_brief, is_brief_associated_with_user
-
+    add_unanswered_counts_to_briefs, all_essentials_are_true, brief_can_be_edited, count_unanswered_questions,
+    counts_for_failed_and_eligible_brief_responses, get_framework_and_lot, get_sorted_responses_for_brief,
+    is_brief_associated_with_user
 )
 
 from dmapiclient import HTTPError

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -8,9 +8,10 @@ from flask_login import current_user
 from app import data_api_client
 from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
-    all_essentials_are_true, count_suppliers_on_lot, counts_for_failed_and_eligible_brief_responses,
-    get_framework_and_lot, get_sorted_responses_for_brief, is_brief_associated_with_user, count_unanswered_questions,
-    brief_can_be_edited, add_unanswered_counts_to_briefs
+    add_response_counts_to_briefs, add_unanswered_counts_to_briefs, all_essentials_are_true, brief_can_be_edited,
+    count_unanswered_questions, counts_for_failed_and_eligible_brief_responses, get_framework_and_lot,
+    get_sorted_responses_for_brief, is_brief_associated_with_user
+
 )
 
 from dmapiclient import HTTPError
@@ -40,8 +41,7 @@ def info_page_for_starting_a_brief(framework_slug, lot_slug):
     return render_template(
         "buyers/start_brief_info.html",
         framework=framework,
-        lot=lot,
-        supplier_count=count_suppliers_on_lot(framework, lot)
+        lot=lot
     ), 200
 
 

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -18,13 +18,6 @@ def get_framework_and_lot(framework_slug, lot_slug, data_api_client, status=None
     return framework, lot
 
 
-def count_suppliers_on_lot(framework, lot):
-
-    # TODO: Implement this properly!
-
-    return 987
-
-
 def is_brief_associated_with_user(brief, current_user_id):
     user_ids = [user.get('id') for user in brief.get('users', [])]
     return current_user_id in user_ids

--- a/app/templates/buyers/_base_brief_summary_page.html
+++ b/app/templates/buyers/_base_brief_summary_page.html
@@ -16,7 +16,7 @@
 
       <div class="marketplace-paragraph">
         <h2>Overview of work</h2>
-        <p class="padding-bottom-large">Create an overview of the work to help suppliers decide whether to apply.</p>
+        <p>Create an overview of the work to help suppliers decide whether to apply.</p>
       </div>
     </div>
               

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -1,8 +1,12 @@
 {% extends "_base_page.html" %}
 
-{% set title_text = "Find a team to provide an outcome" if lot.slug == 'digital-outcomes' else "Find an individual specialist" %}
-{% set supplier_type = "outcomes" if lot.slug == 'digital-outcomes' else "specialists" %}
-{% set button_text = "Choose location" if lot.slug == 'digital-outcomes' else "Choose specialist role" %}
+{% set title_text = 
+    { 
+        "digital-outcomes": "Find a team to provide an outcome",
+        "digital-specialists": "Find an individual specialist",
+        "user-research-participants": "Find user research participants",
+    }[lot.slug]
+%}
 
 {% block page_title %}
 {{ title_text }} - Digital Marketplace
@@ -34,38 +38,65 @@
     </div>
 
     <div class="column-two-thirds large-paragraph">
-        <p class="padding-bottom-small">There are {{ supplier_count }} suppliers who provide {{ supplier_type }} on the Digital Marketplace.</p>
-        
-        <p>You need to write and publish your requirements so these suppliers can decide:</p>
-        <ul class="list-bullet padding-bottom-small">
-            <li>whether to apply for the work</li>
-            {% if lot.slug == 'digital-outcomes' %}
-              <li>what solution best meets your needs</li>
-            {% endif %}
-        </ul>
-        
-        <p>Once you’ve published your requirements, you’ll need to:</p>
-        <ul class="list-bullet padding-bottom-small">
-            <li>answer supplier questions</li>
-            <li>shortlist and evaluate supplier applications</li>
-            <li>award to the supplier that best meets your needs</li>
-        </ul>
-        
-        <p class="padding-bottom-small">
-            <a href="#">View published requirements</a><br />
-            <a href="#">View supplier A to Z</a><br />
-            <a href="#">Find out how suppliers are evaluated</a><br />
-            <a href="#">How to talk to suppliers before you start</a>
-        </p>
-        <p class="padding-bottom-small">The buying process should take around 1 month.</p>
-        <p class="padding-bottom-small">Read more about <a href="#">how to buy</a>.</p>
+        <div class="marketplace-paragraph">
+            <p>
+                {{
+                    {
+                    "digital-outcomes": "To find a digital outcome, eg a booking system or an accessibility audit, you need to tell suppliers about the situation or problem. They’ll then propose a solution to meet your needs.",
+                    "digital-specialists": "To find a digital specialist, eg a developer or a user researcher, you need to tell suppliers to provide a specialist for a specific piece of work.",
+                    "user-research-participants": "To find user research participants, you need to tell suppliers about the types of participants you want to test your service with. They’ll then tell you what they can do and how much it will cost.",
+                    }[lot.slug]
+                }}
+            </p>
+        </div>
+
+        <h2>Before you start</h2>
+        <ol class="list-number">
+            <li>You can talk to suppliers to prepare your requirements.<br>
+                <a href="#">View a list of suppliers.</a>
+            </li>
+            <li>Get budget approval.</li>
+        </ol>
+
+        <h2>Write and publish your requirements</h2>
+        <ol class="list-number" start="3">
+            <li>Write your requirements and say how you’re going to evaluate {{ "specialists" if lot.slug == "digital-specialists" else "suppliers" }}.</li>
+            <li>Publish your requirements and evaluation criteria so suppliers can apply for the work. This information will be published on the Digital Marketplace where anyone can see it.</li>
+        </ol>
+
+        <h2>Answer supplier questions</h2>
+        <ol class="list-number" start="5">
+            <li>Post all supplier questions and answers on the Digital Marketplace.</li>
+        </ol>
+
+        <h2>Evaluate suppliers</h2>
+        <ol class="list-number" start="6">
+            <li>Shortlist and evaluate {{ "specialists’" if lot.slug == "digital-specialists" else "supplier" }} applications.</li>
+            <li>Award a contract to the specialist that best meets your needs.</li>
+        </ol>
+
+        <p>The buying process should take around {{ "4 weeks" if lot.slug == "digital-outcomes" else "2 weeks" }}.</p>
+        <p>Read more about:</p>
+        <div class="explanation-list">
+            <ul class="list-bullet">
+                <li><a href="#">how to buy</a></li>
+                <li><a href="#">how suppliers have been evaluated</a></li>
+            </ul>
+        </div>
     </div>
-    
+
     <div class="column-two-thirds large-paragraph">
         <form action="{{ url_for('buyers.start_new_brief', framework_slug=framework.slug, lot_slug=lot.slug) }}" method="get">
-            <button type="submit" class="button-save">
-                {{ button_text }}
-            </button>
+
+            {%
+            with
+            label="Create requirement",
+            type="save",
+            name = "create_requirement"
+            %}
+            {% include "toolkit/button.html" %}
+            {% endwith %}
+
         </form>
     </div>
 </div>

--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -75,7 +75,7 @@
             <li>Award a contract to the specialist that best meets your needs.</li>
         </ol>
 
-        <p>The buying process should take around {{ "4 weeks" if lot.slug == "digital-outcomes" else "2 weeks" }}.</p>
+        <p>The buying process should take around 2 weeks.</p>
         <p>Read more about:</p>
         <div class="explanation-list">
             <ul class="list-bullet">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,7 +34,7 @@
             "body": "eg a booking system or accessibility audit",
           },
           {
-            "link": url_for("buyers.start_new_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='user-research-participants'),
+            "link": url_for("buyers.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='user-research-participants'),
             "title": "Find user research participants",
             "body": "eg people from a specific user group to test your service",
           },


### PR DESCRIPTION
Completes this story: https://www.pivotaltracker.com/story/show/116130103

The requirements start page design and content has changed quite a lot, and this brings it up to date with the prototype (e.g., http://dm-prototype.herokuapp.com/participants-start), and also adds an introductory sentence specific to each lot at the top of the page (words by Roz, OK'd by Sarah).

The "Find user research participants" link from the homepage now takes the user to this start page rather than straight into creating the requirements.

This is how the three start pages look now...

SPECIALISTS
===========
![screen shot 2016-04-06 at 16 19 48](https://cloud.githubusercontent.com/assets/6525554/14322323/530548b2-fc14-11e5-91fc-e49127d680bb.png)

OUTCOMES
==========
![screen shot 2016-04-06 at 16 20 09](https://cloud.githubusercontent.com/assets/6525554/14322329/5a3741d0-fc14-11e5-8fa8-a29edfd269e7.png)

PARTICIPANTS
=============
![screen shot 2016-04-06 at 16 20 37](https://cloud.githubusercontent.com/assets/6525554/14322332/5d994e18-fc14-11e5-8964-339793e520d7.png)