### PR TITLE
Change supplier questions summary table

### DIFF
--- a/app/templates/buyers/supplier_questions.html
+++ b/app/templates/buyers/supplier_questions.html
@@ -38,6 +38,7 @@
       {% import "toolkit/summary-table.html" as summary %}
 
       {{ summary.heading("Supplier questions", id="clarification-questions") }}
+      {{ summary.top_link("Answer a supplier question", url_for('.add_supplier_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id)) }}
       {% call(question) summary.list_table(
         brief.clarificationQuestions,
         field_headings=[
@@ -60,7 +61,6 @@
     </div>
   </div>
 
-  <a href="{{ url_for('.add_supplier_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}">Answer a supplier question</a>
 
   {%
     with


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/118904977) story on Pivotal.

Changes the Supplier questions summary table to a summary table with
top-level action. The top level link is to the 'Answer a supplier question' page, and the link underneath (to the same page) has been removed.

Ran the functional tests and there's no change required.

***

<img width="973" alt="screen shot 2016-05-12 at 16 01 38" src="https://cloud.githubusercontent.com/assets/13836290/15219232/dba414c0-185a-11e6-84d7-aa143e6ea1a0.png">
