### PR TITLE
Bleeding edge updates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.6.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.9.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.29.0"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.5.0#egg=digitalmarketplace-utils==19.5.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.7.0#egg=digitalmarketplace-utils==19.7.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0


### PR DESCRIPTION
Brings in the latest utils as well as the latest frontend toolkit ([frameworks having already been updated by @TheDoubleK](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/264)). 

Means we can:
- do `abbr`s in the framework notice (happy days!)
- show multiquestions more perspicuously on summary pages

***

## abbr
![screen shot 2016-04-20 at 10 29 44](https://cloud.githubusercontent.com/assets/2454380/14670101/95789d5a-06e3-11e6-9c5a-462fa7eb02c3.png)

## multiquestions
![screen shot 2016-04-20 at 10 30 58](https://cloud.githubusercontent.com/assets/2454380/14670105/97e4224e-06e3-11e6-866e-85b3f0da0112.png)
