### PR TITLE
Don't iterate all (closed) briefs for dashboard

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -8,9 +8,9 @@ from flask_login import current_user
 from app import data_api_client
 from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
-    add_response_counts_to_briefs, all_essentials_are_true, count_suppliers_on_lot,
-    counts_for_failed_and_eligible_brief_responses, get_framework_and_lot, get_sorted_responses_for_brief,
-    is_brief_associated_with_user, count_unanswered_questions, brief_can_be_edited, add_unanswered_counts_to_briefs
+    all_essentials_are_true, count_suppliers_on_lot, counts_for_failed_and_eligible_brief_responses,
+    get_framework_and_lot, get_sorted_responses_for_brief, is_brief_associated_with_user, count_unanswered_questions,
+    brief_can_be_edited, add_unanswered_counts_to_briefs
 )
 
 from dmapiclient import HTTPError
@@ -21,10 +21,7 @@ def buyer_dashboard():
     user_briefs = data_api_client.find_briefs(current_user.id).get('briefs', [])
     draft_briefs = add_unanswered_counts_to_briefs([brief for brief in user_briefs if brief['status'] == 'draft'])
     live_briefs = [brief for brief in user_briefs if brief['status'] == 'live']
-    closed_briefs = add_response_counts_to_briefs(
-        [brief for brief in user_briefs if brief['status'] == 'closed'],
-        data_api_client
-    )
+    closed_briefs = [brief for brief in user_briefs if brief['status'] == 'closed']
 
     return render_template(
         'buyers/dashboard.html',

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -59,14 +59,6 @@ def add_unanswered_counts_to_briefs(briefs):
     return briefs
 
 
-def add_response_counts_to_briefs(briefs, data_api_client):
-    for brief in briefs:
-        responses = data_api_client.find_brief_responses(brief_id=brief['id'])["briefResponses"]
-        brief['responses_count'] = len(responses)
-
-    return briefs
-
-
 def counts_for_failed_and_eligible_brief_responses(brief_id, data_api_client):
     brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
     failed_count = 0

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -109,7 +109,7 @@
     field_headings=[
     "Brief name",
     "Closed",
-    "Number of responses",
+    "Responses",
     ],
     field_headings_visible=True
 ) %}
