### PR TITLE
Add publish page 

### DIFF
--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -27,6 +27,15 @@ def brief_can_be_edited(brief):
     return brief.get('status') == 'draft'
 
 
+def get_flattened_brief(sections):
+    flattened_brief = []
+    for section in sections:
+        for question in section.questions:
+            question.section_id = section.id
+            flattened_brief.append(question)
+    return flattened_brief
+
+
 def count_unanswered_questions(brief_attributes):
     unanswered_required, unanswered_optional = (0, 0)
     for section in brief_attributes:

--- a/app/templates/buyers/_complete_brief.html
+++ b/app/templates/buyers/_complete_brief.html
@@ -1,9 +1,0 @@
-<form action="#" method="POST">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-  {% with type = "save", label = "Ready to publish" %}
-    {% include "toolkit/button.html" %}
-  {% endwith %}
-</form>
-<p class="last-edited ready-to-publish-hint">
-  You will have a chance to review everything before this is published.
-</p>

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -1,0 +1,64 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Your account - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+    {%
+        with items = [
+        {
+            "link": "/",
+            "label": "Digital Marketplace"
+        }
+        ]
+    %}
+    {% include "toolkit/breadcrumb.html" %}
+    {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class='grid-row'>
+  <div class='column-two-thirds large-paragraph'>
+    {% with
+        heading = "Publish your requirements and evaluation criteria",
+        smaller = True,
+        with_breadcrumb = True
+    %}
+        {% include "toolkit/page-heading.html" %}
+    {% endwith %}
+    <p class="dmspeak">All requirements are published on the Digital Marketplace where anyone can see them.</p>
+
+    <p><strong>Suppliers will be able to apply for:</strong></p>
+    <p class="dmspeak">2 weeks ending at midnight.</p>
+
+    <p><strong>Supplier questions will be sent to:</strong></p>
+    <p class="dmspeak">{{ email_address }}</p>
+    <p class="dmspeak">Ensure this email address will be monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
+
+    {% if unanswered_required > 0 %}
+      <p class="dmspeak"><strong>You still need to complete the following questions before the brief can be published:</strong></p>
+      {% for section in flattened_brief %}
+      <ol>
+        <li>
+            {% if section.answer_required %}
+                <a href="{{ url_for('.edit_brief_submission', framework_slug=framework_slug, lot_slug=brief_data.lot, brief_id=brief_data.id, section_id=section.section_id) }}">{{ section.question }}</a>
+            {% endif %}
+        </li>
+      </ol>
+      {% endfor %}
+    {% else %}
+      <form action="{{ url_for('.publish_brief', framework_slug=framework_slug, lot_slug=lot_slug, brief_id=brief_id) }}" method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        {%
+        with
+        type = "save",
+        label = "Publish Requirements"
+        %}
+        {% include "toolkit/button.html" %}
+        {% endwith %}
+      </form>
+    {% endif %}
+  </div>
+</div>
+
+{% endblock %}

--- a/app/templates/buyers/brief_summary.html
+++ b/app/templates/buyers/brief_summary.html
@@ -66,15 +66,14 @@
   {% endif %}
 {% endblock %}
 
-
 {% block after_sections %}
   {% if not delete_requested %}
     <div class="grid-row">
 
       <div class="column-one-third">
-        {% if brief_data.status == 'draft' and can_publish and framework.status == 'live' %}
-          <div class="space-underneath">
-            {% include "buyers/_complete_brief.html" %}
+        {% if brief_data.status == 'draft' %}
+          <div class="padding-bottom-small">
+            <a href ="{{ url_for('buyers.publish_brief', framework_slug=framework.slug, lot_slug=lot.slug, brief_id=brief_data.id) }}">Publish brief</a>
           </div>
         {% endif %}
         {% if framework.status == 'live' and brief_data.status == 'draft' %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ unicodecsv==0.14.1
 werkzeug==0.10.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@19.3.0#egg=digitalmarketplace-utils==19.3.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.4.1#egg=digitalmarketplace-apiclient==3.4.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -163,3 +163,14 @@ class TestBuyersHelpers(unittest.TestCase):
             {"id": "one", "niceToHaveRequirements": [False, False, False, True, False]},
             {'id': 'zero', 'niceToHaveRequirements': [False, False, False, False, False]}
         ]
+
+    def test_get_flattened_brief(self):
+        data_api_client = mock.Mock()
+        brief = data_api_client.api_stubs.brief(status="draft")
+        content = content_loader.get_manifest('dos', 'edit_brief').filter(
+            {'lot': 'digital-specialists'}
+        )
+        sections = content.summary(brief)
+        flattened_brief = helpers.buyers_helpers.get_flattened_brief(sections)
+
+        assert flattened_brief[0].id == 'required1'


### PR DESCRIPTION
Add publish page.  Page only displays links to questions with no publish button is required questions have not been completed, otherwise it only shows the publish button. 

Pulled out flattened_brief method and put it into a helper as this is common to several methods.

The link to the publishing page itself is a placeholder for now and will be replaced when the summary page is replaced with an overview page.