### PR TITLE
[#118019637] Bugfix for brief responses with zero nice-to-haves

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -276,7 +276,7 @@ def download_brief_responses(framework_slug, lot_slug, brief_id):
     if brief['status'] != "closed":
         abort(404)
 
-    sorted_brief_responses = get_sorted_responses_for_brief(brief_id, data_api_client)
+    sorted_brief_responses = get_sorted_responses_for_brief(brief, data_api_client)
 
     content = content_loader.get_manifest(brief['frameworkSlug'], 'output_brief_response').filter(
         {'lot': brief['lotSlug']}

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -72,10 +72,13 @@ def all_essentials_are_true(brief_response):
     return all(brief_response['essentialRequirements'])
 
 
-def get_sorted_responses_for_brief(brief_id, data_api_client):
-    brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
-    return sorted(
-        brief_responses,
-        key=lambda k: len([nice for nice in k['niceToHaveRequirements'] if nice is True]),
-        reverse=True
-    )
+def get_sorted_responses_for_brief(brief, data_api_client):
+    brief_responses = data_api_client.find_brief_responses(brief['id'])['briefResponses']
+    if brief.get("niceToHaveRequirements"):
+        return sorted(
+            brief_responses,
+            key=lambda k: len([nice for nice in k['niceToHaveRequirements'] if nice is True]),
+            reverse=True
+        )
+    else:
+        return brief_responses

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -150,8 +150,9 @@ class TestBuyersHelpers(unittest.TestCase):
                 {"id": "four", "niceToHaveRequirements": [True, True, True, True, False]},
             ]
         }
+        brief = {"id": 1, "niceToHaveRequirements": ["Nice", "to", "have", "yes", "please"]}
 
-        assert helpers.buyers_helpers.get_sorted_responses_for_brief(1, data_api_client) == [
+        assert helpers.buyers_helpers.get_sorted_responses_for_brief(brief, data_api_client) == [
             {'id': 'five', 'niceToHaveRequirements': [True, True, True, True, True]},
             {'id': 'five', 'niceToHaveRequirements': [True, True, True, True, True]},
             {'id': 'four', 'niceToHaveRequirements': [True, True, True, True, False]},
@@ -159,4 +160,22 @@ class TestBuyersHelpers(unittest.TestCase):
             {'id': 'three', 'niceToHaveRequirements': [True, True, False, False, True]},
             {"id": "one", "niceToHaveRequirements": [False, False, False, True, False]},
             {'id': 'zero', 'niceToHaveRequirements': [False, False, False, False, False]}
+        ]
+
+    def test_get_sorted_responses_does_not_sort_if_no_nice_to_haves(self):
+        data_api_client = mock.Mock()
+        data_api_client.find_brief_responses.return_value = {
+            "briefResponses": [
+                {"id": "five"},
+                {"id": "zero"},
+                {"id": "three"},
+                {"id": "five"}
+            ]
+        }
+        brief = {"id": 1, "niceToHaveRequirements": []}
+        assert helpers.buyers_helpers.get_sorted_responses_for_brief(brief, data_api_client) == [
+            {"id": "five"},
+            {"id": "zero"},
+            {"id": "three"},
+            {"id": "five"}
         ]


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/118019637

Currently the CSV generation for downloading responses to briefs always tries to sort them in descending order of the number of nice-to-have requirements.

But if the brief has NO nice-to-haves the call to sort causes an error. (e.g., see excerpt from AWS logs below).

This adds a check that niceToHaveRequirements exists before attempting to sort.  If it doesn't then we just return them in the order they come back from the API.

```
{
    "name": "app",
    "levelname": "ERROR",
    "message": "Exception on /buyers/frameworks/digital-outcomes-and-specialists/requirements/user-research-participants/48/responses/download [GET]",
    "pathname": "/opt/python/run/venv/lib/python2.7/site-packages/flask/app.py",
    "lineno": 1423,
    "exc_info": "Traceback (most recent call last):\n  File \"/opt/python/run/venv/lib/python2.7/site-packages/flask/app.py\", line 1817, in wsgi_app\n    response = self.full_dispatch_request()\n  File \"/opt/python/run/venv/lib/python2.7/site-packages/flask/app.py\", line 1477, in full_dispatch_request\n    rv = self.handle_user_exception(e)\n  File \"/opt/python/run/venv/lib/python2.7/site-packages/flask/app.py\", line 1381, in handle_user_exception\n    reraise(exc_type, exc_value, tb)\n  File \"/opt/python/run/venv/lib/python2.7/site-packages/flask/app.py\", line 1475, in full_dispatch_request\n    rv = self.dispatch_request()\n  File \"/opt/python/run/venv/lib/python2.7/site-packages/flask/app.py\", line 1461, in dispatch_request\n    return self.view_functions[rule.endpoint](**req.view_args)\n  File \"/opt/python/current/app/app/buyers/views/buyers.py\", line 237, in download_brief_responses\n    sorted_brief_responses = get_sorted_responses_for_brief(brief_id, data_api_client)\n  File \"/opt/python/current/app/app/helpers/buyers_helpers.py\", line 83, in get_sorted_responses_for_brief\n    reverse=True\n  File \"/opt/python/current/app/app/helpers/buyers_helpers.py\", line 82, in <lambda>\n    key=lambda k: len([nice for nice in k['niceToHaveRequirements'] if nice is True]),\nKeyError: 'niceToHaveRequirements'",
    "requestId": "3b5cf019-59d5-42ba-8db4-1770abb5e083",
    "application": "buyer-frontend",
    "time": "2016-04-20T15:17:09",
    "logType": "application"
}
```