### PR TITLE
Exclude app/content from PEP8 checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [pep8]
-exclude = ./venv,./bower_components,./node_modules
+exclude = ./venv,./bower_components,./node_modules,./app/content
 max-line-length = 120
 
 [pytest]


### PR DESCRIPTION
As suggested by @allait in https://github.com/alphagov/digitalmarketplace-frameworks/pull/219#issuecomment-206917506