### PR TITLE
Sort out the breadcrumbs

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -47,6 +47,8 @@ def start_new_brief(framework_slug, lot_slug):
     return render_template(
         "buyers/create_brief_question.html",
         brief={},
+        framework=framework,
+        lot=lot,
         section=section,
         question=section.questions[0],
     ), 200
@@ -83,6 +85,8 @@ def create_new_brief(framework_slug, lot_slug):
             "buyers/create_brief_question.html",
             data=update_data,
             brief={},
+            framework=framework,
+            lot=lot,
             section=section,
             question=section.questions[0],
             errors=errors
@@ -346,7 +350,7 @@ def publish_brief(framework_slug, lot_slug, brief_id):
 
     unanswered_required, unanswered_optional = count_unanswered_questions(sections)
     if request.method == 'POST':
-        if (unanswered_required > 0):
+        if unanswered_required > 0:
             abort(400, 'There are still unanswered required questions')
         data_api_client.update_brief_status(brief_id, 'live', brief_user_name)
         return redirect(

--- a/app/templates/buyers/answer_question.html
+++ b/app/templates/buyers/answer_question.html
@@ -12,7 +12,7 @@
         },
         {
           "link": url_for(".buyer_dashboard"),
-          "label": "Your requirements"
+          "label": "Your account"
         },
         {
           "link": url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
@@ -20,7 +20,7 @@
         }
       ]
   %}
-  {% include "toolkit/breadcrumb.html" %}
+    {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
 {% endblock %}
 

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -10,6 +10,10 @@
       {
         "link": "/",
         "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for(".buyer_dashboard"),
+        "label": "Your account"
       }
     ]
   %}

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -3,16 +3,24 @@
 {% block page_title %}Your account - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-    {%
-        with items = [
-        {
-            "link": "/",
-            "label": "Digital Marketplace"
-        }
-        ]
-    %}
+  {%
+    with items = [
+      {
+        "link": "/",
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for(".buyer_dashboard"),
+        "label": "Your account"
+      },
+      {
+        "link": url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+        "label": brief.title
+      }
+    ]
+  %}
     {% include "toolkit/breadcrumb.html" %}
-    {% endwith %}
+  {% endwith %}
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -3,24 +3,24 @@
 {% block page_title %}Responses to {{ brief.title or brief.lotName }} – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-    {%
-        with items = [
+  {%
+      with items = [
         {
-            "link": "/",
-            "label": "Digital Marketplace"
+          "link": "/",
+          "label": "Digital Marketplace"
         },
         {
-            "link": "/buyers",
-            "label": "Your Requirements"
+          "link": url_for(".buyer_dashboard"),
+          "label": "Your account"
         },
         {
-            "link": url_for('buyers.view_brief_overview', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-            "label": brief.title
+        "link": url_for("buyers.view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+        "label": brief.title
         }
-        ]
-    %}
-        {% include "toolkit/breadcrumb.html" %}
-    {% endwith %}
+      ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/buyers/clarification_questions.html
+++ b/app/templates/buyers/clarification_questions.html
@@ -10,8 +10,8 @@
         "label": "Digital Marketplace"
       },
       {
-        "link": url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-        "label": brief.title
+        "link": url_for(".buyer_dashboard"),
+        "label": "Your account"
       }
     ]
   %}
@@ -60,7 +60,7 @@
     </div>
   </div>
 
-  <a href="{{ url_for(".add_clarification_question", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Answer a clarification question</a>
+  <a href="{{ url_for('.add_clarification_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Answer a clarification question</a>
 
   {%
     with

--- a/app/templates/buyers/create_brief_question.html
+++ b/app/templates/buyers/create_brief_question.html
@@ -18,7 +18,7 @@
         "label": "Digital Marketplace"
       },
       {
-        "link": url_for(".info_page_for_starting_a_brief", framework_slug=framework.slug, lot_slug=lot.slug),
+        "link": url_for("main.info_page_for_starting_a_brief", framework_slug=framework.slug, lot_slug=lot.slug),
         "label": previous_title_text
       }
     ]

--- a/app/templates/buyers/create_brief_question.html
+++ b/app/templates/buyers/create_brief_question.html
@@ -3,11 +3,16 @@
 {% import "macros/brief_links.html" as brief_links %}
 
 {% block breadcrumb %}
