### PR TITLE
Add publishing brief dates

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -10,7 +10,7 @@ from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
     all_essentials_are_true, counts_for_failed_and_eligible_brief_responses,
     get_framework_and_lot, get_sorted_responses_for_brief, count_unanswered_questions,
-    brief_can_be_edited, add_unanswered_counts_to_briefs, is_brief_correct
+    brief_can_be_edited, add_unanswered_counts_to_briefs, is_brief_correct, get_publishing_dates
 )
 
 from dmapiclient import HTTPError
@@ -349,6 +349,13 @@ def publish_brief(framework_slug, lot_slug, brief_id):
     brief_user_name = brief_users['name']
 
     sections = content.summary(brief)
+    question_and_answers = {}
+    question_and_answers_content = sections.get_question('questionAndAnswerSessionDetails')
+    question_and_answers['id'] = question_and_answers_content['id']
+
+    for section in sections:
+        if section.get_question('questionAndAnswerSessionDetails') == question_and_answers_content:
+            question_and_answers['slug'] = section['id']
 
     unanswered_required, unanswered_optional = count_unanswered_questions(sections)
     if request.method == 'POST':
@@ -360,13 +367,16 @@ def publish_brief(framework_slug, lot_slug, brief_id):
                     brief_id=brief['id']))
     else:
         email_address = brief_users['emailAddress']
+        dates = get_publishing_dates()
 
         return render_template(
             "buyers/brief_publish_confirmation.html",
             email_address=email_address,
+            question_and_answers=question_and_answers,
             unanswered_required=unanswered_required,
             sections=sections,
-            brief=brief
+            brief=brief,
+            dates=dates
         ), 200
 
 

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -1,4 +1,5 @@
 from flask import abort
+from datetime import datetime, timedelta
 
 
 def get_framework_and_lot(framework_slug, lot_slug, data_api_client, status=None, must_allow_brief=False):
@@ -82,3 +83,19 @@ def get_sorted_responses_for_brief(brief, data_api_client):
         )
     else:
         return brief_responses
+
+
+def get_publishing_dates():
+    application_open_days = 14
+    questions_open_days = application_open_days - 7
+    answers_open_days = application_open_days - 1
+
+    dates = {}
+
+    dates['today'] = datetime.utcnow().replace(hour=23, minute=59, second=59, microsecond=0)
+    dates['questions_close'] = dates['today'] + timedelta(days=questions_open_days)
+    dates['answers_close'] = dates['today'] + timedelta(days=answers_open_days)
+    dates['closing_date'] = dates['today'] + timedelta(days=application_open_days)
+    dates['application_open_weeks'] = application_open_days//7
+    dates['closing_time'] = '{d:%I:%M %p}'.format(d=dates['closing_date']).lower()
+    return dates

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -35,12 +35,10 @@
         {% include "toolkit/page-heading.html" %}
     {% endwith %}
     <p class="padding-bottom-small">All requirements are published on the Digital Marketplace where anyone can see them.</p>
