### PR TITLE
Adjust button width for new padding

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -44,7 +44,7 @@
       height: 50px;
 
       @include media(tablet) {
-        margin-right: 7.6em;
+        margin-right: 8em;
       }
     }
 
@@ -53,10 +53,10 @@
       width: 100%;
 
       @include media(tablet) {
-        width: 7.6em;
+        width: 8em;
         position: absolute;
         top: 0;
-        right: -7.6em;
+        right: -8em;
         margin-right: $gutter-half;
       }
       padding-top: 5px;


### PR DESCRIPTION
The 'Show services' button on the G-Cloud index page is broken:

![image](https://cloud.githubusercontent.com/assets/87140/15828380/01440d7e-2c07-11e6-8b14-ede47ea77eab.png)

This is because of a change made to code the govuk frontend toolkit which came through when we bumped the version this app uses to `14.12.0`.

Story: https://www.pivotaltracker.com/story/show/120939061

The horizontal padding for all buttons using the `button` mixin was increased from 1.2em
(0.6em x 2) to 1.578946em (0.789473em x 2) in version `14.12.0` of the govuk frontend toolkit:

https://github.com/alphagov/govuk_frontend_toolkit/commit/227093d05ea6faa1c3a6dd1aed919ce607b66182

The 'Show services' button has its width set to 7.6em (roughly 183px with the 24px font-size) so
when the padding was increased, this reduced the space available for the text.

![button_diff](https://cloud.githubusercontent.com/assets/87140/15853281/42a4207a-2c9c-11e6-8d21-e15b633c1262.png)

In the CSS for this button, bearing in mind 1px is 0.04166em (1 / 24), the following is true:

Before the change the text had 6.4em (7.6em - 1.2em) of space (153.592px):

![button_old_css](https://cloud.githubusercontent.com/assets/87140/15820804/b5014d6e-2be3-11e6-87e7-a323100053c1.png)

After the change the text had 6.02105em (7.6em - 1.578946em) of space (144.496px):

![button_broken_css](https://cloud.githubusercontent.com/assets/87140/15820807/bf12d44e-2be3-11e6-8431-968996001021.png)

This changes the width so it includes the space the text had before + the new padding.

This ends up as 7.97894em (6.4em + 1.57894em) which we round up to a width of 8em.

Here are the dimensions this leaves us with:

![button_new_css](https://cloud.githubusercontent.com/assets/87140/15820820/cb30815e-2be3-11e6-88ad-b6c14f28765e.png)

...and the button now looks like:

![image](https://cloud.githubusercontent.com/assets/87140/15853344/82027578-2c9c-11e6-99da-6971a3a70014.png)
