### PR TITLE
buyers can view their q + a dates while their brief is live

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -385,7 +385,7 @@ def view_brief_timeline(framework_slug, lot_slug, brief_id):
     get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
-    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or brief_can_be_edited(brief):
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or brief.get('status') != 'live':
         abort(404)
 
     dates = get_publishing_dates(brief)

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -388,22 +388,11 @@ def view_brief_timeline(framework_slug, lot_slug, brief_id):
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or brief_can_be_edited(brief):
         abort(404)
 
-    content = content_loader.get_manifest(brief['frameworkSlug'], 'edit_brief').filter({'lot': brief['lotSlug']})
-    sections = content.summary(brief)
-    question_and_answers = {}
-    question_and_answers_content = sections.get_question('questionAndAnswerSessionDetails')
-    question_and_answers['id'] = question_and_answers_content['id']
-
-    for section in sections:
-        if section.get_question('questionAndAnswerSessionDetails') == question_and_answers_content:
-            question_and_answers['slug'] = section['id']
-
     dates = get_publishing_dates(brief)
 
     return render_template(
         "buyers/brief_publish_confirmation.html",
         email_address=brief['users'][0]['emailAddress'],
-        question_and_answers=question_and_answers,
         published=True,
         brief=brief,
         dates=dates

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -379,6 +379,35 @@ def publish_brief(framework_slug, lot_slug, brief_id):
             dates=dates
         ), 200
 
+@buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/timeline', methods=['GET'])
+def view_brief_timeline(framework_slug, lot_slug, brief_id):
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    brief = data_api_client.get_brief(brief_id)["briefs"]
+
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or brief_can_be_edited(brief):
+        abort(404)
+
+    content = content_loader.get_manifest(brief['frameworkSlug'], 'edit_brief').filter({'lot': brief['lotSlug']})
+    sections = content.summary(brief)
+    question_and_answers = {}
+    question_and_answers_content = sections.get_question('questionAndAnswerSessionDetails')
+    question_and_answers['id'] = question_and_answers_content['id']
+
+    for section in sections:
+        if section.get_question('questionAndAnswerSessionDetails') == question_and_answers_content:
+            question_and_answers['slug'] = section['id']
+
+    dates = get_publishing_dates(brief)
+
+    return render_template(
+        "buyers/brief_publish_confirmation.html",
+        email_address=brief['users'][0]['emailAddress'],
+        question_and_answers=question_and_answers,
+        published=True,
+        brief=brief,
+        dates=dates
+    ), 200
+
 
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/delete', methods=['POST'])
 def delete_a_brief(framework_slug, lot_slug, brief_id):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -379,6 +379,7 @@ def publish_brief(framework_slug, lot_slug, brief_id):
             dates=dates
         ), 200
 
+
 @buyers.route('/buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/timeline', methods=['GET'])
 def view_brief_timeline(framework_slug, lot_slug, brief_id):
     get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -85,17 +85,21 @@ def get_sorted_responses_for_brief(brief, data_api_client):
         return brief_responses
 
 
-def get_publishing_dates():
+def get_publishing_dates(brief=None):
     application_open_days = 14
     questions_open_days = application_open_days - 7
     answers_open_days = application_open_days - 1
 
     dates = {}
