### PR TITLE
Adding phone number to buyer

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -65,8 +65,9 @@ class CreateUserForm(Form):
     phone_number = StringField(
         'Phone number', id="input_phone_number",
         validators=[
-            Regexp("^$|^\\+?([\\d\\s()-]){6,20}$",
-                   message="Phone numbers must be between 6 and 20 characters."
+            Regexp("^$|^\\+?([\\d\\s()-]){9,20}$",
+                   message=("Phone numbers must be at least 9 characters long. "
+                            "They can only include digits, spaces, plus and minus signs, and brackets.")
                    )
         ]
     )

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,7 +1,7 @@
 from flask_wtf import Form
 from wtforms import PasswordField
-from wtforms.validators import DataRequired, Email, EqualTo, Length
-from dmutils.forms import StripWhitespaceStringField
+from wtforms.validators import DataRequired, Email, EqualTo, Length, Regexp
+from dmutils.forms import StripWhitespaceStringField, StringField
 
 
 class LoginForm(Form):
@@ -58,6 +58,15 @@ class CreateUserForm(Form):
             Length(min=1,
                    max=255,
                    message="Names must be between 1 and 255 characters"
+                   )
+        ]
+    )
+
+    phone_number = StringField(
+        'Phone number', id="input_phone_number",
+        validators=[
+            Regexp("^$|^\\+?([\\d\\s()-]){6,20}$",
+                   message="Phone numbers must be between 6 and 20 characters."
                    )
         ]
     )

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -302,6 +302,7 @@ def submit_create_user(encoded_token):
             user = data_api_client.create_user({
                 'name': form.name.data,
                 'password': form.password.data,
+                'phoneNumber': form.phone_number.data,
                 'emailAddress': token.get('email_address'),
                 'role': 'buyer'
             })

--- a/app/templates/auth/create-user.html
+++ b/app/templates/auth/create-user.html
@@ -54,24 +54,43 @@
                 </div>
                 {% endif %}
 
+                {% if form.phone_number.errors %}
+                    <div class="validation-wrapper">
+                {% endif %}
+                    <div class="question" id="{{ form.phone_number.name }}">
+                        {{ form.phone_number.label(class="question-heading-with-hint") }}
+                        <p class="hint">
+                          If there are any urgent problems with your requirements, we need your phone number so the support team can help you fix them quickly.
+                        </p>
+                        {% if form.phone_number.errors %}
+                        <p class="validation-message" id="error-password-textbox">
+                            {% for error in form.phone_number.errors %}{{ error }}{% endfor %}
+                        </p>
+                        {% endif %}
+                        {{ form.phone_number(class="text-box", autocomplete="off") }}
+                    </div>
+                {% if form.phone_number.errors %}
+                    </div>
+                {% endif %}
+
                 {% if form.password.errors %}
-                <div class="validation-wrapper">
-            {% endif %}
-                <div class="question" id="{{ form.password.name }}">
-                    {{ form.password.label(class="question-heading-with-hint") }}
-                    <p class="hint">
-                      Must be between 10 and 50 characters
-                    </p>
-                    {% if form.password.errors %}
-                    <p class="validation-message" id="error-password-textbox">
-                        {% for error in form.password.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.password(class="text-box", autocomplete="off") }}
-                </div>
-            {% if form.password.errors %}
-                </div>
-            {% endif %}
+                    <div class="validation-wrapper">
+                {% endif %}
+                    <div class="question" id="{{ form.password.name }}">
+                        {{ form.password.label(class="question-heading-with-hint") }}
+                        <p class="hint">
+                          Must be between 10 and 50 characters
+                        </p>
+                        {% if form.password.errors %}
+                        <p class="validation-message" id="error-password-textbox">
+                            {% for error in form.password.errors %}{{ error }}{% endfor %}
+                        </p>
+                        {% endif %}
+                        {{ form.password(class="text-box", autocomplete="off") }}
+                    </div>
+                {% if form.password.errors %}
+                    </div>
+                {% endif %}
 
             {%
               with

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -859,6 +859,7 @@ class TestCreateUser(BaseApplicationTest):
             'role': 'buyer',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
+            'phoneNumber': '',
             'name': 'valid name'
         })
 
@@ -882,6 +883,7 @@ class TestCreateUser(BaseApplicationTest):
             'role': 'buyer',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
+            'phoneNumber': '',
             'name': 'valid name'
         })
 
@@ -903,6 +905,7 @@ class TestCreateUser(BaseApplicationTest):
             'role': mock.ANY,
             'password': 'validpassword',
             'emailAddress': mock.ANY,
+            'phoneNumber': '',
             'name': 'valid name'
         })
 
@@ -922,7 +925,8 @@ class TestCreateUser(BaseApplicationTest):
             'role': mock.ANY,
             'password': '  validpassword  ',
             'emailAddress': mock.ANY,
