### PR TITLE
Add temporary messages for G-Cloud-8

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -71,10 +71,6 @@
       margin-bottom: $gutter;
     }
 
-    h3 {
-      @include bold-24;
-    }
-
     p {
       margin: 0;
 

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -13,6 +13,9 @@ $path: "/static/images/";
 
 @import "_reset.scss";
 
+/* Blocks shared between multiple selectors */
+@import "shared_placeholders/_temporary-messages.scss";
+
 // Digtial Marketplace Front-end toolkit styles
 @import "toolkit/_breadcrumb.scss";
 @import "toolkit/_browse-list.scss";
@@ -37,9 +40,6 @@ $path: "/static/images/";
 @import "toolkit/forms/_validation.scss";
 @import "toolkit/search/_search-result.scss";
 @import "toolkit/_secondary-action-link.scss";
-
-/* Blocks shared between multiple selectors */
-@import "shared_placeholders/_temporary-messages.scss";
 
 /* Classes shared between multiple apps */
 @import "toolkit/shared_scss/_lists.scss";

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -92,33 +92,23 @@
   </div>
     <div class="supplier-messages column-one-third">
       <aside role="complementary" aria-labelledby="supplier-message-heading">
-        
+
       {% if temporary_message or current_user.role == 'supplier' or dos_is_live %}
           <h2 id="supplier-message-heading">Sell services</h2>
       {% endif %}
-        
-      {% if temporary_message %}
-        {%
-          with
-            heading = temporary_message.heading,
-            subheading = temporary_message.subheading,
-            messages = temporary_message.messages,
-            message = temporary_message.message
-        %}
-          {% include "toolkit/{}.html".format(temporary_message.template_name) %}
-        {% endwith %}
-      {% endif %}
-        
+
       {% if dos_is_live %}
+
+      {% set opportunities %}
         <div class="padding-bottom-small">
           <p>
             <a href="/digital-outcomes-and-specialists/opportunities" class="top-level-link">
-              Digital Outcomes and Specialists opportunities
+              View Digital Outcomes and Specialists opportunities
             </a>
           </p>
         </div>
-        
-        {% if current_user.role != 'supplier' %}
+      {% endset %}
+      {% set selling %}
         <div class="padding-bottom-small">
           <p>
             <a href="/suppliers/create" class="top-level-link">
@@ -127,10 +117,31 @@
           </p>
           <p>Receive updates about opportunities to sell on the Digital Marketplace.</p>
         </div>
-        {% endif %}
-        
+      {% endset %}
+      {% else %}
+        {% set opportunities = '' %}
+        {% set selling = '' %}
       {% endif %}
-        
+
+      {{ opportunities|safe }}
+
+      {% if temporary_message %}
+        {%
+          with
+            heading = temporary_message.heading,
+            main = True,
+            subheading = temporary_message.subheading,
+            messages = temporary_message.messages,
+            message = temporary_message.message
+        %}
+          {% include "toolkit/temporary-message.html" %}
+        {% endwith %}
+      {% endif %}
+
+      {% if current_user.role != 'supplier' %}
+          {{ selling|safe }}
+      {% endif %}
+
       {% if current_user.role == 'supplier' %}
         <div class="padding-bottom-small">
           <p>

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.12.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.12.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.0.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.1.0"
   }
 }

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -159,6 +159,33 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
         self._load_homepage(framework_slugs_and_statuses, framework_messages)
 
+    def test_homepage_sidebar_message_exists_gcloud_8_coming(self):
+
+        framework_slugs_and_statuses = [
+            ('g-cloud-8', 'coming'),
+            ('digital-outcomes-and-specialists', 'live')
+        ]
+        framework_messages = [
+            u"Provide cloud software and support to the public sector.",
+            u"You need an account to receive notifications about when you can apply."
+        ]
+
+        self._load_homepage(framework_slugs_and_statuses, framework_messages)
+
+    def test_homepage_sidebar_message_exists_gcloud_8_open(self):
+
+        framework_slugs_and_statuses = [
+            ('g-cloud-8', 'open'),
+            ('digital-outcomes-and-specialists', 'live')
+        ]
+        framework_messages = [
+            u"Provide cloud software and support to the public sector",
+            u"You need an account to apply.",
+            u"The application deadline is 5pm BST, 21 June 2016."
+        ]
+
+        self._load_homepage(framework_slugs_and_statuses, framework_messages)
+
     def test_homepage_sidebar_message_exists_g_cloud_7_pending(self):
 
         framework_slugs_and_statuses = [
@@ -187,7 +214,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         )
         sidebar_link_texts = [str(item).strip() for item in sidebar_links]
 
-        assert 'Digital Outcomes and Specialists opportunities' in sidebar_link_texts
+        assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
         assert 'Create a supplier account' in sidebar_link_texts
         assert 'View your services and account information' not in sidebar_link_texts
 
@@ -209,7 +236,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         )
         sidebar_link_texts = [str(item).strip() for item in sidebar_links]
 
-        assert 'Digital Outcomes and Specialists opportunities' in sidebar_link_texts
+        assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
         assert 'View your services and account information' in sidebar_link_texts
         assert 'Create a supplier account' not in sidebar_link_texts
 


### PR DESCRIPTION
Add temporary messages for G-Cloud-8

Move shared placeholders above frontend toolkit styles to prevent extensions of shared placeholders from being overwritten.

Also add new verions of frontend toolkit, with temporary message variant and digital marketplace framework with new content.

Remove h3 class from suppliers scss as this is obsolete.

Remove framework notice option as this has been superceded by the temporary messages pattern.