### PR TITLE
Update "View opportunities" page title and description

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -95,6 +95,7 @@ def list_opportunities(framework_slug):
 
     return render_template('briefs_catalogue.html',
                            framework=framework,
+                           lot_names=[lot['name'] for lot in framework['lots'] if lot['allowsBrief']],
                            briefs=briefs,
                            prev_link=parse_link(links, 'prev'),
                            next_link=parse_link(links, 'next')

--- a/app/templates/briefs_catalogue.html
+++ b/app/templates/briefs_catalogue.html
@@ -18,12 +18,15 @@
 
 {% block main_content %}
 
-    {% with heading="Supplier opportunities" %}
+    {% with heading="{} opportunities".format(framework.name) %}
         {% include "toolkit/page-heading.html" %}
     {% endwith %}
-    
+
     <div class="grid-row">
         <section class="column-two-thirds">
+            <div class="marketplace-paragraph">
+              <p>View buyer requirements for {{ lot_names | map('lower') | join(", ") }}.</p>
+            </div>
             {% include '_briefs_list.html' %}
             {% include '_briefs_pagination.html' %}
         </section>

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -467,12 +467,21 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self._data_api_client.stop()
 
     def test_catalogue_of_briefs_page(self):
+        self._data_api_client.get_framework.return_value = {'frameworks': {
+            'name': "Digital Outcomes and Specialists",
+            'lots': [
+                {'name': 'Lot 1', 'allowsBrief': True},
+                {'name': 'Lot 2', 'allowsBrief': False},
+                {'name': 'Lot 3', 'allowsBrief': True}
+            ]
+        }}
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')
         assert_equal(200, res.status_code)
         document = html.fromstring(res.get_data(as_text=True))
 
         heading = document.xpath('//h1/text()')[0].strip()
-        assert heading == "Supplier opportunities"
+        assert heading == "Digital Outcomes and Specialists opportunities"
+        assert 'lot 1, lot 3' in document.xpath('//div[@class="marketplace-paragraph"]/p/text()')[0]
 
     def test_catalogue_of_briefs_page_shows_pagination_if_more_pages(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')


### PR DESCRIPTION
Adds framework and lot names to the opportunities list page.

![screen shot 2016-04-25 at 16 32 09](https://cloud.githubusercontent.com/assets/246664/14813248/c7f58702-0b98-11e6-871e-2749a82b5054.png)