### PR TITLE
Hide question and answers, and minor changes.

### DIFF
--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -72,20 +72,22 @@
           {{ summary.field_heading_date("Today", scope='row') }}
           {{ summary.text("Suppliers can apply and ask questions about your requirements.") }}
         {% endcall %}
-        {% call summary.row(bold_border=True) %}
-          {{ summary.field_heading_date("Before {}".format(dates.questions_close | shortdateformat), rowspan='3', scope='row') }}
-          {{ summary.text_bold("Details of your question and answer session") }}
-          {{ summary.edit_link("Edit", url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=question_and_answers.slug, question_id=question_and_answers.id)) }}
-        {% endcall %}
-        {% call summary.row(no_border=True) %}
-          {{ summary.text(brief.questionAndAnswerSessionDetails) }}
-        {% endcall %}
-        {% call summary.row(no_border=True) %}
-          {{ summary.text_bold("You must hold your question and answer session before {}.".format(dates.questions_close | shortdateformat), border=True) }}
-        {% endcall %}
+        {% if brief.questionAndAnswerSessionDetails %}
+          {% call summary.row(bold_border=True) %}
+            {{ summary.field_heading_date("Before {}".format(dates.questions_close | shortdateformat), rowspan='3', scope='row') }}
+            {{ summary.text_bold("Details of your question and answer session") }}
+            {{ summary.edit_link("Edit", url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=question_and_answers.slug, question_id=question_and_answers.id)) }}
+          {% endcall %}
+          {% call summary.row(no_border=True) %}
+            {{ summary.text(brief.questionAndAnswerSessionDetails) }}
+          {% endcall %}
+          {% call summary.row(no_border=True) %}
+            {{ summary.text_bold("You must hold your question and answer session before {}.".format(dates.questions_close | shortdateformat), border=True) }}
+          {% endcall %}
+        {% endif %}
         {% call summary.row(bold_border=True) %}
           {{ summary.field_heading_date(dates.questions_close | shortdateformat, scope='row') }}
-          {{ summary.text("Suppliers can no longer ask questions.") }}
+          {{ summary.text("The last day suppliers can ask questions.") }}
         {% endcall %}
         {% call summary.row(bold_border=True) %}
           {{ summary.field_heading_date(dates.answers_close | shortdateformat, rowspan='2', scope='row') }}
@@ -96,7 +98,7 @@
         {% endcall %}
         {% call summary.row(bold_border=True) %}
           {{ summary.field_heading_date(dates.closing_date | shortdateformat, scope='row') }}
-          {{ summary.text("Suppliers can no longer apply.") }}
+          {{ summary.text("The last day suppliers can apply.") }}
         {% endcall %}
       {% endcall %}
       <form action="{{ url_for('.publish_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
@@ -110,6 +112,7 @@
         {% endwith %}
       </form>
     {% endif %}
+    <a href="{{ url_for('.view_brief_overview', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Return to overview</a>
   </div>
 </div>
 


### PR DESCRIPTION
- Hide question and answer session details if these have not been filled in, as this section is optional.
- Add return to overview link at bottom of the page
- Change copy to reflect what the suppliers can do rather than what they can't.

Overview link:
<img width="333" alt="screen shot 2016-04-25 at 17 12 56" src="https://cloud.githubusercontent.com/assets/11633362/14790465/5b5bf200-0b09-11e6-95ac-c5f970282f28.png">

With question and answer details, when these are available:
<img width="708" alt="screen shot 2016-04-25 at 17 13 33" src="https://cloud.githubusercontent.com/assets/11633362/14790479/64bcb3f2-0b09-11e6-88c6-6df7feaa5749.png">

Without question and answer details, when this section has not been filled in:
<img width="745" alt="screen shot 2016-04-25 at 17 14 58" src="https://cloud.githubusercontent.com/assets/11633362/14790506/7ee43a98-0b09-11e6-9c19-c181198e4c70.png">

