### PR TITLE
Move catalogues to communications bucket

### DIFF
--- a/app/templates/buyers/start_brief_info.html
+++ b/app/templates/buyers/start_brief_info.html
@@ -53,7 +53,7 @@
         <h2>Before you start</h2>
         <ol class="list-number">
             <li>You can talk to suppliers to prepare your requirements.<br>
-                <a href="https://assets.digitalmarketplace.service.gov.uk/catalogues/digital-outcomes-and-specialists/{{ lot.slug }}-suppliers.csv">
+                <a href="https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/communications/catalogues/{{ lot.slug }}-suppliers.csv">
                     Download list of suppliers.
                 </a>
             </li>

--- a/app/templates/buyers/studios_start_page.html
+++ b/app/templates/buyers/studios_start_page.html
@@ -83,7 +83,7 @@ Find a user research lab - Digital Marketplace
             items = [
             {
             "title": "List of labs",
-            "link": "https://assets.digitalmarketplace.service.gov.uk/catalogues/digital-outcomes-and-specialists/user-research-studios.csv",
+            "link": "https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/communications/catalogues/user-research-studios.csv",
             "file_type": "csv"
             }
             ]

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.11.6",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.32.1"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v0.32.2"
   }
 }


### PR DESCRIPTION
Changes the catalogues CSV URLs to match communications bucket.
Only the admin app uploads files to the communications bucket, so it feels more appropriate to keep catalogue files there.