### PR TITLE
[#116129469] Studios catalogue

### DIFF
--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -1,7 +1,5 @@
 from flask import abort
 
-from ..buyers import content_loader
-
 
 def get_framework_and_lot(framework_slug, lot_slug, data_api_client, status=None, must_allow_brief=False):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
@@ -48,7 +46,7 @@ def count_unanswered_questions(brief_attributes):
     return unanswered_required, unanswered_optional
 
 
-def add_unanswered_counts_to_briefs(briefs):
+def add_unanswered_counts_to_briefs(briefs, content_loader):
     for brief in briefs:
         content = content_loader.get_manifest(brief.get('frameworkSlug'), 'edit_brief').filter(
             {'lot': brief.get('lotSlug')}

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -3,4 +3,7 @@ from flask import Blueprint
 main = Blueprint('main', __name__)
 
 from . import errors
-from .views import crown_hosting, digital_services_framework, g_cloud, login, marketplace, suppliers
+from .views import (
+    crown_hosting, digital_services_framework, g_cloud, login, marketplace, suppliers,
+    digital_outcomes_and_specialists
+)

--- a/app/main/views/digital_outcomes_and_specialists.py
+++ b/app/main/views/digital_outcomes_and_specialists.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from app import data_api_client
+
+from flask import render_template
+from ...helpers.buyers_helpers import get_framework_and_lot, count_suppliers_on_lot
+from ...main import main
+
+
+@main.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>', methods=['GET'])
+def info_page_for_starting_a_brief(framework_slug, lot_slug):
+    framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
+                                           status='live', must_allow_brief=True)
+    print("LOT: {}".format(lot))
+    print("FRAMEWORK: {}".format(framework))
+    return render_template(
+        "buyers/start_brief_info.html",
+        framework=framework,
+        lot=lot,
+        supplier_count=count_suppliers_on_lot(framework, lot)
+    ), 200

--- a/app/main/views/digital_outcomes_and_specialists.py
+++ b/app/main/views/digital_outcomes_and_specialists.py
@@ -2,20 +2,28 @@
 from __future__ import unicode_literals
 from app import data_api_client
 
-from flask import render_template
-from ...helpers.buyers_helpers import get_framework_and_lot, count_suppliers_on_lot
+from flask import abort, render_template
+from ...helpers.buyers_helpers import get_framework_and_lot
 from ...main import main
+
+
+@main.route('/buyers/frameworks/<framework_slug>/requirements/user-research-studios', methods=['GET'])
+def studios_start_page(framework_slug):
+    framework = data_api_client.get_framework(framework_slug)['frameworks']
+    if framework['status'] != 'live':
+        abort(404)
+
+    return render_template(
+        "buyers/studios_start_page.html"
+    ), 200
 
 
 @main.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>', methods=['GET'])
 def info_page_for_starting_a_brief(framework_slug, lot_slug):
     framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
                                            status='live', must_allow_brief=True)
-    print("LOT: {}".format(lot))
-    print("FRAMEWORK: {}".format(framework))
     return render_template(
         "buyers/start_brief_info.html",
         framework=framework,
-        lot=lot,
-        supplier_count=count_suppliers_on_lot(framework, lot)
+        lot=lot
     ), 200

