### PR TITLE
Change button text on publish a supplier Q&A page

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -459,5 +459,6 @@ def add_supplier_question(framework_slug, lot_slug, brief_id):
         brief=brief,
         section=section,
         question=section.questions[0],
+        button_label="Publish question and answer",
         errors=errors
     ), status_code

--- a/app/templates/buyers/edit_brief_question.html
+++ b/app/templates/buyers/edit_brief_question.html
@@ -34,7 +34,7 @@
 
   {%
     with
-    label="Save and continue",
+    label= button_label or "Save and continue",
     type="save",
     name = "return_to_overview"
   %}


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/118417371

The Q&A page now re-uses the `edit_brief_question` template, which has "Save and continue" as the button text.
By passing in `button_label` to the template this changes the text to the required "Publish question and answer".

The button now looks like this:
![screen shot 2016-04-27 at 08 25 47](https://cloud.githubusercontent.com/assets/6525554/14844893/9e119ccc-0c52-11e6-8c1b-d73f2b1a4dbc.png)
