### PR TITLE
[#117143511] Display flashed messages on the view-opportunity page

### DIFF
--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -19,6 +19,18 @@
 
 {% block main_content %}
 
+{% with messages = get_flashed_messages(with_categories=True) %}
+  {% for category, message in messages %}
+    {%
+      with
+      message = message,
+      type = "destructive" if category == "error" else "success"
+    %}
+    {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  {% endfor %}
+{% endwith %}
+
 {% if brief.status == 'closed' %}
 <div class="grid-row">
   <div class="column-one-whole">


### PR DESCRIPTION
Part of the fix for this bug: https://www.pivotaltracker.com/story/show/117143511

Rather than 404 when a supplier has already responded to a brief, we will show a flashed message on the brief page that explains they have already submitted and can't do so twice.  The message itself will be flashed through from the supplier app.