### PR TITLE
Opportunity page should display dates

### DIFF
--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -1,7 +1,9 @@
 {% import "toolkit/summary-table.html" as summary %}
 {% call(item) summary.list_table(
   [
-    {"label": "Published", "value": brief.publishedAt|dateformat}
+    {"label": "Published", "value": brief.publishedAt|dateformat},
+    {"label": "Deadline for asking questions", "value": brief.clarificationQuestionsPublishedBy|dateformat},
+    {"label": "Closing date for applications", "value": brief.applicationsClosedAt|dateformat}
   ],
   caption="Important dates",
   field_headings=[

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -2,7 +2,7 @@
 {% call(item) summary.list_table(
   [
     {"label": "Published", "value": brief.publishedAt|dateformat},
-    {"label": "Deadline for asking questions", "value": brief.clarificationQuestionsPublishedBy|dateformat},
+    {"label": "Deadline for asking questions", "value": brief.clarificationQuestionsClosedAt|dateformat},
     {"label": "Closing date for applications", "value": brief.applicationsClosedAt|dateformat}
   ],
   caption="Important dates",

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -314,6 +314,8 @@ class TestBriefPage(BaseApplicationTest):
 
     def test_dos_brief_has_important_dates(self):
         brief_id = self.brief['briefs']['id']
+        self.brief['briefs']['clarificationQuestionsClosedAt'] = "2016-03-10T11:08:28.054129Z"
+        self.brief['briefs']['applicationsClosedAt'] = "2016-03-11T11:08:28.054129Z"
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
 
@@ -325,10 +327,16 @@ class TestBriefPage(BaseApplicationTest):
         assert_equal(len(brief_important_dates), 3)
         assert_true(brief_important_dates[0].xpath(
             'td[@class="summary-item-field-first"]')[0].text_content().strip(), "Published")
+        assert_true(brief_important_dates[0].xpath(
+            'td[@class="summary-item-field"]')[0].text_content().strip(), "Thursday 25 February 2016")
         assert_true(brief_important_dates[1].xpath(
             'td[@class="summary-item-field-first"]')[0].text_content().strip(), "Deadline for asking questions")
+        assert_true(brief_important_dates[1].xpath(
+            'td[@class="summary-item-field"]')[0].text_content().strip(), "Thursday 10 March 2016")
         assert_true(brief_important_dates[2].xpath(
             'td[@class="summary-item-field-first"]')[0].text_content().strip(), "Closing date for applications")
+        assert_true(brief_important_dates[2].xpath(
+            'td[@class="summary-item-field"]')[0].text_content().strip(), "Thursday 11 March 2016")
 
     def test_dos_brief_has_at_least_one_section(self):
         brief_id = self.brief['briefs']['id']

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -312,6 +312,24 @@ class TestBriefPage(BaseApplicationTest):
 
         self._assert_page_title(document)
 
+    def test_dos_brief_has_important_dates(self):
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert_equal(200, res.status_code)
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        brief_important_dates = document.xpath(
+            '//table[@class="summary-item-body"][1]/tbody/tr')
+
+        assert_equal(len(brief_important_dates), 3)
+        assert_true(brief_important_dates[0].xpath(
+            'td[@class="summary-item-field-first"]')[0].text_content().strip(), "Published")
+        assert_true(brief_important_dates[1].xpath(
+            'td[@class="summary-item-field-first"]')[0].text_content().strip(), "Deadline for asking questions")
+        assert_true(brief_important_dates[2].xpath(
+            'td[@class="summary-item-field-first"]')[0].text_content().strip(), "Closing date for applications")
+
     def test_dos_brief_has_at_least_one_section(self):
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -322,7 +322,7 @@ class TestBriefPage(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         brief_important_dates = document.xpath(
-            '//table[@class="summary-item-body"][1]/tbody/tr')
+            '(//table[@class="summary-item-body"])[1]/tbody/tr')
 
         assert_equal(len(brief_important_dates), 3)
         assert_true(brief_important_dates[0].xpath(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/118006933

Under published date opportunity pages now also show:
- Deadline for asking questions
- Closing date for applications

![opportunity_with_new_dates](https://cloud.githubusercontent.com/assets/87140/14682069/cea31802-071b-11e6-9cd9-cc1405df4bab.png)
