### PR TITLE
removed use of 'clarification questions'

### DIFF
--- a/app/templates/buyers/clarification_questions.html
+++ b/app/templates/buyers/clarification_questions.html
@@ -25,7 +25,7 @@
     {% block before_heading %}{% endblock %}
     <div class="column-two-thirds">
       {% with
-        heading = "Clarification questions",
+        heading = "Supplier questions",
         smaller = true,
         context = brief.get('title', brief['lotName'])
       %}
@@ -37,7 +37,7 @@
     <div class="column-one-whole">
       {% import "toolkit/summary-table.html" as summary %}
 
-      {{ summary.heading("Clarification questions", id="clarification-questions") }}
+      {{ summary.heading("Supplier questions", id="clarification-questions") }}
       {% call(question) summary.list_table(
         brief.clarificationQuestions,
         field_headings=[
@@ -45,7 +45,7 @@
           "Answer"
         ],
         field_headings_visible=False,
-        empty_message="No clarification questions have been answered yet"
+        empty_message="No questions or answers have been published"
       ) %}
 
         {% call summary.row() %}
@@ -60,7 +60,7 @@
     </div>
   </div>
 
-  <a href="{{ url_for('.add_clarification_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Answer a clarification question</a>
+  <a href="{{ url_for('.add_clarification_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Answer a supplier question</a>
 
   {%
     with

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1264,7 +1264,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert res.status_code == 200
             page_html = res.get_data(as_text=True)
             assert "Clarification questions" in page_html
-            assert "No clarification questions have been answered yet" in page_html
+            assert "No questions or answers have been published" in page_html
             assert "Answer a clarification question" in page_html
 
     def test_show_clarification_questions_page_for_live_brief_with_one_question(self, data_api_client):
@@ -1296,7 +1296,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Why is my question a question?" in page_html
             assert "Because" in page_html
             assert "Answer a clarification question" in page_html
-            assert "No clarification questions have been answered yet" not in page_html
+            assert "No questions or answers have been published" not in page_html
 
     def test_404_if_framework_does_not_allow_brief(self, data_api_client):
         with self.app.app_context():

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1265,7 +1265,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             page_html = res.get_data(as_text=True)
             assert "Clarification questions" in page_html
             assert "No questions or answers have been published" in page_html
-            assert "Answer a clarification question" in page_html
+            assert "Answer a supplier question" in page_html
 
     def test_show_clarification_questions_page_for_live_brief_with_one_question(self, data_api_client):
         with self.app.app_context():
@@ -1295,7 +1295,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert "Clarification questions" in page_html
             assert "Why is my question a question?" in page_html
             assert "Because" in page_html
-            assert "Answer a clarification question" in page_html
+            assert "Answer a supplier question" in page_html
             assert "No questions or answers have been published" not in page_html
 
     def test_404_if_framework_does_not_allow_brief(self, data_api_client):


### PR DESCRIPTION
changed most of the uses 'clarification' to 'supplier' except where the table where it now says 'No questions or answers have been published'