### PR TITLE
Add temporary messages for G-Cloud-8

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -71,10 +71,6 @@
       margin-bottom: $gutter;
     }
 
-    h3 {
-      @include bold-24;
-    }
-
     p {
       margin: 0;
 

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -13,6 +13,9 @@ $path: "/static/images/";
 
 @import "_reset.scss";
 
+/* Blocks shared between multiple selectors */
+@import "shared_placeholders/_temporary-messages.scss";
+
 // Digtial Marketplace Front-end toolkit styles
 @import "toolkit/_breadcrumb.scss";
 @import "toolkit/_browse-list.scss";
@@ -37,9 +40,6 @@ $path: "/static/images/";
 @import "toolkit/forms/_validation.scss";
 @import "toolkit/search/_search-result.scss";
 @import "toolkit/_secondary-action-link.scss";
-
-/* Blocks shared between multiple selectors */
-@import "shared_placeholders/_temporary-messages.scss";
 
 /* Classes shared between multiple apps */
 @import "toolkit/shared_scss/_lists.scss";

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -20,45 +20,47 @@
 <div class="index-page grid-row">
   <div class="column-two-thirds">
     <h2 class="marketplace-homepage-subheading">Find technology or people for digital projects in the public sector</h2>
+    {% set buyer_dashboard = [] %}
+    {% set dss_items = [] %}
+    {% set dos_items = [] %}
+    {% set g_cloud_subtext = '' %}
+    {% set crown_hosting_subtext = '' %}
+
     {% if dos_is_live %}
       {% set
         dos_items = [
           {
-            "link": url_for("main.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-specialists'),
+            "link": url_for("main.info_page_for_starting_a_brief", framework_slug=dos_is_live.slug, lot_slug='digital-specialists'),
             "title": "Find an individual specialist",
             "body": "eg a developer or user researcher",
           },
           {
-            "link": url_for("main.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='digital-outcomes'),
+            "link": url_for("main.info_page_for_starting_a_brief", framework_slug=dos_is_live.slug, lot_slug='digital-outcomes'),
             "title": "Find a team to provide an outcome",
             "body": "eg a booking system or accessibility audit",
           },
           {
-            "link": url_for("main.info_page_for_starting_a_brief", framework_slug='digital-outcomes-and-specialists', lot_slug='user-research-participants'),
+            "link": url_for("main.info_page_for_starting_a_brief", framework_slug=dos_is_live.slug, lot_slug='user-research-participants'),
             "title": "Find user research participants",
             "body": "eg people from a specific user group to test your service",
           },
           {
-            "link": url_for("main.studios_start_page", framework_slug='digital-outcomes-and-specialists'),
+            "link": url_for("main.studios_start_page", framework_slug=dos_is_live.slug),
             "title": "Find a user research lab",
             "body": "eg a room to conduct research sessions",
           },
         ]
       %}
-      {% set dss_items = [] %}
-        {% if current_user.role == 'buyer' %}
-          {% set buyer_dashboard = [
-              {
-                "link": "/buyers",
-                "title": "View your requirements and supplier responses",
-              },
-            ]
-          %}
-        {% else %}
-          {% set buyer_dashboard = [] %}
-        {% endif %}
+      {% if current_user.role == 'buyer' %}
+        {% set buyer_dashboard = [
+            {
+              "link": "/buyers",
+              "title": "View your requirements and supplier responses",
+            },
+          ]
+        %}
+      {% endif %}
     {% else %}
-      {% set dos_items = [] %}
       {% set dss_items = [
           {
             "link": "https://digitalservicesstore.service.gov.uk/",
@@ -68,7 +70,9 @@
           }
         ]
       %}
-      {% set buyer_dashboard = [] %}
+      {% set g_cloud_subtext = "Procurement framework: <a href='/g-cloud/framework'>G&#8209;Cloud</a>" %}
+      {% set crown_hosting_subtext = "Procurement framework: <a href='/crown-hosting/framework'>Crown Hosting Data Centres</a>" %}
+
     {% endif %}
 
     {% with
@@ -77,48 +81,51 @@
           "link": "/g-cloud",
           "title": "Find cloud technology and support",
           "body": "eg web hosting or IT health checks",
-          "subtext": "Procurement framework: <a href='/g-cloud/framework'>G&#8209;Cloud</a>" if not dos_is_live else None
+          "subtext": g_cloud_subtext
         },
         {
           "link": "/crown-hosting",
           "title": "Buy physical datacentre space for legacy systems",
           "body": "eg for services that can’t be migrated to the cloud",
-          "subtext": "Procurement framework: <a href='/crown-hosting/framework'>Crown Hosting Data Centres</a>" if not dos_is_live else None
+          "subtext": crown_hosting_subtext
         },
       ] + dss_items + buyer_dashboard
     %}
       {% include "toolkit/browse-list.html" %}
     {% endwith %}
-  </div>
+    </div>
+
     <div class="supplier-messages column-one-third">
       <aside role="complementary" aria-labelledby="supplier-message-heading">
-        
+
       {% if temporary_message or current_user.role == 'supplier' or dos_is_live %}
           <h2 id="supplier-message-heading">Sell services</h2>
       {% endif %}
-        
+
+      {% if dos_is_live %}
+        <div class="padding-bottom-small">
+            <p>
+              <a href="/digital-outcomes-and-specialists/opportunities" class="top-level-link">
+                View Digital Outcomes and Specialists opportunities
+              </a>
+            </p>
+        </div>
+      {% endif %}
+
       {% if temporary_message %}
         {%
           with
             heading = temporary_message.heading,
+            main = True,
             subheading = temporary_message.subheading,
             messages = temporary_message.messages,
             message = temporary_message.message
         %}
-          {% include "toolkit/{}.html".format(temporary_message.template_name) %}
+          {% include "toolkit/temporary-message.html" %}
         {% endwith %}
       {% endif %}
-        
-      {% if dos_is_live %}
-        <div class="padding-bottom-small">
-          <p>
-            <a href="/digital-outcomes-and-specialists/opportunities" class="top-level-link">
-              Digital Outcomes and Specialists opportunities
-            </a>
-          </p>
-        </div>
-        
-        {% if current_user.role != 'supplier' %}
+
+      {% if current_user.role != 'supplier' %}
         <div class="padding-bottom-small">
           <p>
             <a href="/suppliers/create" class="top-level-link">
@@ -127,11 +134,7 @@
           </p>
           <p>Receive updates about opportunities to sell on the Digital Marketplace.</p>
         </div>
-        {% endif %}
-        
-      {% endif %}
-        
-      {% if current_user.role == 'supplier' %}
+      {% elif current_user.role == 'supplier' %}
         <div class="padding-bottom-small">
           <p>
             <a href="/suppliers" class="top-level-link">
@@ -140,7 +143,7 @@
           </p>
         </div>
       {% endif %}
-        
+
       </aside>
     </div>
 </div>

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.13.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.0.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.1.0"
   }
 }

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -133,28 +133,29 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         else:
             self._assert_message_container_is_empty(response_data)
 