+  {# TODO: this is the wrong label, probably #}
   {%
     with items = [
       {
         "link": "/",
         "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for(".info_page_for_starting_a_brief", framework_slug=framework.slug, lot_slug=lot.slug),
+        "label": lot.name
       }
     ]
   %}

--- a/app/templates/buyers/create_brief_question.html
+++ b/app/templates/buyers/create_brief_question.html
@@ -2,8 +2,15 @@
 
 {% import "macros/brief_links.html" as brief_links %}
 
+{% set previous_title_text =
+    {
+        "digital-outcomes": "Find a team to provide an outcome",
+        "digital-specialists": "Find an individual specialist",
+        "user-research-participants": "Find user research participants",
+    }[lot.slug]
+%}
+
 {% block breadcrumb %}
-  {# TODO: this is the wrong label, probably #}
   {%
     with items = [
       {
@@ -12,7 +19,7 @@
       },
       {
         "link": url_for(".info_page_for_starting_a_brief", framework_slug=framework.slug, lot_slug=lot.slug),
-        "label": lot.name
+        "label": previous_title_text
       }
     ]
   %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -3,16 +3,16 @@
 {% block page_title %}Your account - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
-    {%
-        with items = [
-        {
-            "link": "/",
-            "label": "Digital Marketplace"
-        }
-        ]
-    %}
+  {%
+    with items = [
+    {
+        "link": "/",
+        "label": "Digital Marketplace"
+    }
+    ]
+  %}
     {% include "toolkit/breadcrumb.html" %}
-    {% endwith %}
+  {% endwith %}
 {% endblock %}
 
 {% block main_content %}

--- a/app/templates/buyers/edit_brief_question.html
+++ b/app/templates/buyers/edit_brief_question.html
@@ -10,6 +10,10 @@
         "label": "Digital Marketplace"
       },
       {
+        "link": url_for(".buyer_dashboard"),
+        "label": "Your account"
+      },
+      {
         "link": url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
         "label": brief.title
       },

--- a/app/templates/buyers/edit_brief_question.html
+++ b/app/templates/buyers/edit_brief_question.html
@@ -3,8 +3,7 @@
 {% import "macros/brief_links.html" as brief_links %}
 
 {% block breadcrumb %}
-  {%
-    with items = [
+  {% set base_breadcrumbs = [
       {
         "link": "/",
         "label": "Digital Marketplace"
@@ -16,12 +15,16 @@
       {
         "link": url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
         "label": brief.title
-      },
-      {
-        "link": url_for(".view_brief_section_summary", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug),
-        "label": section.name
       }
     ]
+  %}
+  {% set section_breadcrumb = [{
+        "link": url_for(".view_brief_section_summary", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug),
+        "label": section.name
+      }] if section.has_summary_page else []
+  %}
+  {%
+    with items = base_breadcrumbs + section_breadcrumb
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}

--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -10,6 +10,10 @@
         "label": "Digital Marketplace"
       },
       {
+        "link": url_for(".buyer_dashboard"),
+        "label": "Your account"
+      },
+      {
         "link": url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
         "label": brief.title
       }

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -373,6 +373,32 @@ class TestEveryDamnPage(BaseApplicationTest):
 
 @mock.patch('app.buyers.views.buyers.data_api_client')
 class TestEditBriefSubmission(BaseApplicationTest):
+
+    def _test_breadcrumbs_on_question_page(self, response, has_summary_page=False, section_name=None):
+        breadcrumbs = html.fromstring(response.get_data(as_text=True)).xpath(
+            '//*[@id="global-breadcrumb"]/nav/ol/li'
+        )
+
+        breadcrumbs_we_expect = [
+            ('Digital Marketplace', '/'),
+            ('Your account', '/buyers'),
+            ('I need a thing to do a thing',
+             '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234')
+        ]
+        if has_summary_page and section_name:
+            breadcrumbs_we_expect.append((
+                section_name,
+                '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/{}'.format(
+                    section_name.lower().replace(' ', '-')
+                )
+            ))
+
+        assert len(breadcrumbs) == len(breadcrumbs_we_expect)
+
+        for index, link in enumerate(breadcrumbs_we_expect):
+            assert breadcrumbs[index].find('a').text_content().strip() == link[0]
+            assert breadcrumbs[index].find('a').get('href').strip() == link[1]
+
     def test_edit_brief_submission(self, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
@@ -420,6 +446,7 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert document.xpath(
             '//form//div[contains(@class, "secondary-action-link")]/a'
         )[0].get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-4"  # noqa
+        self._test_breadcrumbs_on_question_page(response=res, has_summary_page=True, section_name='Section 4')
 
     @mock.patch("app.buyers.views.buyers.content_loader")
     def test_edit_brief_submission_return_link_to_section_summary_if_other_questions(self, content_loader,
@@ -448,6 +475,7 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert document.xpath(
             '//form//div[contains(@class, "secondary-action-link")]/a'
         )[0].get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-1"  # noqa
+        self._test_breadcrumbs_on_question_page(response=res, has_summary_page=True, section_name='Section 1')
 
     @mock.patch("app.buyers.views.buyers.content_loader")
     def test_edit_brief_submission_return_link_to_brief_overview_if_single_question(self, content_loader,
@@ -476,6 +504,7 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert document.xpath(
             '//form//div[contains(@class, "secondary-action-link")]/a'
         )[0].get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"  # noqa
+        self._test_breadcrumbs_on_question_page(response=res, has_summary_page=False)
 
     @mock.patch("app.buyers.views.buyers.content_loader")
     def test_edit_brief_submission_multiquestion(self, content_loader, data_api_client):

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -417,9 +417,9 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
         assert document.xpath('//h1')[0].text_content().strip() == "Optional 2"
-        document.xpath(
+        assert document.xpath(
             '//form//div[contains(@class, "secondary-action-link")]/a'
-        )[0].get('url') == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/section-4"  # noqa
+        )[0].get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-4"  # noqa
 
     @mock.patch("app.buyers.views.buyers.content_loader")
     def test_edit_brief_submission_return_link_to_section_summary_if_other_questions(self, content_loader,
@@ -445,9 +445,9 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
         assert document.xpath('//h1')[0].text_content().strip() == "Required 1"
-        document.xpath(
+        assert document.xpath(
             '//form//div[contains(@class, "secondary-action-link")]/a'
-        )[0].get('url') == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/section-1"  # noqa
+        )[0].get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-1"  # noqa
 
     @mock.patch("app.buyers.views.buyers.content_loader")
     def test_edit_brief_submission_return_link_to_brief_overview_if_single_question(self, content_loader,
@@ -473,9 +473,9 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
         assert document.xpath('//h1')[0].text_content().strip() == "Required 2"
-        document.xpath(
+        assert document.xpath(
             '//form//div[contains(@class, "secondary-action-link")]/a'
-        )[0].get('url') == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/section-2"  # noqa
+        )[0].get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"  # noqa
 
     @mock.patch("app.buyers.views.buyers.content_loader")
     def test_edit_brief_submission_multiquestion(self, content_loader, data_api_client):


### PR DESCRIPTION
Breadcrumbs have always been fine for navigating around a brief, but
there's never been a link back to the buyer dashboard (aka, "Your
requirements") in any of the breadcrumbs.
Added them in where they were missing/necessary.

Talked to @ralph-hawkins about them, so they should be okay.

Did a cool thing around only doing breadcrumbs back to section summary pages if `section.has_summary_page` is `True` and added tests for it.

Only pages I didn't update the breadcrumbs on are those clarification question pages because they have to be updated anyway.

***

### brief overview
![screen shot 2016-04-19 at 12 40 41](https://cloud.githubusercontent.com/assets/2454380/14637943/972fa8e4-062c-11e6-88ea-de1b93d265f5.png)

***

### section summary 
![screen shot 2016-04-19 at 12 41 33](https://cloud.githubusercontent.com/assets/2454380/14637976/c3885ec2-062c-11e6-86ef-5c8170570584.png)

***

### question page (with section summary)
![screen shot 2016-04-19 at 12 41 50](https://cloud.githubusercontent.com/assets/2454380/14637971/bc044404-062c-11e6-8448-87d3694f576a.png)

***

### question page (w/o section summary)
![screen shot 2016-04-19 at 12 41 12](https://cloud.githubusercontent.com/assets/2454380/14637952/aa7aafb6-062c-11e6-954f-9ae095458223.png)