### PR TITLE
[#118094925] Question title displayed twice on page

### DIFF
--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -5,6 +5,10 @@
 
 {% block main_content %}
 
+  {% if question.type != 'multiquestion' %}
+    <div class="single-question-page">
+  {% endif %}
+
   <div class="grid-row">
     <div class="column-two-thirds">
 
@@ -55,4 +59,8 @@
     </div>
 
   </form>
+
+  {% if question.type != 'multiquestion' %}
+    </div>
+  {% endif %}
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.14.1",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.15.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.3"
   }


### PR DESCRIPTION
Brings in [latest toolkit version](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/259) (not merged yet) which hides question labels inside `.single-question-page` divs.  Also adds a `.single-question-page` wrapping div to non-multiquestion questions.

That's kind of it. 

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/118094925)

***

### Screenshots

Before before            |  Now
:-------------------------:|:-------------------------:
![screen shot 2016-05-10 at 18 06 45](https://cloud.githubusercontent.com/assets/2454380/15155833/2293cf86-16dc-11e6-8c22-d39c56cf8389.png)  |  ![screen shot 2016-05-10 at 18 07 01](https://cloud.githubusercontent.com/assets/2454380/15155836/24feb7cc-16dc-11e6-8d9e-79aeee8572a8.png)