### PR TITLE
Fix return to overview link on publish page

### DIFF
--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -112,7 +112,14 @@
         {% endwith %}
       </form>
     {% endif %}
-    <a href="{{ url_for('.view_brief_overview', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Return to overview</a>
+
+    {%
+      with
+      url = url_for(".view_brief_overview", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+      text = "Return to overview"
+    %}
+      {% include "toolkit/secondary-action-link.html" %}
+    {% endwith %}
   </div>
 </div>
 


### PR DESCRIPTION
Now using the macro instead of just a link.
Means we have the right spacing.

[>> Bug on Pivotal](https://www.pivotaltracker.com/story/show/118406997)

***

### not nice
![screen shot 2016-04-27 at 17 01 51](https://cloud.githubusercontent.com/assets/2454380/14859432/0760d7c6-0c9c-11e6-956a-3f0aaaacfb57.png)

### nice 
![screen shot 2016-04-27 at 17 01 20](https://cloud.githubusercontent.com/assets/2454380/14859434/0b836ca6-0c9c-11e6-9452-8842ed48bdc5.png)
