### PR TITLE
[#117542773] Remove `yet` from home page

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -82,7 +82,7 @@
         {
           "link": "/crown-hosting",
           "title": "Buy physical datacentre space for legacy systems",
-          "body": "eg for services that can’t be migrated to the cloud yet",
+          "body": "eg for services that can’t be migrated to the cloud",
           "subtext": "Procurement framework: <a href='/crown-hosting/framework'>Crown Hosting Data Centres</a>" if not dos_is_live else None
         },
       ] + dss_items + buyer_dashboard


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/117542773

I've checked the functional tests and this change shouldn't break them as far as I can see.