### PR TITLE
Explain extra parameter added for brief publishing

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -363,6 +363,7 @@ def publish_brief(framework_slug, lot_slug, brief_id):
             abort(400, 'There are still unanswered required questions')
         data_api_client.update_brief_status(brief_id, 'live', brief_user_name)
         return redirect(
+            # the 'published' parameter is for tracking this request by analytics
             url_for('.view_brief_overview', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'],
                     brief_id=brief['id'], published='true'))
     else:


### PR DESCRIPTION
It was raised in [another analytics story on the supplier app](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/488) that adding a query parameter to requests just for analytics leaves no explanation for those reading the code in future why it's there.

This adds a comment to explain the reasoning behind the changes made in [#331](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/331)