### PR TITLE
Pc supplement steps with states

### DIFF
--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -53,6 +53,7 @@
                 {
                   'href': url_for(".publish_brief",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': 'Review and publish your requirements',
+                  'allowed_statuses': 'draft'
                 }
               ]
             },
@@ -62,11 +63,13 @@
               'links': [
                 {
                   'href': url_for(".clarification_questions",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-                  'text': 'Publish questions and answers'
+                  'text': 'Publish questions and answers',
+                  'allowed_statuses': 'live'
                 },
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-answer-supplier-questions-on-the-digital-marketplace',
-                  'text': 'How to answer supplier questions'
+                  'text': 'How to answer supplier questions',
+                  'allowed_statuses': ['draft', 'live']
                 }
               ]
             },
@@ -77,6 +80,7 @@
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers',
                   'text': 'How to shortlist suppliers',
+                  'allowed_statuses': ['draft', 'live']
                 }
               ]
             },
@@ -86,7 +90,8 @@
               'links': [
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers',
-                  'text': 'How to evaluate suppliers'
+                  'text': 'How to evaluate suppliers',
+                  'allowed_statuses': ['draft', 'live']
                 }
               ]
             },
@@ -95,7 +100,8 @@
               'links': [
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services',
-                  'text': 'How to award a contract'
+                  'text': 'How to award a contract',
+                  'allowed_statuses': ['draft', 'live']
                 }
               ]
             }
@@ -111,7 +117,7 @@
             {% if step.description %}
               <p class="instruction-list-item-extra-information">{{ step.description }}</p>
             {% endif %}
-            {% if step_number in step_sections %}
+            {% if step_number in step_sections and brief.status == 'draft' %}
               {% if step_sections.count(step_number) == 1 %}
                 {% set section = sections.sections[step_sections.index(step_number)] %}
                 <a class="instruction-list-item-extra-information" href="{{ brief_links.brief_link_url('grandparent', section, brief) }}">
@@ -140,9 +146,11 @@
               {% else %}
                 <ul class="instruction-list-item-extra-information">
                   {% for link in step.links %}
-                    <li>
-                      <a href="{{ link.href }}">{{ link.text }}</a>
-                    </li>
+                    {% if brief.status in link.allowed_statuses %}
+                      <li>
+                        <a href="{{ link.href }}">{{ link.text }}</a>
+                      </li>
+                    {% endif %}
                   {% endfor %}
                 </ul>
               {% endif %}

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -41,11 +41,13 @@
           steps = [
             {
               'title': 'Write requirements',
-              'description': 'Before you can publish your requirements, you must complete:'
+              'description': 'Before you can publish your requirements, you must complete:',
+              'allowed_statuses': ['draft']
             },
             {
               'title': 'Set how you’ll evaluate suppliers',
-              'description': 'Before you can publish your requirements, you must complete:'
+              'description': 'Before you can publish your requirements, you must complete:',
+              'allowed_statuses': ['draft']
             },
             {
               'title': 'Publish requirements',
@@ -53,7 +55,12 @@
                 {
                   'href': url_for(".publish_brief",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': 'Review and publish your requirements',
-                  'allowed_statuses': 'draft'
+                  'allowed_statuses': ['draft']
+                },
+                {
+                  'href': url_for("main.get_brief_by_id", framework_slug=brief.frameworkSlug, brief_id=brief.id),
+                  'text': 'View published requirements',
+                  'allowed_statuses': ['live', 'closed']
                 }
               ]
             },
@@ -64,12 +71,11 @@
                 {
                   'href': url_for(".clarification_questions",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': 'Publish questions and answers',
-                  'allowed_statuses': 'live'
+                  'allowed_statuses': ['live']
                 },
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-answer-supplier-questions-on-the-digital-marketplace',
                   'text': 'How to answer supplier questions',
-                  'allowed_statuses': ['draft', 'live']
                 }
               ]
             },
@@ -80,7 +86,6 @@
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers',
                   'text': 'How to shortlist suppliers',
-                  'allowed_statuses': ['draft', 'live']
                 }
               ]
             },
@@ -91,7 +96,6 @@
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers',
                   'text': 'How to evaluate suppliers',
-                  'allowed_statuses': ['draft', 'live']
                 }
               ]
             },
@@ -101,7 +105,6 @@
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services',
                   'text': 'How to award a contract',
-                  'allowed_statuses': ['draft', 'live']
                 }
               ]
             }
@@ -114,8 +117,10 @@
             <h2 class="instruction-list-item-body">
               <span class="step-number" role="presentation">{{ step_number }}. </span>
               {{ step.title }}</h2>
-            {% if step.description %}
+            {% if step.description and (not step.allowed_statuses or brief.status in step.allowed_statuses) %}
               <p class="instruction-list-item-extra-information">{{ step.description }}</p>
+            {% elif 'draft' in step.allowed_statuses and brief.status not in step.allowed_statuses %}
+              <p class="instruction-list-item-extra-information">Done</p>
             {% endif %}
             {% if step_number in step_sections and brief.status == 'draft' %}
               {% if step_sections.count(step_number) == 1 %}
@@ -141,19 +146,15 @@
               {% endif %}
             {% endif %}
             {% if step.links %}
