### PR TITLE
Fix validation messages and validation summary HTML

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -6,24 +6,24 @@ from dmutils.forms import StripWhitespaceStringField
 
 class LoginForm(Form):
     email_address = StripWhitespaceStringField('Email address', validators=[
-        DataRequired(message="Email address must be provided"),
-        Email(message="Please enter a valid email address")
+        DataRequired(message="You must provide an email address"),
+        Email(message="You must provide a valid email address")
     ])
     password = PasswordField('Password', validators=[
-        DataRequired(message="Please enter your password")
+        DataRequired(message="You must provide your password")
     ])
 
 
 class EmailAddressForm(Form):
     email_address = StripWhitespaceStringField('Email address', validators=[
-        DataRequired(message="Email address must be provided"),
-        Email(message="Please enter a valid email address")
+        DataRequired(message="You must provide an email address"),
+        Email(message="You must provide a valid email address")
     ])
 
 
 class ChangePasswordForm(Form):
     password = PasswordField('Password', validators=[
-        DataRequired(message="Please enter a new password"),
+        DataRequired(message="You must enter a new password"),
         Length(min=10,
                max=50,
                message="Passwords must be between 10 and 50 characters"
@@ -37,7 +37,7 @@ class ChangePasswordForm(Form):
 
 class CreateUserForm(Form):
     name = StripWhitespaceStringField('Your name', validators=[
-        DataRequired(message="Please enter a name"),
+        DataRequired(message="You must enter a name"),
         Length(min=1,
                max=255,
                message="Names must be between 1 and 255 characters"
@@ -45,7 +45,7 @@ class CreateUserForm(Form):
     ])
 
     password = PasswordField('Password', validators=[
-        DataRequired(message="Please enter a password"),
+        DataRequired(message="You must enter a password"),
         Length(min=10,
                max=50,
                message="Passwords must be between 10 and 50 characters"

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -5,49 +5,70 @@ from dmutils.forms import StripWhitespaceStringField
 
 
 class LoginForm(Form):
-    email_address = StripWhitespaceStringField('Email address', validators=[
-        DataRequired(message="You must provide an email address"),
-        Email(message="You must provide a valid email address")
-    ])
-    password = PasswordField('Password', validators=[
-        DataRequired(message="You must provide your password")
-    ])
+    email_address = StripWhitespaceStringField(
+        'Email address', id="input_email_address",
+        validators=[
+            DataRequired(message="You must provide an email address"),
+            Email(message="You must provide a valid email address")
+        ]
+    )
+    password = PasswordField(
+        'Password', id="input_password",
+        validators=[
+            DataRequired(message="You must provide your password")
+        ]
+    )
 
 
 class EmailAddressForm(Form):
-    email_address = StripWhitespaceStringField('Email address', validators=[
-        DataRequired(message="You must provide an email address"),
-        Email(message="You must provide a valid email address")
-    ])
+    email_address = StripWhitespaceStringField(
+        'Email address', id="input_email_address",
+        validators=[
+            DataRequired(message="You must provide an email address"),
+            Email(message="You must provide a valid email address")
+        ]
+    )
 
 
 class ChangePasswordForm(Form):
-    password = PasswordField('Password', validators=[
-        DataRequired(message="You must enter a new password"),
-        Length(min=10,
-               max=50,
-               message="Passwords must be between 10 and 50 characters"
-               )
-    ])
-    confirm_password = PasswordField('Confirm password', validators=[
-        DataRequired(message="Please confirm your new password"),
-        EqualTo('password', message="The passwords you entered do not match")
-    ])
+    password = PasswordField(
+        'Password', id="input_password",
+        validators=[
+            DataRequired(message="You must enter a new password"),
+            Length(min=10,
+                   max=50,
+                   message="Passwords must be between 10 and 50 characters"
+                   )
+        ]
+    )
+    confirm_password = PasswordField(
+        'Confirm password', id="input_confirm_password",
+        validators=[
+            DataRequired(message="Please confirm your new password"),
+            EqualTo('password', message="The passwords you entered do not match")
+        ]
+    )
 
 
 class CreateUserForm(Form):
-    name = StripWhitespaceStringField('Your name', validators=[
-        DataRequired(message="You must enter a name"),
-        Length(min=1,
-               max=255,
-               message="Names must be between 1 and 255 characters"
-               )
-    ])
+    name = StripWhitespaceStringField(
+        'Your name', id="input_name",
+        validators=[
+            DataRequired(message="You must enter a name"),
+            Length(min=1,
+                   max=255,
+                   message="Names must be between 1 and 255 characters"
+                   )
+        ]
+    )
 
-    password = PasswordField('Password', validators=[
-        DataRequired(message="You must enter a password"),
-        Length(min=10,
-               max=50,
-               message="Passwords must be between 10 and 50 characters"
-               )
-    ])
+    password = PasswordField(
+        'Password', id="input_password",
+        validators=[
+            DataRequired(message="You must enter a password"),
+            Length(min=10,
+                   max=50,
+                   message="Passwords must be between 10 and 50 characters"
+                   )
+        ]
+    )

--- a/app/templates/auth/create-buyer-account.html
+++ b/app/templates/auth/create-buyer-account.html
@@ -18,6 +18,21 @@
 
 {% block main_content %}
 
+{% if form.errors %}
+    <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
+        <h3 class="validation-masthead-heading" id="validation-masthead-heading">
+            There was a problem with the details you gave for:
+        </h3>
+        <ul>
+        {% for field_name, field_errors in form.errors|dictsort if field_errors %}
+        {% for error in field_errors %}
+          <li><a href="#{{ form[field_name].name }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
+        {% endfor %}
+        {% endfor %}
+        </ul>
+    </div>
+{% endif %}
+
 {%
   with
     smaller = true,

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -4,6 +4,21 @@
 
 {% block main_content %}
 
+{% if form.errors|length > 1 %}
+    <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
+        <h3 class="validation-masthead-heading" id="validation-masthead-heading">
+            There was a problem with the details you gave for:
+        </h3>
+        <ul>
+        {% for field_name, field_errors in form.errors|dictsort if field_errors %}
+        {% for error in field_errors %}
+          <li><a href="#{{ form[field_name].name }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
+        {% endfor %}
+        {% endfor %}
+        </ul>
+    </div>
+{% endif %}
+
 {%
   with
   smaller = true,
@@ -23,7 +38,7 @@
                 {% if form.name.errors %}
                 <div class="validation-wrapper">
                     {% endif %}
-                    <div class="question">
+                    <div class="question" id="{{ form.name.name }}">
                         {{ form.name.label(class="question-heading-with-hint") }}
                         <p class="hint">
                             Enter the name to be referred to on the Digital Marketplace
@@ -42,7 +57,7 @@
                 {% if form.password.errors %}
                 <div class="validation-wrapper">
             {% endif %}
-                <div class="question">
+                <div class="question" id="{{ form.password.name }}">
                     {{ form.password.label(class="question-heading-with-hint") }}
                     <p class="hint">
                       Must be between 10 and 50 characters

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -53,7 +53,7 @@
         <ul>
         {% for field_name, field_errors in form.errors|dictsort if field_errors %}
         {% for error in field_errors %}
-          <li><a href="#{{ form[field_name].id }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
+          <li><a href="#{{ form[field_name].name }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
         {% endfor %}
         {% endfor %}
         </ul>
@@ -75,7 +75,7 @@
             {% if form.email_address.errors %}
                 <div class="validation-wrapper">
             {% endif %}
-                <div class="question">
+                <div class="question" id="{{ form.email_address.name }}">
                     {{ form.email_address.label(class="question-heading-with-hint") }}
                     <p class="hint">
                         Enter the email address you used to register with the Digital Marketplace
@@ -94,7 +94,7 @@
             {% if form.password.errors %}
                 <div class="validation-wrapper">
             {% endif %}
-                <div class="question">
+                <div class="question" id="{{ form.password.name }}">
                     {{ form.password.label(class="question-heading") }}
                     {% if form.password.errors %}
                     <p class="validation-message" id="error-password-textbox">

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -48,13 +48,15 @@
 {% if form.errors|length > 1 %}
     <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
         <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-            There was a problem with your answer to the following questions
+            There was a problem with the details you gave for:
         </h3>
+        <ul>
         {% for field_name, field_errors in form.errors|dictsort if field_errors %}
         {% for error in field_errors %}
-        <a href="#example-textbox" class="validation-masthead-link">{{ form[field_name].label }}</a>
+          <li><a href="#{{ form[field_name].id }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
         {% endfor %}
         {% endfor %}
+        </ul>
     </div>
 {% endif %}
 

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -12,7 +12,7 @@
         <ul>
         {% for field_name, field_errors in form.errors|dictsort|reverse if field_errors %}
           {% for error in field_errors %}
-            <li><a href="#{{ form[field_name].id }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
+            <li><a href="#{{ form[field_name].name }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
           {% endfor %}
         {% endfor %}
         </ul>
@@ -35,7 +35,7 @@
             {% if form.password.errors %}
                 <div class="validation-wrapper">
             {% endif %}
-                <div class="question">
+                <div class="question" id="{{ form.password.name }}">
                     {{ form.password.label(class="question-heading-with-hint") }}
                     <p class="hint">
                       Must be between 10 and 50 characters
@@ -54,7 +54,7 @@
             {% if form.confirm_password.errors %}
                 <div class="validation-wrapper">
             {% endif %}
-                <div class="question">
+                <div class="question" id="{{ form.confirm_password.name }}">
                     {{ form.confirm_password.label(class="question-heading-with-hint") }}
                     <p class="hint">
                         Repeat password used above

--- a/app/templates/auth/reset-password.html
+++ b/app/templates/auth/reset-password.html
@@ -7,13 +7,15 @@
 {% if form.errors|length > 1 %}
     <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
         <h3 class="validation-masthead-heading" id="validation-masthead-heading">
-            There was a problem with your answer to the following questions
+            There was a problem with the details you gave for:
         </h3>
+        <ul>
         {% for field_name, field_errors in form.errors|dictsort|reverse if field_errors %}
-        {% for error in field_errors %}
-        <a href="#example-textbox" class="validation-masthead-link">{{ form[field_name].label }}</a>
+          {% for error in field_errors %}
+            <li><a href="#{{ form[field_name].id }}" class="validation-masthead-link">{{ form[field_name].label.text }}</a></li>
+          {% endfor %}
         {% endfor %}
-        {% endfor %}
+        </ul>
     </div>
 {% endif %}
 

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -8,13 +8,13 @@ from ...helpers import BaseApplicationTest
 from lxml import html
 import mock
 
-EMAIL_EMPTY_ERROR = "Email address must be provided"
-EMAIL_INVALID_ERROR = "Please enter a valid email address"
+EMAIL_EMPTY_ERROR = "You must provide an email address"
+EMAIL_INVALID_ERROR = "You must provide a valid email address"
 EMAIL_SENT_MESSAGE = "If the email address you've entered belongs to a Digital Marketplace account, we'll send a link to reset the password."  # noqa
-PASSWORD_EMPTY_ERROR = "Please enter your password"
+PASSWORD_EMPTY_ERROR = "You must provide your password"
 PASSWORD_INVALID_ERROR = "Passwords must be between 10 and 50 characters"
 PASSWORD_MISMATCH_ERROR = "The passwords you entered do not match"
-NEW_PASSWORD_EMPTY_ERROR = "Please enter a new password"
+NEW_PASSWORD_EMPTY_ERROR = "You must enter a new password"
 NEW_PASSWORD_CONFIRM_EMPTY_ERROR = "Please confirm your new password"
 
 USER_CREATION_EMAIL_ERROR = "Failed to send user creation email."
@@ -532,7 +532,7 @@ class TestBuyersCreation(BaseApplicationTest):
         assert res.status_code == 400
         data = res.get_data(as_text=True)
         assert 'Create a buyer account' in data
-        assert 'Please enter a valid email address' in data
+        assert 'You must provide a valid email address' in data
 
     def test_should_raise_validation_error_for_empty_email_address(self):
         res = self.client.post(
@@ -543,7 +543,7 @@ class TestBuyersCreation(BaseApplicationTest):
         assert res.status_code == 400
         data = res.get_data(as_text=True)
         assert 'Create a buyer account' in data
-        assert 'Email address must be provided' in data
+        assert 'You must provide an email address' in data
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_show_error_page_for_unrecognised_email_domain(self, data_api_client):
@@ -677,8 +677,8 @@ class TestCreateUser(BaseApplicationTest):
 
         assert res.status_code == 400
         for message in [
-            "Please enter a name",
-            "Please enter a password"
+            "You must enter a name",
+            "You must enter a password"
         ]:
             assert message in res.get_data(as_text=True)
 
@@ -694,7 +694,7 @@ class TestCreateUser(BaseApplicationTest):
 
         assert res.status_code == 400
         for message in [
-            "Please enter a name",
+            "You must enter a name",
             "Passwords must be between 10 and 50 characters"
         ]:
             assert message in res.get_data(as_text=True)


### PR DESCRIPTION
Originally intended to bring in the correct text for validation summaries (from [#245](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/245) in the DM Toolkit), this now also contains the following fixes:

- fixes for the [Validation summary links don't work](https://www.pivotaltracker.com/story/show/118185295) story
- corrections to the HTML of validation summaries, replacing label tags for their text in the links and wrapping links in a list

### New validation copy

![validation_copy_changes](https://cloud.githubusercontent.com/assets/87140/14779403/f1f2a4d2-0acf-11e6-9b7d-2a680b68fbbe.png)

### Validation summary HTML

#### Old

![image](https://cloud.githubusercontent.com/assets/87140/14779502/4c4d8776-0ad0-11e6-9819-7f570c7a3b93.png)

### New

![image](https://cloud.githubusercontent.com/assets/87140/14779529/6622dbe2-0ad0-11e6-8b3b-60a637209b23.png)

