### PR TITLE
Fix template footer css

### DIFF
--- a/app/assets/scss/_footer.scss
+++ b/app/assets/scss/_footer.scss
@@ -64,12 +64,12 @@
 
     hr {
       clear: both;
-      margin: $gutter 0 0;
+      margin: $gutter 0;
       border: 1px solid $border-colour;
       border-width: 1px 0 0 0;
 
       @include media(tablet) {
-        margin: 0;
+        margin-top: 0;
       }
     }
 

--- a/app/assets/scss/_footer.scss
+++ b/app/assets/scss/_footer.scss
@@ -80,6 +80,9 @@
     @include media(tablet) {
       padding: 0;
     }
+    /* Temporary fix:
+       chrome is breaking this layout when font-size-adjust is set */
+    font-size-adjust: none;
 
     .terms-and-conditions {
       display: block;

--- a/app/assets/scss/_footer.scss
+++ b/app/assets/scss/_footer.scss
@@ -5,22 +5,6 @@
 
 #footer {
 
-    h2 {
-
-      @include bold-19;
-      padding: 10px 0 0;
-      margin: 0;
-      border-bottom: none;
-
-      @include media(tablet) {
-
-        padding: 0 0 20px;
-        border-bottom: 1px solid #a1acb2;
-
-      }
-
-    }
-
   .footer-categories {
 
     padding: 0 $gutter-half $gutter;
@@ -36,6 +20,22 @@
       @include media(tablet) {
         padding: 0 $gutter-half $gutter * 2;
       }
+    }
+
+    h2 {
+
+      @include bold-19;
+      padding: 10px 0 0;
+      margin: 0;
+      border-bottom: none;
+
+      @include media(tablet) {
+
+        padding: 0 0 20px;
+        border-bottom: 1px solid #a1acb2;
+
+      }
+
     }
 
     ul {

--- a/app/assets/scss/_footer.scss
+++ b/app/assets/scss/_footer.scss
@@ -76,6 +76,10 @@
   }
 
   .footer-meta {
+    padding: 0 $gutter-half;
+    @include media(tablet) {
+      padding: 0;
+    }
 
     .terms-and-conditions {
       display: block;

--- a/app/assets/scss/_footer.scss
+++ b/app/assets/scss/_footer.scss
@@ -5,20 +5,18 @@
 
 #footer {
 
-  .footer-categories {
+  .footer-categories, .footer-meta {
+    @extend %grid-row;
+  }
 
-    padding: 0 $gutter-half $gutter;
-    overflow: hidden;
+  .footer-categories {
 
     .footer-about,
     .footer-buyers,
     .footer-suppliers {
-
       @include grid-column( 1/3 );
-      padding: 0;
-
       @include media(tablet) {
-        padding: 0 $gutter-half $gutter * 2;
+        padding-bottom: $gutter * 2;
       }
     }
 

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.16.3",
-    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.14.1/jinja_govuk_template-0.14.1.tgz",
+    "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.5.1"
   }
 }


### PR DESCRIPTION
We were getting some issues with the footer alignment in chrome:

Was:

![image](https://cloud.githubusercontent.com/assets/87140/15967413/86db2768-2f1f-11e6-9080-3ca5f5566c78.png)

Now:

![image](https://cloud.githubusercontent.com/assets/87140/15967468/c7589cda-2f1f-11e6-8ce6-07e2f04aa026.png)

This includes a fix for that (7e3057a) but also uses the opportunity to bump the govuk template used to the latest version and use the [new grids](https://github.com/alphagov/govuk_frontend_toolkit/pull/136) for the footer's category sections.