--- a/app/main/views/digital_outcomes_and_specialists.py
+++ b/app/main/views/digital_outcomes_and_specialists.py
@@ -9,9 +9,8 @@ from ...main import main
 
 @main.route('/buyers/frameworks/<framework_slug>/requirements/user-research-studios', methods=['GET'])
 def studios_start_page(framework_slug):
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
-    if framework['status'] != 'live':
-        abort(404)
+    # Check framework is live and has the user-research-studios lot
+    get_framework_and_lot(framework_slug, 'user-research-studios', data_api_client, status='live')
 
     return render_template(
         "buyers/studios_start_page.html"

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -82,7 +82,7 @@ Find a user research lab - Digital Marketplace
         with
             items = [
             {
-            "title": "List of labs (???K)",
+            "title": "List of labs",
             "link": "https://assets.digitalmarketplace.service.gov.uk/catalogues/digital-outcomes-and-specialists/user-research-studios.csv",
             "file_type": "csv"
             }

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -73,7 +73,7 @@ Find a user research lab - Digital Marketplace
         </ol>
 
         <div class="marketplace-paragraph">
-            <p>Read more about <a href="#">how to hire user research labs</a>.</p>
+            <p>Read more about <a href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">how to hire user research labs</a>.</p>
         </div>
         
         <h2>Download the list of labs</h2>

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -70,20 +70,20 @@ Find a user research lab - Digital Marketplace
         </ol>
 
         <div class="marketplace-paragraph">
-            <p>Read more about <a href="">how to hire user research labs</a>.</p>
+            <p>Read more about <a href="#">how to hire user research labs</a>.</p>
         </div>
         
         <h2>Download the list of labs</h2>
 
         {%
         with
-        items = [
-        {
-        "title": "List of labs",
-        "link": "#",
-        "file_type": "csv"
-        }
-        ]
+            items = [
+            {
+            "title": "List of labs (???K)",
+            "link": "https://assets.digitalmarketplace.service.gov.uk/catalogues/digital-outcomes-and-specialists/user-research-studios.csv",
+            "file_type": "csv"
+            }
+            ]
         %}
         {% include "toolkit/documents.html" %}
         {% endwith %}

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -38,7 +38,10 @@ Find a user research lab - Digital Marketplace
 
         <h2>Before you start</h2>
         <ol class="list-number">
-            <li>Prepare your requirements and set evaluation criteria.</li>
+            <li>
+                Prepare your requirements and set evaluation criteria.<br />
+                eg a lab in York with a desktop PC and an observation room
+            </li>
             <li>Get approval to buy what you need.</li>
         </ol>
 

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -1,0 +1,96 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}
+Find a user research lab - Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+    {%
+    with items = [
+        {
+        "link": "/",
+        "label": "Digital Marketplace"
+        }
+    ]
+    %}
+        {% include "toolkit/breadcrumb.html" %}
+    {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="grid-row">
+    <div class="column-two-thirds large-paragraph">
+        {% with
+        smaller = true,
+        heading = "Find a user research lab"
+        %}
+        {% include 'toolkit/page-heading.html' %}
+        {% endwith %}
+    </div>
+
+    <div class="column-two-thirds large-paragraph">
+        <div class="marketplace-paragraph">
+            <p>
+                To find a user research lab, you need to tell suppliers what facilities you need and when. They’ll then tell you what they can do and how much it will cost.
+            </p>
+        </div>
+
+        <h2>Before you start</h2>
+        <ol class="list-number">
+            <li>Prepare your requirements and set evaluation criteria.</li>
+            <li>Get approval to buy what you need.</li>
+        </ol>
+
+        <h2>Create a shortlist</h2>
+        <ol class="list-number" start="3">
+            <li>Download the list of user research labs from the Digital Marketplace.</li>
+            <li>Filter the list of labs on location and your requirements to create a shortlist.</li>
+        </ol>
+
+        <h2>Contact your shortlist</h2>
+        <ol class="list-number" start="5">
+            <li>Send your requirements and evaluation criteria to shortlisted suppliers.</li>
+            <li>Answer supplier questions.</li>
+            <li>Suppliers will tell you if they can meet your requirements.</li>
+        </ol>
+
+        <h2>Evaluate</h2>
+        <ol class="list-number" start="8">
+            <li>Evaluate suppliers responses on:
+                <div class="explanation-list">
+                    <ul class="list-bullet">
+                        <li>availability</li>
+                        <li>location, facilities and accessibility</li>
+                        <li>price</li>
+                    </ul>
+                </div>
+            </li>
+            <li>Award a contract to the supplier that best meets your needs.</li>
+        </ol>
+
+        <div class="marketplace-paragraph">
+            <p>Read more about <a href="">how to hire user research labs</a>.</p>
+        </div>
+        
+        <h2>Download the list of labs</h2>
+
+        {%
+        with
+        items = [
+        {
+        "title": "List of labs",
+        "link": "#",
+        "file_type": "csv"
+        }
+        ]
+        %}
+        {% include "toolkit/documents.html" %}
+        {% endwith %}
+
+        <p>Get help filtering the list at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a></p>
+        
+    </div>
+</div>
+
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,12 +34,12 @@
             "body": "eg a booking system or accessibility audit",
           },
           {
-            "link": url_for("buyers.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='user-research-participants'),
+            "link": url_for("main.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='user-research-participants'),
             "title": "Find user research participants",
             "body": "eg people from a specific user group to test your service",
           },
           {
-            "link": url_for("main.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='user-research-studios'),
+            "link": url_for("main.studios_start_page", framework_slug='digital-outcomes-and-specialists'),
             "title": "Find a user research lab",
             "body": "eg a room to conduct research sessions",
           },

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -24,12 +24,12 @@
       {% set
         dos_items = [
           {
-            "link": url_for("buyers.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-specialists'),
+            "link": url_for("main.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-specialists'),
             "title": "Find an individual specialist",
             "body": "eg a developer or user researcher",
           },
           {
-            "link": url_for("buyers.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-outcomes'),
+            "link": url_for("main.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-outcomes'),
             "title": "Find a team to provide an outcome",
             "body": "eg a booking system or accessibility audit",
           },
@@ -39,7 +39,7 @@
             "body": "eg people from a specific user group to test your service",
           },
           {
-            "link": "/somewhere",
+            "link": url_for("main.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='user-research-studios'),
             "title": "Find a user research lab",
             "body": "eg a room to conduct research sessions",
           },

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -536,56 +536,6 @@ class TestUpdateBriefSubmission(BaseApplicationTest):
         assert not data_api_client.update_brief.called
 
 
-@mock.patch('app.main.views.digital_outcomes_and_specialists.data_api_client')
-class TestStartBriefInfoPage(BaseApplicationTest):
-    def test_show_start_brief_info_page(self, data_api_client):
-        with self.app.app_context():
-            self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='live',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                ]
-            )
-
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists")
-            assert res.status_code == 200
-            document = html.fromstring(res.get_data(as_text=True))
-            assert document.xpath('//h1')[0].text_content().strip() == "Find an individual specialist"
-
-    def test_404_if_lot_does_not_allow_brief(self, data_api_client):
-        with self.app.app_context():
-            self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='live',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=False)
-                ]
-            )
-
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists")
-            assert res.status_code == 404
-
-    def test_404_if_framework_status_is_not_live_(self, data_api_client):
-        with self.app.app_context():
-            self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='open',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                ]
-            )
-
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists")
-            assert res.status_code == 404
-
-
 @mock.patch('app.buyers.views.buyers.data_api_client')
 class TestPublishBrief(BaseApplicationTest):
     def test_publish_brief(self, data_api_client):

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -536,7 +536,7 @@ class TestUpdateBriefSubmission(BaseApplicationTest):
         assert not data_api_client.update_brief.called
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.main.views.digital_outcomes_and_specialists.data_api_client')
 class TestStartBriefInfoPage(BaseApplicationTest):
     def test_show_start_brief_info_page(self, data_api_client):
         with self.app.app_context():

--- a/tests/app/views/test_digital_outcomes_and_specialists.py
+++ b/tests/app/views/test_digital_outcomes_and_specialists.py
@@ -1,0 +1,87 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from ...helpers import BaseApplicationTest
+from dmapiclient import api_stubs
+import mock
+from lxml import html
+
+
+@mock.patch('app.main.views.digital_outcomes_and_specialists.data_api_client')
+class TestStartBriefInfoPage(BaseApplicationTest):
+    def test_show_start_brief_info_page(self, data_api_client):
+        with self.app.app_context():
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists")
+            assert res.status_code == 200
+            document = html.fromstring(res.get_data(as_text=True))
+            assert document.xpath('//h1')[0].text_content().strip() == "Find an individual specialist"
+
+    def test_404_if_lot_does_not_allow_brief(self, data_api_client):
+        with self.app.app_context():
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=False)
+                ]
+            )
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists")
+            assert res.status_code == 404
+
+    def test_404_if_framework_status_is_not_live(self, data_api_client):
+        with self.app.app_context():
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='open',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists")
+            assert res.status_code == 404
+
+
+@mock.patch('app.main.views.digital_outcomes_and_specialists.data_api_client')
+class TestStartStudiosInfoPage(BaseApplicationTest):
+    def test_show_start_studios_info_page(self, data_api_client):
+        with self.app.app_context():
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='user-research-studios'),
+                ]
+            )
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/user-research-studios")
+            assert res.status_code == 200
+            document = html.fromstring(res.get_data(as_text=True))
+            assert document.xpath('//h1')[0].text_content().strip() == "Find a user research lab"
+
+    def test_404_if_framework_status_is_not_live(self, data_api_client):
+        with self.app.app_context():
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='open',
+                lots=[
+                    api_stubs.lot(slug='user-research-studios'),
+                ]
+            )
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/user-research-studios")
+            assert res.status_code == 404

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -97,9 +97,7 @@ class TestBuyersHelpers(unittest.TestCase):
             'required1': True,
         }]
 
-        helpers.buyers_helpers.content_loader = content_loader
-
-        assert helpers.buyers_helpers.add_unanswered_counts_to_briefs(briefs) == [{
+        assert helpers.buyers_helpers.add_unanswered_counts_to_briefs(briefs, content_loader) == [{
             'status': 'draft',
             'frameworkSlug': 'dos',
             'lotSlug': 'digital-specialists',


### PR DESCRIPTION
With: @Wynndow 

Fixes this bug: https://www.pivotaltracker.com/story/show/117521463
And completes this story: https://www.pivotaltracker.com/story/show/116129469

This moves the start pages from the `buyers` blueprint to the `main` blueprint, thus making them accessible without logging in.

The CSV of labs itself is not yet finalised, and should only be put up at the live URL when DOS is live.  There's a holding file there for now, just to make sure the link/download works OK:
https://assets.digitalmarketplace.service.gov.uk/catalogues/digital-outcomes-and-specialists/user-research-studios.csv

Also adds the studios start page, which ~~looks like this~~:
       _See comment below for latest screenshot_

~~The link to the guidance doesn't go anywhere yet - waiting for guides to be live on GOV.UK to put the proper URL in.~~ Proper URL now added from the spreadsheet of guidance links.