### PR TITLE
Track the publishing of a brief

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -364,7 +364,7 @@ def publish_brief(framework_slug, lot_slug, brief_id):
         data_api_client.update_brief_status(brief_id, 'live', brief_user_name)
         return redirect(
             url_for('.view_brief_overview', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'],
-                    brief_id=brief['id']))
+                    brief_id=brief['id'], published='true'))
     else:
         email_address = brief_users['emailAddress']
         dates = get_publishing_dates()

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -950,7 +950,7 @@ class TestPublishBrief(BaseApplicationTest):
         assert res.status_code == 302
         assert data_api_client.update_brief_status.called
         assert res.location == "http://localhost/buyers/frameworks/digital-outcomes-and-specialists/" \
-                               "requirements/digital-specialists/1234"
+                               "requirements/digital-specialists/1234?published=true"
 
     def test_publish_brief_with_unanswered_required_questions(self, data_api_client):
         self.login_as_buyer()


### PR DESCRIPTION
Publishing a brief redirects to the brief overview page (which has the same URL as normally).

We need to track this action so this adds a `published=true` query string parameter to the URL when it is requested as a result of a publish.

https://www.pivotaltracker.com/story/show/119634461