-    def test_homepage_sidebar_message_exists_dos_coming(self):
+    def test_homepage_sidebar_message_exists_gcloud_8_coming(self):
 
         framework_slugs_and_statuses = [
-            ('g-cloud-7', 'pending'),
-            ('digital-outcomes-and-specialists', 'coming')
+            ('g-cloud-8', 'coming'),
+            ('digital-outcomes-and-specialists', 'live')
         ]
         framework_messages = [
-            u"Become a Digital Outcomes and Specialists supplier",
-            u"Digital Outcomes and Specialists will be open for applications soon."
+            u"Provide cloud software and support to the public sector.",
+            u"You need an account to receive notifications about when you can apply."
         ]
 
         self._load_homepage(framework_slugs_and_statuses, framework_messages)
 
-    def test_homepage_sidebar_message_exists_dos_open(self):
+    def test_homepage_sidebar_message_exists_gcloud_8_open(self):
 
         framework_slugs_and_statuses = [
-            ('g-cloud-7', 'pending'),
-            ('digital-outcomes-and-specialists', 'open')
+            ('g-cloud-8', 'open'),
+            ('digital-outcomes-and-specialists', 'live')
         ]
         framework_messages = [
-            u"Become a Digital Outcomes and Specialists supplier",
-            u"Digital Outcomes and Specialists is open for applications."
+            u"Provide cloud software and support to the public sector",
+            u"You need an account to apply.",
+            u"The application deadline is 5pm BST, 21 June 2016."
         ]
 
         self._load_homepage(framework_slugs_and_statuses, framework_messages)
@@ -187,7 +188,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         )
         sidebar_link_texts = [str(item).strip() for item in sidebar_links]
 
-        assert 'Digital Outcomes and Specialists opportunities' in sidebar_link_texts
+        assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
         assert 'Create a supplier account' in sidebar_link_texts
         assert 'View your services and account information' not in sidebar_link_texts
 
@@ -209,37 +210,9 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         )
         sidebar_link_texts = [str(item).strip() for item in sidebar_links]
 
-        assert 'Digital Outcomes and Specialists opportunities' in sidebar_link_texts
+        assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
         assert 'View your services and account information' in sidebar_link_texts
         assert 'Create a supplier account' not in sidebar_link_texts
-
-    @mock.patch('app.main.views.marketplace.data_api_client')
-    def test_no_homepage_sidebar_messages_are_shown_to_not_logged_in_users_before_dos_is_live(self, data_api_client):
-        data_api_client.find_frameworks.return_value = self._find_frameworks([
-            ('digital-outcomes-and-specialists', 'standstill')
-        ])
-        res = self.client.get('/')
-
-        assert res.status_code == 200
-        self._assert_message_container_is_empty(res.get_data(as_text=True))
-
-    def test_homepage_sidebar_message_doesnt_exist_without_frameworks(self):
-        framework_slugs_and_statuses = [
-            ('g-cloud-2', 'expired'),
-            ('g-cloud-3', 'expired'),
-            ('g-cloud-4', 'expired')
-        ]
-
-        # there are no messages
-        self._load_homepage(framework_slugs_and_statuses, None)
-
-    @mock.patch('app.main.views.marketplace.data_api_client')
-    def test_api_error_message_doesnt_exist(self, data_api_client):
-
-        data_api_client.find_frameworks.side_effect = APIError()
-        res = self.client.get('/')
-        assert_equal(200, res.status_code)
-        self._assert_message_container_is_empty(res.get_data(as_text=True))
 
     # here we've given an valid framework with a valid status but there is no message.yml file to read from
     @mock.patch('app.main.views.marketplace.data_api_client')


### PR DESCRIPTION
Add temporary messages for G-Cloud-8

Move shared placeholders above frontend toolkit styles to prevent extensions of shared placeholders from being overwritten.

Also add new verions of frontend toolkit, with temporary message variant and digital marketplace framework with new content.

Remove h3 class from suppliers scss as this is obsolete.

Remove framework notice option as this has been superceded by the temporary messages pattern.