-              {% if step.links|length == 1 %}
-                <a class="instruction-list-item-extra-information" href="{{ step.links[0].href }}">{{ step.links[0].text }}</a>
-              {% else %}
-                <ul class="instruction-list-item-extra-information">
-                  {% for link in step.links %}
-                    {% if brief.status in link.allowed_statuses %}
-                      <li>
-                        <a href="{{ link.href }}">{{ link.text }}</a>
-                      </li>
-                    {% endif %}
-                  {% endfor %}
-                </ul>
-              {% endif %}
+              <ul class="instruction-list-item-extra-information">
+                {% for link in step.links %}
+                  {% if not link.allowed_statuses or brief.status in link.allowed_statuses %}
+                    <li>
+                      <a href="{{ link.href }}">{{ link.text }}</a>
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
             {% endif %}
           </li>
         {% endfor %}

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -41,16 +41,27 @@
           steps = [
             {
               'title': 'Write requirements',
-              'description': 'Before you can publish your requirements, you must complete:',
-              'allowed_statuses': ['draft']
+              'description': {
+                'draft': 'Before you can publish your requirements, you must complete:',
+                'live': 'Done',
+                'closed': 'Done',
+              },
             },
             {
               'title': 'Set how you’ll evaluate suppliers',
-              'description': 'Before you can publish your requirements, you must complete:',
-              'allowed_statuses': ['draft']
+              'description': {
+                'draft': 'Before you can publish your requirements, you must complete:',
+                'live': 'Done',
+                'closed': 'Done',
+              },
             },
             {
               'title': 'Publish requirements',
+              'description': {
+                'draft': '',
+                'live': 'Your requirements are open for applications until {}.'.format(brief.applicationsClosedAt | dateformat),
+                'closed': 'Your requirements closed for applications on {}.'.format(brief.applicationsClosedAt | dateformat),
+              },
               'links': [
                 {
                   'href': url_for(".publish_brief",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
@@ -66,7 +77,11 @@
             },
             {
               'title': 'Answer supplier questions',
-              'description': 'When you’ve published your requirements, you must answer all supplier questions.',
+              'description': {
+                'draft': 'When you’ve published your requirements, you must answer all supplier questions.',
+                'live': 'You must answer all questions by {}. Suppliers will send you questions by email.'.format(brief.clarificationQuestionsPublishedBy | dateformat),
+                'closed': 'Done',
+              },
               'links': [
                 {
                   'href': url_for(".clarification_questions",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
@@ -76,13 +91,23 @@
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-answer-supplier-questions-on-the-digital-marketplace',
                   'text': 'How to answer supplier questions',
+                  'allowed_statuses': ['draft', 'live']
                 }
               ]
             },
             {
               'title': 'Shortlist',
-              'description': 'After the application deadline, shortlist the suppliers who applied.',
+              'description': {
+                'draft': 'After the application deadline, shortlist the suppliers who applied.',
+                'live': 'After the application deadline, shortlist the suppliers who applied.',
+                'closed': 'You can view and shortlist suppliers who best meet your needs.',
+              },
               'links': [
+                {
+                  'href': url_for(".view_brief_responses", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  'text': 'View and shortlist suppliers',
+                  'allowed_statuses': ['closed']
+                },
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers',
                   'text': 'How to shortlist suppliers',
@@ -91,7 +116,11 @@
             },
             {
               'title': 'Evaluate',
-              'description': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
+              'description': {
+                'draft': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
+                'live': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
+                'closed': 'Evaluate your shortlist using the criteria and methods you published with your requirements.',
+              },
               'links': [
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-evaluate-digital-outcomes-and-specialists-suppliers',
@@ -101,6 +130,11 @@
             },
             {
               'title': 'Award a contract',
+              'description': {
+                'draft': 'You must give your chosen supplier a contract before they start work.',
+                'live': 'You must give your chosen supplier a contract before they start work.',
+                'closed': 'You must give your chosen supplier a contract before they start work.',
+              },
               'links': [
                 {
                   'href': 'https://www.gov.uk/guidance/how-to-award-a-contract-when-you-buy-services',
@@ -117,10 +151,8 @@
             <h2 class="instruction-list-item-body">
               <span class="step-number" role="presentation">{{ step_number }}. </span>
               {{ step.title }}</h2>
-            {% if step.description and (not step.allowed_statuses or brief.status in step.allowed_statuses) %}
-              <p class="instruction-list-item-extra-information">{{ step.description }}</p>
-            {% elif 'draft' in step.allowed_statuses and brief.status not in step.allowed_statuses %}
-              <p class="instruction-list-item-extra-information">Done</p>
+            {% if step.description %}
+              <p class="instruction-list-item-extra-information">{{ step.description[brief.status] }}</p>
             {% endif %}
             {% if step_number in step_sections and brief.status == 'draft' %}
               {% if step_sections.count(step_number) == 1 %}

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1259,7 +1259,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
             assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
                 'View published requirements',
-                'How to answer supplier questions',
+                'View and shortlist suppliers',
                 'How to shortlist suppliers',
                 'How to evaluate suppliers',
                 'How to award a contract',


### PR DESCRIPTION
### Set allowed statuses for brief overview page steps
Hides the step description based on step.allowed_statuses. Shows 'Done' instead of the step description for live briefs on draft brief steps.

allowed_statuses defaults to all possible statuses, so when not set the link/step will be always displayed (eg for guidance links).

### Split brief overview page step descriptions for each brief status
Sets a separate step descriptions for each available brief status. This simplifies the 'Done' description logic and allows setting different descriptions for any brief state, but requires some duplication for descriptions that don't change.

# Draft brief

![screen shot 2016-04-20 at 13 38 11](https://cloud.githubusercontent.com/assets/246664/14674741/60a1950e-06fd-11e6-9b08-c446b707177f.png)

# Live brief

![screen shot 2016-04-20 at 13 38 23](https://cloud.githubusercontent.com/assets/246664/14674750/68f5796e-06fd-11e6-9a69-4b8b33508020.png)

# Closed brief

![screen shot 2016-04-20 at 13 38 33](https://cloud.githubusercontent.com/assets/246664/14674757/6f3492ba-06fd-11e6-8c49-d2bc8bb979ef.png)

