### PR TITLE
Render all section links as lists.

### DIFF
--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -175,17 +175,7 @@
               <p class="instruction-list-item-extra-information">{{ step.description[brief.status] }}</p>
             {% endif %}
             {% if step_number in step_sections and brief.status == 'draft' %}
-              {% if step_sections.count(step_number) == 1 %}
-                {% set section = sections.sections[step_sections.index(step_number)] %}
-                <a class="instruction-list-item-extra-information" href="{{ brief_links.brief_link_url('grandparent', section, brief) }}">
-                  {% if completed_sections[section.slug]  %}
-                    <span class="tick">
-                      <img src="{{ asset_path }}svg/tick.svg" alt="done" width="15" height="14" />
-                    </span>
-                  {% endif %}
-                  {{ section.name }}
-                </a>
-              {% else %}
+
                 <ul class="instruction-list-item-extra-information">
                   {% for section in sections %}
                     {% if section.step == step_number %}
@@ -200,7 +190,6 @@
                     {% endif %}
                   {% endfor %}
                 </ul>
-              {% endif %}
             {% endif %}
             {% if step.links %}
               <ul class="instruction-list-item-extra-information">

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1125,6 +1125,8 @@ class TestBriefSummaryPage(BaseApplicationTest):
                 'Specialist role',
                 'Location',
                 'Description of work',
+                'Shortlist and evaluation process',
+                'Describe question and answer session',
                 'Review and publish your requirements',
                 'How to answer supplier questions',
                 'How to shortlist suppliers',


### PR DESCRIPTION
Previously, we would either render section links as either `li`s in a list (if there were multiple questions in a section) or as `a` elements (if there was just one question in a section).

Rendering things two different ways wasn't really giving us anything and it basically confused anyone who came into contact with it (including me), as well as our functional tests.

We're presenting all section links identically, whether they're the only question in a section or otherwise, so we should render them consistently.