### PR TITLE
Update content on publish page

### DIFF
--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -94,7 +94,7 @@
           {{ summary.text("You must have published answers to all suppliers’ questions.") }}
         {% endcall %}
         {% call summary.row(no_border=True) %}
-          {{ summary.text("If {} is a Saturday or Sunday, you need to have published all questions and answers by the Friday before.".format(dates.answers_close | shortdateformat), border=True) }}
+          {{ summary.text("If {} is a Saturday or Sunday, publish all questions and answers by the Friday before.".format(dates.answers_close | shortdateformat), border=True) }}
         {% endcall %}
         {% call summary.row(bold_border=True) %}
           {{ summary.field_heading_date(dates.closing_date | shortdateformat, scope='row') }}


### PR DESCRIPTION
## Updates the content in the table of dates on the 'Publish your requirements and evaluation criteria' page.

For [this](https://www.pivotaltracker.com/story/show/118173825) story on Pivotal.

Old: 'If 16 April is a Saturday or Sunday, you need to have published
all questions and answers by the Friday before.'

New: 'If 16 April is a Saturday or Sunday, publish all questions
and answers by the Friday before.

<img width="655" alt="screen shot 2016-05-19 at 15 28 07" src="https://cloud.githubusercontent.com/assets/13836290/15397164/010b189a-1dd7-11e6-86f2-2e50498c395c.png">