### PR TITLE
Add gunicorn to requirements.txt for PaaS deploys

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ werkzeug==0.10.4
 git+https://github.com/alphagov/digitalmarketplace-utils.git@20.1.0#egg=digitalmarketplace-utils==20.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.0.1#egg=digitalmarketplace-content-loader==1.0.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0
+
+# For Cloud Foundry
+cffi==1.5.2
+gunicorn==19.4.5


### PR DESCRIPTION
Add gunicorn to requirements.txt for running the app on Cloud Foundry
(possibly not ideal see [1]).

Explicitly add cffi to requirements so that Cloud Foundry spots it and
adds libffi.

There doesn't seem to be an easy way to use a different requirements
file for Cloud Foundry, so we'll have to add the dependencies
everywhere.

[1] https://github.com/etianen/django-herokuapp/issues/9