### PR TITLE
Update 'View Opportunities' page to include missing 'and'

### DIFF
--- a/app/templates/briefs_catalogue.html
+++ b/app/templates/briefs_catalogue.html
@@ -25,7 +25,7 @@
     <div class="grid-row">
         <section class="column-two-thirds">
             <div class="marketplace-paragraph">
-              <p>View buyer requirements for {{ lot_names | map('lower') | join(", ") }}.</p>
+              <p>View buyer requirements for {{ lot_names | map('lower') | smartjoin }}.</p>
             </div>
             {% include '_briefs_list.html' %}
             {% include '_briefs_pagination.html' %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@20.0.0#egg=digitalmarketplace-utils==20.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@20.1.0#egg=digitalmarketplace-utils==20.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.1#egg=digitalmarketplace-content-loader==1.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -453,7 +453,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
 
         heading = document.xpath('//h1/text()')[0].strip()
         assert heading == "Digital Outcomes and Specialists opportunities"
-        assert 'lot 1, lot 3' in document.xpath('//div[@class="marketplace-paragraph"]/p/text()')[0]
+        assert 'lot 1 and lot 3' in document.xpath('//div[@class="marketplace-paragraph"]/p/text()')[0]
 
     def test_catalogue_of_briefs_page_shows_pagination_if_more_pages(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/118472411) story on Pivotal.

This PR updates the view opportunities page to use a new filter (see [this PR](https://github.com/alphagov/digitalmarketplace-utils/pull/265)) which will convert a list of strings to a properly formatted string. It joins all elements with a ', ' except for the last which it joins with ' and '.

If a list has only one element, it just returns that element as a lower case string without any commas or 'and'.

If the list has no elements it will just return an empty string. This should never occur in this use case, but the functionality has been added in case it is needed for another application in the future.

All strings are converted to lowercase.

See the screenshot below.


<img width="736" alt="screen shot 2016-05-23 at 17 09 55" src="https://cloud.githubusercontent.com/assets/13836290/15476818/441dd656-2109-11e6-855f-89c9a97943ea.png">
