### PR TITLE
Add delete button to brief overview

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -101,7 +101,8 @@ def create_new_brief(framework_slug, lot_slug):
 
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>', methods=['GET'])
 def view_brief_overview(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    framework, lot = get_framework_and_lot(
+        framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
@@ -123,6 +124,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
 
     return render_template(
         "buyers/brief_overview.html",
+        framework=framework,
         confirm_remove=request.args.get("confirm_remove", None),
         brief=brief,
         sections=sections,

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -378,15 +378,9 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):
         abort(404)
 
-    if request.form.get('delete_confirmed'):
         data_api_client.delete_brief(brief_id, current_user.email_address)
         flash({"requirements_deleted": brief.get("title")})
         return redirect(url_for('.buyer_dashboard'))
-    else:
-        return redirect(
-            url_for('.view_brief_overview', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'],
-                    brief_id=brief['id'], delete_requested=True)
-        )
 
 
 @buyers.route(

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -378,9 +378,9 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):
         abort(404)
 
-        data_api_client.delete_brief(brief_id, current_user.email_address)
-        flash({"requirements_deleted": brief.get("title")})
-        return redirect(url_for('.buyer_dashboard'))
+    data_api_client.delete_brief(brief_id, current_user.email_address)
+    flash({"requirements_deleted": brief.get("title")})
+    return redirect(url_for('.buyer_dashboard'))
 
 
 @buyers.route(

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -24,7 +24,22 @@
 {% block main_content %}
   <div class="grid-row">
 
-    {% block before_heading %}{% endblock %}
+    {% block before_heading %}
+      {% if delete_requested %}
+        <div class="column-one-whole">
+          <form action="{{ url_for('buyers.delete_a_brief', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+            <input type="hidden" name="delete_confirmed" value="true" />
+            <div class="banner-destructive-with-action">
+              <p class="banner-message">
+               Are you sure you want to delete these requirements?
+              </p>
+              <button type="submit" class="button-destructive banner-action">Yes, delete</button>
+            </div>
+          </form>
+        </div>
+      {% endif %}
+   {% endblock %}
     <div class="column-two-thirds">
       {% with
         heading = brief.get('title', brief['lotName']),
@@ -195,4 +210,13 @@
     </div>
 
   </div>
+  {% if not delete_requested %}
+     <div class="grid-row">
+       <div class="column-two-thirds">
+         {% if framework.status == 'live' and brief.status == 'draft' %}
+         <a href="{{ url_for('buyers.view_brief_overview', framework_slug=framework.slug, lot_slug=brief.lotSlug, brief_id=brief.id, delete_requested=True) }}">Delete</a>
+         {% endif %}
+       </div>
+     </div>
+   {% endif %}
 {% endblock %}


### PR DESCRIPTION
#### Add UI to allow deletion of draft briefs
Replace the delete button previously there with a link to the same page so users can confirm through the banner form that is displayed then.

