### PR TITLE
Reword homepage opportunities link

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -113,17 +113,9 @@
         <div class="padding-bottom-small">
           <p>
             <a href="/digital-outcomes-and-specialists/opportunities" class="top-level-link">
-              View supplier opportunities
+              Digital Outcomes and Specialists opportunities
             </a>
           </p>
-          <div class="explanation-list">
-            <p class="lead">Find published requirements for:</p>
-            <ul class="list-bullet">
-              <li>digital specialists</li>
-              <li>digital outcomes</li>
-              <li>user research participant recruitment</li>
-            </ul>  
-          </div>
         </div>
         
         {% if current_user.role != 'supplier' %}

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -187,7 +187,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         )
         sidebar_link_texts = [str(item).strip() for item in sidebar_links]
 
-        assert 'View supplier opportunities' in sidebar_link_texts
+        assert 'Digital Outcomes and Specialists opportunities' in sidebar_link_texts
         assert 'Create a supplier account' in sidebar_link_texts
         assert 'View your services and account information' not in sidebar_link_texts
 
@@ -209,7 +209,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         )
         sidebar_link_texts = [str(item).strip() for item in sidebar_links]
 
-        assert 'View supplier opportunities' in sidebar_link_texts
+        assert 'Digital Outcomes and Specialists opportunities' in sidebar_link_texts
         assert 'View your services and account information' in sidebar_link_texts
         assert 'Create a supplier account' not in sidebar_link_texts
 


### PR DESCRIPTION
We’ve decided that the 'view opportunities' page would be more helpful if the page title said 'Digital Outcomes and Specialists opportunities' because suppliers think about lots'. The link to this page should reflect this.

https://www.pivotaltracker.com/story/show/118280489

### Old version

![sidebar_link_old](https://cloud.githubusercontent.com/assets/87140/14789517/d832551c-0b04-11e6-8fab-d24652fe2902.png)

### New version

![sidebar_link_new](https://cloud.githubusercontent.com/assets/87140/14789522/dc2a02aa-0b04-11e6-8479-090a34d35acf.png)
