### PR TITLE
Change button label on 'Publish your requirements and evaluation criteria' page

### DIFF
--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -106,7 +106,7 @@
         {%
         with
         type = "save",
-        label = "Publish Requirements"
+        label = "Publish requirements"
         %}
         {% include "toolkit/button.html" %}
         {% endwith %}

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1030,7 +1030,7 @@ class TestPublishBrief(BaseApplicationTest):
         page_html = res.get_data(as_text=True)
 
         assert res.status_code == 200
-        assert 'Publish Requirements' in page_html, page_html
+        assert 'Publish requirements' in page_html, page_html
 
     def test_publish_button_unavailable_if_questions_not_answered(self, data_api_client):
         self.login_as_buyer()
@@ -1049,7 +1049,7 @@ class TestPublishBrief(BaseApplicationTest):
         page_html = res.get_data(as_text=True)
 
         assert res.status_code == 200
-        assert 'Publish Requirements' not in page_html
+        assert 'Publish requirements' not in page_html
 
 
 @mock.patch('app.buyers.views.buyers.data_api_client')


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/118418389) story on Pivotal.

The button to publish a brief was labelled with 'Publish Requirements'. It has been updated to 'Publish requirements'. See screenshot.

![screen shot 2016-05-24 at 14 43 14](https://cloud.githubusercontent.com/assets/13836290/15506055/e63845de-21bd-11e6-81f2-0750c82aa886.png)