-
-    dates['today'] = datetime.utcnow().replace(hour=23, minute=59, second=59, microsecond=0)
-    dates['questions_close'] = dates['today'] + timedelta(days=questions_open_days)
-    dates['answers_close'] = dates['today'] + timedelta(days=answers_open_days)
-    dates['closing_date'] = dates['today'] + timedelta(days=application_open_days)
-    dates['application_open_weeks'] = application_open_days//7
-    dates['closing_time'] = '{d:%I:%M %p}'.format(d=dates['closing_date']).lower()
+    if brief is not None and brief.get('publishedAt'):
+        dates['questions_close'] = brief['clarificationQuestionsClosedAt']
+        dates['answers_close'] = brief['clarificationQuestionsPublishedBy']
+        dates['closing_date'] = brief['applicationsClosedAt']
+    else:
+        dates['today'] = datetime.utcnow().replace(hour=23, minute=59, second=59, microsecond=0)
+        dates['questions_close'] = dates['today'] + timedelta(days=questions_open_days)
+        dates['answers_close'] = dates['today'] + timedelta(days=answers_open_days)
+        dates['closing_date'] = dates['today'] + timedelta(days=application_open_days)
+        dates['application_open_weeks'] = application_open_days//7
+        dates['closing_time'] = '{d:%I:%M %p}'.format(d=dates['closing_date']).lower()
     return dates

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -86,7 +86,7 @@
                 {
                   'href': url_for(".view_brief_timeline",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
                   'text': 'View question and answer dates',
-                  'allowed_statuses': ['live', 'closed']
+                  'allowed_statuses': ['live']
                 },
                 {
                   'href': url_for("main.get_brief_by_id", framework_slug=brief.frameworkSlug, brief_id=brief.id),

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -84,8 +84,13 @@
                   'allowed_statuses': ['draft']
                 },
                 {
+                  'href': url_for(".view_brief_timeline",framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  'text': 'View question and answer dates',
+                  'allowed_statuses': ['live', 'closed']
+                },
+                {
                   'href': url_for("main.get_brief_by_id", framework_slug=brief.frameworkSlug, brief_id=brief.id),
-                  'text': 'View published requirements',
+                  'text': 'View your published requirements',
                   'allowed_statuses': ['live', 'closed']
                 }
               ]

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -28,20 +28,22 @@
 <div class='grid-row'>
   <div class='column-two-thirds large-paragraph'>
     {% with
-        heading = "Publish your requirements and evaluation criteria",
+        heading = "Publish your requirements and evaluation criteria" if not published else "Question and answer dates",
         smaller = True,
         with_breadcrumb = True
     %}
         {% include "toolkit/page-heading.html" %}
     {% endwith %}
-    <p class="padding-bottom-small">All requirements are published on the Digital Marketplace where anyone can see them.</p>
-    <p class="padding-bottom-small">All requirements are open for {{ dates.application_open_weeks }} weeks.</p>
-    <p class="padding-bottom-small">If you publish your requirements today ({{ dates.today | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date | shortdateformat}}.</p>
+    {% if not published %}
+      <p class="padding-bottom-small">All requirements are published on the Digital Marketplace where anyone can see them.</p>
+      <p class="padding-bottom-small">All requirements are open for {{ dates.application_open_weeks }} weeks.</p>
+      <p class="padding-bottom-small">If you publish your requirements today ({{ dates.today | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date | shortdateformat}}.</p>
+    {% endif %}
+    <p><strong>Supplier questions will be sent to:</strong></p>
+    <p class="padding-bottom-small">{{ email_address }}</p>
+    <p class="padding-bottom-small">Ensure this email address {% if not published %}will be{% else %}is{% endif %} monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
 
-    <p class="padding-bottom-small"><strong>Supplier questions will be sent to:</strong> {{ email_address }}</p>
-    <p class="padding-bottom-small">Ensure this email address will be monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
-
-    {% if unanswered_required > 0 %}
+    {% if not published and unanswered_required > 0 %}
       <p class="padding-bottom-small"><strong>You still need to complete the following questions before your requirements can be published:</strong></p>
       {% for section in sections %}
         {% for question in section.questions %}
@@ -60,8 +62,8 @@
         row_bold_borders=True,
         text_large = True,
         no_bottom_border=True,
-        caption="If you publish today, you must be aware of the following dates:",
-        caption_visible=True,
+        caption="If you publish today, you must be aware of the following dates:" if not published,
+        caption_visible=not published,
         field_headings=[
           "Date",
           "Notice",
@@ -69,14 +71,16 @@
         field_headings_visible=False
       ) %}
         {% call summary.row(no_border=True) %}
-          {{ summary.field_heading_date("Today", scope='row') }}
+          {{ summary.field_heading_date("Today" if not published else (brief.publishedAt | shortdateformat), scope='row') }}
           {{ summary.text("Suppliers can apply and ask questions about your requirements.") }}
         {% endcall %}
         {% if brief.questionAndAnswerSessionDetails %}
           {% call summary.row(bold_border=True) %}
             {{ summary.field_heading_date("Before {}".format(dates.questions_close | shortdateformat), rowspan='3', scope='row') }}
             {{ summary.text_bold("Details of your question and answer session") }}
-            {{ summary.edit_link("Edit", url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=question_and_answers.slug, question_id=question_and_answers.id)) }}
+            {% if not published %}
+              {{ summary.edit_link("Edit", url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=question_and_answers.slug, question_id=question_and_answers.id)) }}
+            {% endif %}
           {% endcall %}
           {% call summary.row(no_border=True) %}
             {{ summary.text(brief.questionAndAnswerSessionDetails) }}