-            'name': 'valid name'
+            'name': 'valid name',
+            'phoneNumber': '',
         })
 
     @mock.patch('app.main.views.login.data_api_client')

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -851,7 +851,8 @@ class TestCreateUser(BaseApplicationTest):
             '/create-user/{}'.format(token),
             data={
                 'password': 'validpassword',
-                'name': 'valid name'
+                'name': 'valid name',
+                'phone_number': '020-7930-4832'
             }
         )
 
@@ -859,7 +860,7 @@ class TestCreateUser(BaseApplicationTest):
             'role': 'buyer',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
-            'phoneNumber': '',
+            'phoneNumber': '020-7930-4832',
             'name': 'valid name'
         })
 
@@ -875,6 +876,7 @@ class TestCreateUser(BaseApplicationTest):
             '/create-user/{}'.format(token),
             data={
                 'password': 'validpassword',
+                'phone_number': '020-7930-4832',
                 'name': 'valid name'
             }
         )
@@ -883,7 +885,7 @@ class TestCreateUser(BaseApplicationTest):
             'role': 'buyer',
             'password': 'validpassword',
             'emailAddress': 'test@email.com',
-            'phoneNumber': '',
+            'phoneNumber': '020-7930-4832',
             'name': 'valid name'
         })
 
@@ -897,7 +899,9 @@ class TestCreateUser(BaseApplicationTest):
             '/create-user/{}'.format(token),
             data={
                 'password': 'validpassword',
-                'name': '  valid name  '
+                'name': '  valid name  ',
+                'phone_number': '020-7930-4832'
+
             }
         )
 
@@ -905,7 +909,7 @@ class TestCreateUser(BaseApplicationTest):
             'role': mock.ANY,
             'password': 'validpassword',
             'emailAddress': mock.ANY,
-            'phoneNumber': '',
+            'phoneNumber': '020-7930-4832',
             'name': 'valid name'
         })
 
@@ -917,7 +921,9 @@ class TestCreateUser(BaseApplicationTest):
             '/create-user/{}'.format(token),
             data={
                 'password': '  validpassword  ',
-                'name': 'valid name  '
+                'name': 'valid name  ',
+                'phone_number': '020-7930-4832'
+
             }
         )
 
@@ -926,7 +932,7 @@ class TestCreateUser(BaseApplicationTest):
             'password': '  validpassword  ',
             'emailAddress': mock.ANY,
             'name': 'valid name',
-            'phoneNumber': '',
+            'phoneNumber': '020-7930-4832',
         })
 
     @mock.patch('app.main.views.login.data_api_client')

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -892,6 +892,45 @@ class TestCreateUser(BaseApplicationTest):
         assert res.status_code == 400
 
     @mock.patch('app.main.views.login.data_api_client')
+    def test_should_create_user_if_no_phone_number(self, data_api_client):
+
+        token = self._generate_token()
+        res = self.client.post(
+            '/create-user/{}'.format(token),
+            data={
+                'password': 'validpassword',
+                'name': 'valid name',
+                'phone_number': None
+            }
+        )
+
+        data_api_client.create_user.assert_called_once_with({
+            'role': 'buyer',
+            'password': 'validpassword',
+            'emailAddress': 'test@email.com',
+            'phoneNumber': '',
+            'name': 'valid name'
+        })
+
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/'
+
+    @mock.patch('app.main.views.login.data_api_client')
+    def test_should_return_an_error_if_bad_phone_number(self, data_api_client):
+
+        token = self._generate_token()
+        res = self.client.post(
+            '/create-user/{}'.format(token),
+            data={
+                'password': 'validpassword',
+                'name': 'valid name',
+                'phone_number': 'Not a number'
+            }
+        )
+
+        assert res.status_code == 400
+
+    @mock.patch('app.main.views.login.data_api_client')
     def test_should_strip_whitespace_surrounding_create_user_name_field(self, data_api_client):
         data_api_client.get_user.return_value = None
         token = self._generate_token()


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/119726147) story on Pivotal.

This PR compliments [this](https://github.com/alphagov/digitalmarketplace-api/pull/399) one for the api.

It updates the app to include a field for phone number when buyer's create an account. It's included on the page with the name and password field.

The phone number is validated on the Regex pattern used in the user json_schema. I suspect that validation message will need changing. Screenshots below.


<img width="702" alt="screen shot 2016-05-27 at 11 56 54" src="https://cloud.githubusercontent.com/assets/13836290/15606445/3be3ee46-2404-11e6-8c4e-7cf3de5fd7fe.png">
___________________________________________________________________________
<img width="689" alt="screen shot 2016-05-27 at 12 11 40" src="https://cloud.githubusercontent.com/assets/13836290/15606447/3fab30a2-2404-11e6-91f7-ae4699369f0a.png">