+    <p class="padding-bottom-small">All requirements are open for {{ dates.application_open_weeks }} weeks.</p>
+    <p class="padding-bottom-small">If you publish your requirements today ({{ dates.today | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date | shortdateformat}}.</p>
 
-    <p><strong>Suppliers will be able to apply for:</strong></p>
-    <p class="padding-bottom-small">2 weeks ending at midnight.</p>
-
-    <p><strong>Supplier questions will be sent to:</strong></p>
-    <p class="padding-bottom-small">{{ email_address }}</p>
+    <p class="padding-bottom-small"><strong>Supplier questions will be sent to:</strong> {{ email_address }}</p>
     <p class="padding-bottom-small">Ensure this email address will be monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
 
     {% if unanswered_required > 0 %}
@@ -57,6 +55,50 @@
         {% endfor %}
       {% endfor %}
     {% else %}
+      {% import "toolkit/summary-table.html" as summary %}
+        {% call summary.mapping_table(
+        row_bold_borders=True,
+        text_large = True,
+        no_bottom_border=True,
+        caption="If you publish today, you must be aware of the following dates:",
+        caption_visible=True,
+        field_headings=[
+          "Date",
+          "Notice",
+        ],
+        field_headings_visible=False
+      ) %}
+        {% call summary.row(no_border=True) %}
+          {{ summary.field_heading_date("Today", scope='row') }}
+          {{ summary.text("Suppliers can apply and ask questions about your requirements.") }}
+        {% endcall %}
+        {% call summary.row(bold_border=True) %}
+          {{ summary.field_heading_date("Before {}".format(dates.questions_close | shortdateformat), rowspan='3', scope='row') }}
+          {{ summary.text_bold("Details of your question and answer session") }}
+          {{ summary.edit_link("Edit", url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=question_and_answers.slug, question_id=question_and_answers.id)) }}
+        {% endcall %}
+        {% call summary.row(no_border=True) %}
+          {{ summary.text(brief.questionAndAnswerSessionDetails) }}
+        {% endcall %}
+        {% call summary.row(no_border=True) %}
+          {{ summary.text_bold("You must hold your question and answer session before {}.".format(dates.questions_close | shortdateformat), border=True) }}
+        {% endcall %}
+        {% call summary.row(bold_border=True) %}
+          {{ summary.field_heading_date(dates.questions_close | shortdateformat, scope='row') }}
+          {{ summary.text("Suppliers can no longer ask questions.") }}
+        {% endcall %}
+        {% call summary.row(bold_border=True) %}
+          {{ summary.field_heading_date(dates.answers_close | shortdateformat, rowspan='2', scope='row') }}
+          {{ summary.text("You must have published answers to all suppliers’ questions.") }}
+        {% endcall %}
+        {% call summary.row(no_border=True) %}
+          {{ summary.text("If {} is a Saturday or Sunday, you need to have published all questions and answers by the Friday before.".format(dates.answers_close | shortdateformat), border=True) }}
+        {% endcall %}
+        {% call summary.row(bold_border=True) %}
+          {{ summary.field_heading_date(dates.closing_date | shortdateformat, scope='row') }}
+          {{ summary.text("Suppliers can no longer apply.") }}
+        {% endcall %}
+      {% endcall %}
       <form action="{{ url_for('.publish_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         {%

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -337,8 +337,6 @@ class TestEveryDamnPage(BaseApplicationTest):
         self._load_page("/digital-specialists/1234/responses", 200)
 
     # get and post are the same for publishing
-    def test_wrong_lot_publish_brief(self):
-        self._load_page("/digital-specialists/1234/publish", 200)
 
     def test_wrong_lot_post_delete_a_brief(self):
         data = {"delete_confirmed": True}

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -1,5 +1,6 @@
 import mock
 import unittest
+import datetime
 from werkzeug.exceptions import NotFound
 
 import app.helpers as helpers
@@ -179,3 +180,21 @@ class TestBuyersHelpers(unittest.TestCase):
             {"id": "three"},
             {"id": "five"}
         ]
+
+    def test_get_publishing_dates_formats_time(self):
+        with mock.patch('app.helpers.buyers_helpers.datetime') as mock_date:
+            mock_date.utcnow.return_value = datetime.datetime(2015, 5, 22, 20, 39, 39, 417900)
+
+            assert helpers.buyers_helpers.datetime.utcnow() == datetime.datetime(2015, 5, 22, 20, 39, 39, 417900)
+            assert helpers.buyers_helpers.get_publishing_dates()['closing_time'] == '11:59 pm'
+
+    def test_get_publish_dates_are_correct(self):
+        with mock.patch('app.helpers.buyers_helpers.datetime') as mock_date:
+            mock_date.utcnow.return_value = datetime.datetime(2015, 5, 22, 20, 39, 39, 417900)
+
+            assert helpers.buyers_helpers.get_publishing_dates()['questions_close'] == datetime.datetime(
+                2015, 5, 29, 23, 59, 59)
+            assert helpers.buyers_helpers.get_publishing_dates()['answers_close'] == datetime.datetime(
+                2015, 6, 4, 23, 59, 59)
+            assert helpers.buyers_helpers.get_publishing_dates()['closing_date'] == datetime.datetime(
+                2015, 6, 5, 23, 59, 59)


### PR DESCRIPTION
Add publishing brief dates and new summary table using current version of frontend toolkit.

Update to use dmutils with short date format without localised time format.

<img width="671" alt="screen shot 2016-04-20 at 18 48 03" src="https://cloud.githubusercontent.com/assets/11633362/14684836/b82720ba-0729-11e6-8174-7c039b90911d.png">

<img width="765" alt="screen shot 2016-04-20 at 18 48 12" src="https://cloud.githubusercontent.com/assets/11633362/14684868/d18e30ac-0729-11e6-8e01-380d128e930b.png">
