### PR TITLE
[#118568577] Return to description of work

### DIFF
--- a/app/templates/buyers/edit_brief_question.html
+++ b/app/templates/buyers/edit_brief_question.html
@@ -44,7 +44,7 @@
   {%
     with
     url = brief_links.brief_link_url('child', section, brief) ,
-    text = "Return to {}".format('overview' if section.questions|length == 1 else section.name|lower)
+    text = "Return to {}".format(section.name|lower if section.has_summary_page else 'overview')
   %}
     {% include "toolkit/secondary-action-link.html" %}
   {% endwith %}

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -440,10 +440,10 @@ class TestEditBriefSubmission(BaseApplicationTest):
 
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
+        secondary_action_link = document.xpath('//form//div[contains(@class, "secondary-action-link")]/a')[0]
         assert document.xpath('//h1')[0].text_content().strip() == "Optional 2"
-        assert document.xpath(
-            '//form//div[contains(@class, "secondary-action-link")]/a'
-        )[0].get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-4"  # noqa
+        assert secondary_action_link.get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-4"  # noqa
+        assert secondary_action_link.text_content().strip() == "Return to section 4"
         self._test_breadcrumbs_on_question_page(response=res, has_summary_page=True, section_name='Section 4')
 
     @mock.patch("app.buyers.views.buyers.content_loader")
@@ -469,10 +469,10 @@ class TestEditBriefSubmission(BaseApplicationTest):
 
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
+        secondary_action_link = document.xpath('//form//div[contains(@class, "secondary-action-link")]/a')[0]
         assert document.xpath('//h1')[0].text_content().strip() == "Required 1"
-        assert document.xpath(
-            '//form//div[contains(@class, "secondary-action-link")]/a'
-        )[0].get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-1"  # noqa
+        assert secondary_action_link.get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-1"  # noqa
+        assert secondary_action_link.text_content().strip() == "Return to section 1"
         self._test_breadcrumbs_on_question_page(response=res, has_summary_page=True, section_name='Section 1')
 
     @mock.patch("app.buyers.views.buyers.content_loader")
@@ -498,10 +498,10 @@ class TestEditBriefSubmission(BaseApplicationTest):
 
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
+        secondary_action_link = document.xpath('//form//div[contains(@class, "secondary-action-link")]/a')[0]
         assert document.xpath('//h1')[0].text_content().strip() == "Required 2"
-        assert document.xpath(
-            '//form//div[contains(@class, "secondary-action-link")]/a'
-        )[0].get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"  # noqa
+        assert secondary_action_link.get('href').strip() == "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"  # noqa
+        assert secondary_action_link.text_content().strip() == "Return to overview"
         self._test_breadcrumbs_on_question_page(response=res, has_summary_page=False)
 
     @mock.patch("app.buyers.views.buyers.content_loader")


### PR DESCRIPTION
The logic for deciding whether the secondary action link should return a user to the the overview or the section summary page was right, but not applied consistently.

The generated link was correct (and tested), but the link text itself was using slightly different logic (and wasn't being tested).

Fixed the logic and added some tests for link text on brief question pages.

[>> Bug in Tracker](https://www.pivotaltracker.com/story/show/118568577)