@@ -117,7 +117,7 @@
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_summary", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.applicationsClosedAt|dateformat) }}
-        {{ summary.link("{} responses".format(item.responses_count), url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        {{ summary.link("View responses", url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}
 {% endblock %}

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 #Required for testing
-pytest==2.8.2
+pytest==2.9.1
 pep8==1.5.7
 nose==1.3.4
 mock==1.0.1

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -40,37 +40,40 @@ class TestBuyerDashboard(BaseApplicationTest):
             assert live_row[0] == "A live brief"
             assert live_row[1] == "Thursday 04 February 2016"
 
-    def test_closed_brief_response_count(self, data_api_client):
-        with self.app.app_context():
-            self.login_as_buyer()
-            data_api_client.find_briefs.return_value = {
-                "briefs": [
-                    {"status": "closed",
-                     "id": 12,
-                     "title": "A closed brief",
-                     "createdAt": "2016-02-01T00:00:00.000000Z",
-                     "publishedAt": "2016-02-04T12:00:00.000000Z",
-                     "frameworkSlug": "digital-outcomes-and-specialists"},
-                ]
-            }
-            data_api_client.find_brief_responses.return_value = {
-                "links": [],
-                "briefResponses": [
-                    {"empty": "empty"},
-                ]
-            }
-
-            res = self.client.get("/buyers")
-            document = html.fromstring(res.get_data(as_text=True))
-
-            assert res.status_code == 200
-
-            cell = document.xpath(
-                "//caption[contains(text(), 'Closed requirements')]"
-                "//following-sibling::tbody/tr[1]/td[last()]"
-            )[0]
-
-            assert "1 responses" in cell.text_content()
+    # TODO: reinstate this test when reponse counts are back on the buyer dashboard page
+    # TheDoubleK says 11-04-2016: I am leaving this test commented out as this should be reinstated soon
+    #
+    # def test_closed_brief_response_count(self, data_api_client):
+    #     with self.app.app_context():
+    #         self.login_as_buyer()
+    #         data_api_client.find_briefs.return_value = {
+    #             "briefs": [
+    #                 {"status": "closed",
+    #                  "id": 12,
+    #                  "title": "A closed brief",
+    #                  "createdAt": "2016-02-01T00:00:00.000000Z",
+    #                  "publishedAt": "2016-02-04T12:00:00.000000Z",
+    #                  "frameworkSlug": "digital-outcomes-and-specialists"},
+    #             ]
+    #         }
+    #         data_api_client.find_brief_responses.return_value = {
+    #             "links": [],
+    #             "briefResponses": [
+    #                 {"empty": "empty"},
+    #             ]
+    #         }
+    #
+    #         res = self.client.get("/buyers")
+    #         document = html.fromstring(res.get_data(as_text=True))
+    #
+    #         assert res.status_code == 200
+    #
+    #         cell = document.xpath(
+    #             "//caption[contains(text(), 'Closed requirements')]"
+    #             "//following-sibling::tbody/tr[1]/td[last()]"
+    #         )[0]
+    #
+    #         assert "1 responses" in cell.text_content()
 
 
 @mock.patch('app.buyers.views.buyers.data_api_client')

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -5,6 +5,7 @@ from ...helpers import BaseApplicationTest
 from dmapiclient import api_stubs, HTTPError
 import mock
 from lxml import html
+import pytest
 
 
 @mock.patch('app.buyers.views.buyers.data_api_client')
@@ -40,40 +41,38 @@ class TestBuyerDashboard(BaseApplicationTest):
             assert live_row[0] == "A live brief"
             assert live_row[1] == "Thursday 04 February 2016"
 
-    # TODO: reinstate this test when reponse counts are back on the buyer dashboard page
-    # TheDoubleK says 11-04-2016: I am leaving this test commented out as this should be reinstated soon
-    #
-    # def test_closed_brief_response_count(self, data_api_client):
-    #     with self.app.app_context():
-    #         self.login_as_buyer()
-    #         data_api_client.find_briefs.return_value = {
-    #             "briefs": [
-    #                 {"status": "closed",
-    #                  "id": 12,
-    #                  "title": "A closed brief",
-    #                  "createdAt": "2016-02-01T00:00:00.000000Z",
-    #                  "publishedAt": "2016-02-04T12:00:00.000000Z",
-    #                  "frameworkSlug": "digital-outcomes-and-specialists"},
-    #             ]
-    #         }
-    #         data_api_client.find_brief_responses.return_value = {
-    #             "links": [],
-    #             "briefResponses": [
-    #                 {"empty": "empty"},
-    #             ]
-    #         }
-    #
-    #         res = self.client.get("/buyers")
-    #         document = html.fromstring(res.get_data(as_text=True))
-    #
-    #         assert res.status_code == 200
-    #
-    #         cell = document.xpath(
-    #             "//caption[contains(text(), 'Closed requirements')]"
-    #             "//following-sibling::tbody/tr[1]/td[last()]"
-    #         )[0]
-    #
-    #         assert "1 responses" in cell.text_content()
+    @pytest.mark.skip(reason="no counts on dashboard until API response includes them")
+    def test_closed_brief_response_count(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.find_briefs.return_value = {
+                "briefs": [
+                    {"status": "closed",
+                     "id": 12,
+                     "title": "A closed brief",
+                     "createdAt": "2016-02-01T00:00:00.000000Z",
+                     "publishedAt": "2016-02-04T12:00:00.000000Z",
+                     "frameworkSlug": "digital-outcomes-and-specialists"},
+                ]
+            }
+            data_api_client.find_brief_responses.return_value = {
+                "links": [],
+                "briefResponses": [
+                    {"empty": "empty"},
+                ]
+            }
+
+            res = self.client.get("/buyers")
+            document = html.fromstring(res.get_data(as_text=True))
+
+            assert res.status_code == 200
+
+            cell = document.xpath(
+                "//caption[contains(text(), 'Closed requirements')]"
+                "//following-sibling::tbody/tr[1]/td[last()]"
+            )[0]
+
+            assert "1 responses" in cell.text_content()
 
 
 @mock.patch('app.buyers.views.buyers.data_api_client')


### PR DESCRIPTION
This should fix the problems with preview API running out of credit because the functional test user has 1000s of briefs.

Iterating all closed briefs will soon (now in the case of the functional tests) result in too many API requests per page.

Instead we're going to add the response count to the API response.