### PR TITLE
[#121388173] Fix for tick marks on the brief overview

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -10,7 +10,8 @@ from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
     all_essentials_are_true, counts_for_failed_and_eligible_brief_responses,
     get_framework_and_lot, get_sorted_responses_for_brief, count_unanswered_questions,
-    brief_can_be_edited, add_unanswered_counts_to_briefs, is_brief_correct, get_publishing_dates
+    brief_can_be_edited, add_unanswered_counts_to_briefs, is_brief_correct, get_publishing_dates,
+    section_has_at_least_one_required_question
 )
 
 from dmapiclient import HTTPError
@@ -115,7 +116,10 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
     completed_sections = {}
     for section in sections:
         required, optional = count_unanswered_questions([section])
-        completed_sections[section.slug] = True if required == 0 else False
+        if section_has_at_least_one_required_question(section):
+            completed_sections[section.slug] = True if required == 0 else False
+        else:
+            completed_sections[section.slug] = True if optional == 0 else False
 
     brief['clarificationQuestions'] = [
         dict(question, number=index+1)

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -37,9 +37,9 @@ def section_has_at_least_one_required_question(section):
     return len(required_questions) > 0
 
 
-def count_unanswered_questions(brief_attributes):
+def count_unanswered_questions(sections):
     unanswered_required, unanswered_optional = (0, 0)
-    for section in brief_attributes:
+    for section in sections:
         for question in section.questions:
             if question.answer_required:
                 unanswered_required += 1

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -32,6 +32,11 @@ def brief_can_be_edited(brief):
     return brief.get('status') == 'draft'
 
 
+def section_has_at_least_one_required_question(section):
+    required_questions = [q for q in section.questions if not q.get('optional')]
+    return len(required_questions) > 0
+
+
 def count_unanswered_questions(brief_attributes):
     unanswered_required, unanswered_optional = (0, 0)
     for section in brief_attributes:

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -178,6 +178,11 @@
               {% if step_sections.count(step_number) == 1 %}
                 {% set section = sections.sections[step_sections.index(step_number)] %}
                 <a class="instruction-list-item-extra-information" href="{{ brief_links.brief_link_url('grandparent', section, brief) }}">
+                  {% if completed_sections[section.slug]  %}
+                    <span class="tick">
+                      <img src="{{ asset_path }}svg/tick.svg" alt="done" width="15" height="14" />
+                    </span>
+                  {% endif %}
                   {{ section.name }}
                 </a>
               {% else %}

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -74,6 +74,22 @@ class TestBuyersHelpers(unittest.TestCase):
         assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='draft')['briefs']) is True
         assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='live')['briefs']) is False
 
+    def test_section_has_at_least_one_required_question(self):
+        content = content_loader.get_manifest('dos', 'edit_brief').filter(
+            {'lot': 'digital-specialists'}
+        )
+
+        sections_with_required_questions = {
+            'section-1': True,
+            'section-2': True,
+            'section-4': False,
+            'section-5': True
+        }
+
+        for section in content.sections:
+            assert helpers.buyers_helpers.section_has_at_least_one_required_question(section) \
+                == sections_with_required_questions[section.slug]
+
     def test_count_unanswered_questions(self):
         brief = {
             'status': 'draft',


### PR DESCRIPTION
There were two problems with tick marks that cropped up.

1. Sections containing only one question would never show ticks.
2. Sections containing no required questions would always show ticks.

Added some more template code to show ticks next to single questions, so that fixed the first case.

In the second case, new logic goes like:

```
if required_questions exist:
  count unanswered required questions
else:
  count unanswered optional questions
```

Also, I gave up on my `is_*` naming convention for methods that return boolean values because it just sounded too weird. (ie, otherwise it would have been called `is_section_has_at_least_one_required_question`)

[>> Bug bug bug](https://www.pivotaltracker.com/story/show/121388173)