### PR TITLE
Breadcrumbs on brief page link back to catalogue

### DIFF
--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -10,6 +10,10 @@
       {
           "link": url_for('.index'),
           "label": "Digital Marketplace"
+      },
+      {
+          "link": url_for('.list_opportunities', framework_slug=brief.frameworkSlug),
+          "label": "Supplier opportunities"
       }
     ]
   %}


### PR DESCRIPTION
Add extra breadcrumb to a brief page (pointing back to the catalogue of opportunities).

Didn't add tests because there's nothing weird going on here: no url string formatting or additional logic.

***

![screen shot 2016-04-22 at 14 54 30](https://cloud.githubusercontent.com/assets/2454380/14743594/29116558-089a-11e6-9af5-74dbcce55091.png)
