### PR TITLE
[#117850243] Remove `clarification` from URLs

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -384,9 +384,9 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
 
 
 @buyers.route(
-    "/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/clarification-questions",
+    "/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/supplier-questions",
     methods=["GET"])
-def clarification_questions(framework_slug, lot_slug, brief_id):
+def supplier_questions(framework_slug, lot_slug, brief_id):
     get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
@@ -402,15 +402,15 @@ def clarification_questions(framework_slug, lot_slug, brief_id):
     ]
 
     return render_template(
-        "buyers/clarification_questions.html",
+        "buyers/supplier_questions.html",
         brief=brief,
     )
 
 
 @buyers.route(
-    "/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/clarification-questions/answer-question",
+    "/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/supplier-questions/answer-question",
     methods=["GET", "POST"])
-def add_clarification_question(framework_slug, lot_slug, brief_id):
+def add_supplier_question(framework_slug, lot_slug, brief_id):
     get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
@@ -434,7 +434,7 @@ def add_clarification_question(framework_slug, lot_slug, brief_id):
                                                              current_user.email_address)
 
             return redirect(
-                url_for('.clarification_questions', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'],
+                url_for('.supplier_questions', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'],
                         brief_id=brief['id']))
         except HTTPError as e:
             if e.status_code != 400:

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -16,8 +16,8 @@
   brief.clarificationQuestions,
   caption="Questions asked by suppliers",
   field_headings=[
-    "Clarification question",
-    "Clarification answer"
+    "Supplier question",
+    "Buyer answer"
     ],
     field_headings_visible=False,
     empty_message="No questions have been answered yet"

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -99,7 +99,7 @@
               },
               'links': [
                 {
-                  'href': url_for(".clarification_questions",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  'href': url_for(".supplier_questions",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': 'Publish questions and answers',
                   'allowed_statuses': ['live']
                 },

--- a/app/templates/buyers/supplier_questions.html
+++ b/app/templates/buyers/supplier_questions.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Clarification questions – Digital Marketplace{% endblock %}
+{% block page_title %}Supplier questions – Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -60,7 +60,7 @@
     </div>
   </div>
 
-  <a href="{{ url_for('.add_clarification_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Answer a supplier question</a>
+  <a href="{{ url_for('.add_supplier_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Answer a supplier question</a>
 
   {%
     with

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1258,12 +1258,12 @@ class TestBriefSummaryPage(BaseApplicationTest):
             data_api_client.get_brief.return_value = brief_json
 
             res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/clarification-questions"  # noqa
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
             )
 
             assert res.status_code == 200
             page_html = res.get_data(as_text=True)
-            assert "Clarification questions" in page_html
+            assert "Supplier questions" in page_html
             assert "No questions or answers have been published" in page_html
             assert "Answer a supplier question" in page_html
 
@@ -1287,12 +1287,12 @@ class TestBriefSummaryPage(BaseApplicationTest):
             data_api_client.get_brief.return_value = brief_json
 
             res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/clarification-questions"  # noqa
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
             )
 
             assert res.status_code == 200
             page_html = res.get_data(as_text=True)
-            assert "Clarification questions" in page_html
+            assert "Supplier questions" in page_html
             assert "Why is my question a question?" in page_html
             assert "Because" in page_html
             assert "Answer a supplier question" in page_html
@@ -1391,7 +1391,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         res = self.client.get(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/clarification-questions/answer-question")
+            "/digital-specialists/1234/supplier-questions/answer-question")
 
         assert res.status_code == 200
 
@@ -1409,7 +1409,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/clarification-questions/answer-question",
+            "/digital-specialists/1234/supplier-questions/answer-question",
             data={
                 "question": "Why?",
                 "answer": "Because",
@@ -1421,7 +1421,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         # test that the redirect ends up on the right page
         assert res.headers['Location'].endswith(
-            '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/clarification-questions'  # noqa
+            '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions'  # noqa
         ) is True
 
     def test_404_if_framework_is_not_live(self, data_api_client):
@@ -1439,7 +1439,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/clarification-questions/answer-question",
+            "/digital-specialists/1234/supplier-questions/answer-question",
             data={
                 "question": "Why?",
                 "answer": "Because",
@@ -1463,7 +1463,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/clarification-questions/answer-question",
+            "/digital-specialists/1234/supplier-questions/answer-question",
             data={
                 "question": "Why?",
                 "answer": "Because",
@@ -1487,7 +1487,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/clarification-questions/answer-question",
+            "/digital-specialists/1234/supplier-questions/answer-question",
             data={
                 "question": "Why?",
                 "answer": "Because",
@@ -1511,7 +1511,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/clarification-questions/answer-question",
+            "/digital-specialists/1234/supplier-questions/answer-question",
             data={
                 "question": "Why?",
                 "answer": "Because",
@@ -1537,7 +1537,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/clarification-questions/answer-question",
+            "/digital-specialists/1234/supplier-questions/answer-question",
             data={
                 "question": "Why?",
                 "answer": "Because",
@@ -1563,7 +1563,7 @@ class TestAddBriefClarificationQuestion(BaseApplicationTest):
 
         res = self.client.post(
             "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/clarification-questions/answer-question",
+            "/digital-specialists/1234/supplier-questions/answer-question",
             data={
                 "question": "Why?",
                 "answer": "Because",


### PR DESCRIPTION
We now talk about `supplier questions` instead.