### PR TITLE
Update dependencies with new 'number' question type support

### DIFF
--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -127,12 +127,13 @@
   {% endwith %}
 {%- endmacro %}
 
-{% macro percentage(question_content, data, errors) -%}
+{% macro number(question_content, data, errors) -%}
   {%
     with
-    unit_in_full="percent",
-    unit_position="after",
-    unit="%",
+    unit_in_full=question_content.unit_in_full,
+    unit_position=question_content.unit_position,
+    unit=question_content.unit,
+    smaller=True,
     question=question_content.question|markdown,
     question_advice=question_content.question_advice,
     hint=question_content.hint,

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.13.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.14.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.1.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.1"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@19.7.2#egg=digitalmarketplace-utils==19.7.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@19.9.0#egg=digitalmarketplace-utils==19.9.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -36,11 +36,11 @@ class TestBuyerDashboard(BaseApplicationTest):
             tables = document.xpath('//table')
             draft_row = [cell.text_content().strip() for cell in tables[0].xpath('.//tbody/tr/td')]
             assert draft_row[0] == "A draft brief"
-            assert draft_row[1] == "Tuesday 02 February 2016"
+            assert draft_row[1] == "Tuesday 2 February 2016"
 
             live_row = [cell.text_content().strip() for cell in tables[1].xpath('.//tbody/tr/td')]
             assert live_row[0] == "A live brief"
-            assert live_row[1] == "Thursday 04 February 2016"
+            assert live_row[1] == "Thursday 4 February 2016"
 
     @pytest.mark.skip(reason="no counts on dashboard until API response includes them")
     def test_closed_brief_response_count(self, data_api_client):

--- a/tests/app/views/test_services.py
+++ b/tests/app/views/test_services.py
@@ -233,7 +233,7 @@ class TestServicePage(BaseApplicationTest):
             unavailable_banner.heading_text(),
             '{} stopped offering this service on {}'.format(
                 self.service['services']['supplierName'],
-                'Tuesday 05 January 2016.'
+                'Tuesday 5 January 2016.'
             )
         )
         assert_equal(
@@ -266,7 +266,7 @@ class TestServicePage(BaseApplicationTest):
             unavailable_banner.heading_text(),
             '{} stopped offering this service on {}'.format(
                 self.service['services']['supplierName'],
-                'Tuesday 05 January 2016.'
+                'Tuesday 5 January 2016.'
             )
         )
         assert_equal(
@@ -304,7 +304,7 @@ class TestServicePage(BaseApplicationTest):
             unavailable_banner.body_text(),
             'The {} framework expired on {}. Any existing contracts with {} are still valid.'.format(
                 self.service['services']['frameworkName'],
-                'Tuesday 05 January 2016',
+                'Tuesday 5 January 2016',
                 self.service['services']['supplierName']
             )
         )


### PR DESCRIPTION
### Update toolkit form macro to support 'number' question type
Renames percentage form macro to number and passes the number
question 'unit' fields to the form template.

Number fields are always rendered as `smaller` text inputs.

#### Remove leading zeroes from test date formats