@@ -101,16 +105,18 @@
           {{ summary.text("The last day suppliers can apply.") }}
         {% endcall %}
       {% endcall %}
-      <form action="{{ url_for('.publish_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        {%
-        with
-        type = "save",
-        label = "Publish requirements"
-        %}
-        {% include "toolkit/button.html" %}
-        {% endwith %}
-      </form>
+      {% if not published %}
+        <form action="{{ url_for('.publish_brief', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}" method="POST">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {%
+          with
+          type = "save",
+          label = "Publish requirements"
+          %}
+          {% include "toolkit/button.html" %}
+          {% endwith %}
+        </form>
+      {% endif %}
     {% endif %}
 
     {%

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1195,7 +1195,8 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
             assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
             assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
-                'View published requirements',
+                'View question and answer dates',
+                'View your published requirements',
                 'Publish questions and answers',
                 'How to answer supplier questions',
                 'How to shortlist suppliers',
@@ -1231,7 +1232,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
             assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
             assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
-                'View published requirements',
+                'View your published requirements',
                 'View and shortlist suppliers',
                 'How to shortlist suppliers',
                 'How to evaluate suppliers',

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1880,3 +1880,83 @@ class TestDownloadBriefResponsesCsv(BaseApplicationTest):
         self.login_as_buyer()
         res = self.client.get(self.url)
         assert res.status_code == 404
+
+
+@mock.patch('app.buyers.views.buyers.data_api_client')
+class TestViewQuestionAndAnswerDates(BaseApplicationTest):
+    def test_show_question_and_answer_dates_for_published_brief(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            brief_json = api_stubs.brief(status="live")
+            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+            brief_json['briefs']['clarificationQuestionsClosedAt'] = "2016-04-12T23:59:00.00000Z"
+            brief_json['briefs']['clarificationQuestionsPublishedBy'] = "2016-04-14T23:59:00.00000Z"
+            brief_json['briefs']['applicationsClosedAt'] = "2016-04-16T23:59:00.00000Z"
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+            data_api_client.get_brief.return_value = brief_json
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/timeline"
+            )
+
+            assert res.status_code == 200
+            page_html = res.get_data(as_text=True)
+            document = html.fromstring(page_html)
+
+            assert (document.xpath('//h1')[0]).text_content().strip() == "Question and answer dates"
+            assert all(
+                date in
+                [e.text_content() for e in document.xpath('//main[@id="content"]//th/span')]
+                for date in ['2 April', '12 April', '14 April', '16 April']
+            )
+
+    def test_do_not_show_question_and_answer_dates_for_draft_brief(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            brief_json = api_stubs.brief(status="draft")
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+            data_api_client.get_brief.return_value = brief_json
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/timeline"
+            )
+
+            assert res.status_code == 404
+
+    def test_do_not_show_question_and_answer_dates_for_closed_brief(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            brief_json = api_stubs.brief(status="closed")
+            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+            brief_json['briefs']['specialistRole'] = 'communicationsManager'
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+            data_api_client.get_brief.return_value = brief_json
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/timeline"
+            )
+
+            assert res.status_code == 404


### PR DESCRIPTION
Adds a link to 'View question and answer dates' on the overview page that links to `brief_publish_confirmation.html`.

![image](https://cloud.githubusercontent.com/assets/8417288/15470288/c05aabe4-20e7-11e6-999c-dcf420417f24.png)

The `brief_publish_confirmation.html` changes when a opportunity is live:
- removes the warnings that are no longer relevant and the publish button
- changes content to present tense.

The page isn't visible when the opportunity closes.

![image](https://cloud.githubusercontent.com/assets/8417288/15470458/c285f59e-20e8-11e6-8048-1e57f3888ec6.png)

