### PR TITLE
Add publishing brief dates

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -10,7 +10,7 @@ from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
     all_essentials_are_true, counts_for_failed_and_eligible_brief_responses,
     get_framework_and_lot, get_sorted_responses_for_brief, count_unanswered_questions,
-    brief_can_be_edited, add_unanswered_counts_to_briefs, is_brief_correct
+    brief_can_be_edited, add_unanswered_counts_to_briefs, is_brief_correct, get_publishing_dates
 )
 
 from dmapiclient import HTTPError
@@ -360,13 +360,15 @@ def publish_brief(framework_slug, lot_slug, brief_id):
                     brief_id=brief['id']))
     else:
         email_address = brief_users['emailAddress']
+        dates = get_publishing_dates()
 
         return render_template(
             "buyers/brief_publish_confirmation.html",
             email_address=email_address,
             unanswered_required=unanswered_required,
             sections=sections,
-            brief=brief
+            brief=brief,
+            dates=dates
         ), 200
 
 

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -1,4 +1,6 @@
 from flask import abort
+from datetime import datetime, timedelta
+from dmutils.formats import shortdateformat
 
 
 def get_framework_and_lot(framework_slug, lot_slug, data_api_client, status=None, must_allow_brief=False):
@@ -82,3 +84,23 @@ def get_sorted_responses_for_brief(brief, data_api_client):
         )
     else:
         return brief_responses
+
+
+def get_publishing_dates():
+    application_open_days = 14
+    questions_open_days = application_open_days - 7
+    answers_open_days = application_open_days - 1
+
+    dates = {}
+
+    dates['today'] = datetime.now().replace(hour=23, minute=59, second=59, microsecond=0)
+    dates['questions_close'] = dates['today'] + timedelta(days=questions_open_days)
+    dates['answers_close'] = dates['today'] + timedelta(days=answers_open_days)
+    closing_date = dates['today'] + timedelta(days=application_open_days)
+    dates['closing_date'] = closing_date
+
+    for date in dates:
+        dates[date] = shortdateformat(dates[date])
+    dates['application_open_weeks'] = application_open_days/7
+    dates['closing_time'] = '{d:%I:%M %p}'.format(d=closing_date).lower()
+    return dates

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -35,9 +35,8 @@
         {% include "toolkit/page-heading.html" %}
     {% endwith %}
     <p class="padding-bottom-small">All requirements are published on the Digital Marketplace where anyone can see them.</p>
-
-    <p><strong>Suppliers will be able to apply for:</strong></p>
-    <p class="padding-bottom-small">2 weeks ending at midnight.</p>
+    <p class="padding-bottom-small">All requirements are open for {{ dates.application_open_weeks }} weeks.</p>
+    <p class="padding-bottom-small">If you publish your requirements today ({{ dates.today }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date }}.</p>
 
     <p><strong>Supplier questions will be sent to:</strong></p>
     <p class="padding-bottom-small">{{ email_address }}</p>
@@ -57,6 +56,49 @@
         {% endfor %}
       {% endfor %}
     {% else %}
+      {% import "toolkit/summary-table.html" as summary %}
+        {% call summary.mapping_table(
+        row_bold_borders=True,
+        text_large = True,
+        no_bottom_border=True,
+        caption="If you publish today, you must be aware of the following dates:",
+        caption_visible=True,
+        field_headings=[
+          "Date",
+          "Notice",
+        ],
+        field_headings_visible=False
+      ) %}
+        {% call summary.row(no_border=True) %}
+          {{ summary.field_heading_date("Today", scope='row') }}
+          {{ summary.text("Suppliers can apply and ask questions about your requirements.") }}
+        {% endcall %}
+        {% call summary.row(bold_border=True) %}
+          {{ summary.field_heading_date("Before {}".format(dates.questions_close), rowspan='3', scope='row') }}
+          {{ summary.text_bold("Details of your question and answer session") }}
+        {% endcall %}
+        {% call summary.row(no_border=True) %}
+          {{ summary.text("Question and answer session information.") }}
+        {% endcall %}
+        {% call summary.row(no_border=True) %}
+          {{ summary.text_bold("You must hold your question and answer session before {}.".format(dates.questions_close), border=True) }}
+        {% endcall %}
+        {% call summary.row(bold_border=True) %}
+          {{ summary.field_heading_date(dates.questions_close, scope='row') }}
+          {{ summary.text("Suppliers can no longer ask questions.") }}
+        {% endcall %}
+        {% call summary.row(bold_border=True) %}
+          {{ summary.field_heading_date(dates.answers_close, rowspan='2', scope='row') }}
+          {{ summary.text("You must have published answers to all suppliers’ questions.") }}
+        {% endcall %}
+        {% call summary.row(no_border=True) %}
+          {{ summary.text("If dates.answers_close is a Saturday or Sunday, you need to have published all questions and answers by the Friday before.", border=True) }}
+        {% endcall %}
+        {% call summary.row(bold_border=True) %}
+          {{ summary.field_heading_date(dates.closing_date, scope='row') }}
+          {{ summary.text("Suppliers can no longer apply.") }}
+        {% endcall %}
+      {% endcall %}
       <form action="{{ url_for('.publish_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         {%

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.9.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.10.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.29.0"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.7.0#egg=digitalmarketplace-utils==19.7.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.7.2#egg=digitalmarketplace-utils==19.7.2
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0


### PR DESCRIPTION
Add publishing brief dates and new summary table using current version of frontend toolkit.

Update to use dmutils with short date format without localised time format.

<img width="671" alt="screen shot 2016-04-20 at 18 48 03" src="https://cloud.githubusercontent.com/assets/11633362/14684836/b82720ba-0729-11e6-8174-7c039b90911d.png">

<img width="765" alt="screen shot 2016-04-20 at 18 48 12" src="https://cloud.githubusercontent.com/assets/11633362/14684868/d18e30ac-0729-11e6-8e01-380d128e930b.png">
