### PR TITLE
Add question and answer session details link to opportunity page

### DIFF
--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -40,5 +40,5 @@
     {% endif %}
   </a>
 {% elif brief.status == 'live' %}
-  The deadline for asking clarification questions was {{ brief.clarificationQuestionsClosedAt|dateformat }}.
+  The deadline for asking questions about this opportunity was {{ brief.clarificationQuestionsClosedAt|dateformat }}.
 {% endif %}

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -1,4 +1,16 @@
 {% import "toolkit/summary-table.html" as summary %}
+
+{% if brief.status == 'live' %}
+  {{ summary.heading("Question and answer session", id="question-and-answer-session") }}
+  <a href="/suppliers/opportunities/{{ brief.id }}/question-and-answer-session">
+    {% if current_user.is_authenticated() and current_user.role == 'supplier' %}
+      View question and answer session details
+    {% else %}
+      Log in to view question and answer session details
+    {% endif %}
+  </a>
+{% endif %}
+
 {{ summary.heading("Questions asked by suppliers", id="clarification-questions") }}
 {% call(question) summary.list_table(
   brief.clarificationQuestions,

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -1,6 +1,6 @@
 {% import "toolkit/summary-table.html" as summary %}
 
-{% if not brief.clarificationQuestionsAreClosed %}
+{% if (not brief.clarificationQuestionsAreClosed) and brief.questionAndAnswerSessionDetails %}
   {{ summary.heading("Question and answer session", id="question-and-answer-session") }}
   <a href="/suppliers/opportunities/{{ brief.id }}/question-and-answer-session">
     {% if current_user.is_authenticated() and current_user.role == 'supplier' %}

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -1,6 +1,6 @@
 {% import "toolkit/summary-table.html" as summary %}
 
-{% if brief.status == 'live' %}
+{% if not brief.clarificationQuestionsAreClosed %}
   {{ summary.heading("Question and answer session", id="question-and-answer-session") }}
   <a href="/suppliers/opportunities/{{ brief.id }}/question-and-answer-session">
     {% if current_user.is_authenticated() and current_user.role == 'supplier' %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.5.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.5.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.22.0"
   }

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -346,6 +346,20 @@ class TestBriefPage(BaseApplicationTest):
 
         assert qa_session_link_text == "Log in to view question and answer session details"
 
+    def test_dos_brief_question_and_answer_session_details_hidden_when_questions_closed(self):
+        self.brief['briefs']['clarificationQuestionsAreClosed'] = True
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+
+        assert "/question-and-answer-session" not in res.get_data(as_text=True)
+
+    def test_dos_brief_question_and_answer_session_details_hidden_when_empty(self):
+        del self.brief['briefs']['questionAndAnswerSessionDetails']
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+
+        assert "/question-and-answer-session" not in res.get_data(as_text=True)
+
     def test_dos_brief_has_questions_and_answers(self):
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -335,6 +335,17 @@ class TestBriefPage(BaseApplicationTest):
         assert_equal(contract_length_key[0], 'Contract length')
         assert_equal(contract_length_value[0], '4 weeks')
 
+    def test_dos_brief_has_question_and_answer_session_details_link(self):
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+
+        document = html.fromstring(res.get_data(as_text=True))
+        qa_session_link_text = document.xpath(
+            '//a[@href="/suppliers/opportunities/{}/question-and-answer-session"]/text()'.format(brief_id)
+        )[0].strip()
+
+        assert qa_session_link_text == "Log in to view question and answer session details"
+
     def test_dos_brief_has_questions_and_answers(self):
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))

--- a/tests/fixtures/dos_brief_fixture.json
+++ b/tests/fixtures/dos_brief_fixture.json
@@ -30,6 +30,7 @@
     ],
     "organisation": "ByteMe IT",
     "publishedAt": "2016-02-25T11:08:28.054129Z",
+    "questionAndAnswerSessionDetails": "session details",
     "specialistRole": "qualityAssurance",
     "startDate": "01/03/2016",
     "status": "live",


### PR DESCRIPTION
### Add question and answer session details link to opportunity page
Adds a link to view q+a session (webinar) details to the brief page. Adding this to the _brief_q_and_a template since it seems to be closely related to the clarification questions (one of the main points during the discussion was whether it should be a separate link or the same one as "Ask a question")

#### [#117296739] Update clarification questions closed message

![screen shot 2016-04-14 at 15 13 43](https://cloud.githubusercontent.com/assets/246664/14531030/96034b9c-0253-11e6-950c-c7ca299e14a7.png)
