### PR TITLE
Update frameworks requirement version to 1.3.6

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.15.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.3"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.3.6"
   }
 }


### PR DESCRIPTION
Updates the frameworks version to make use of [this](https://github.com/alphagov/digitalmarketplace-frameworks/pull/274) PR. It changes the link destination on the 'Additional terms and conditions' question to take the buyer directly to the standard contract.