### PR TITLE
opportunities show summary

### DIFF
--- a/app/templates/_briefs_list.html
+++ b/app/templates/_briefs_list.html
@@ -27,7 +27,7 @@
     </ul>
     
     <p class="search-result-excerpt">
-        {{ brief.backgroundInformation }}
+        {{ brief.summary }}
     </p>
 </div>
 


### PR DESCRIPTION
Each opportunity on /digital-outcomes-and-specialists/opportunities needs to show the 'summary' for all lots. Was 'backgroundInfromation' answer, which is specific to Outcomes, so nothing was showing for either specialists or participants opportunities.