### PR TITLE
Fix download of responses if no nice-to-have requirements

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -291,7 +291,7 @@ def download_brief_responses(framework_slug, lot_slug, brief_id):
     # Build header row from manifest and add it to the list of rows
     for question in section.questions:
         question_key_sequence.append(question.id)
-        if question['type'] == 'boolean_list':
+        if question['type'] == 'boolean_list' and question.id in brief:
             column_headings.extend(brief[question.id])
             boolean_list_questions.append(question.id)
         else:


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/118019637

I thought I'd fixed it here: https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/269

But it turns out that I missed a bit and that was only half of the fix.  The change here prevents this error:
```
File \"/opt/python/current/app/app/buyers/views/buyers.py\", line 295, in download_brief_responses
    column_headings.extend(brief[question.id])
KeyError: 'niceToHaveRequirements'"
```

Properly tested locally this time and this really does fix the bug. 