### PR TITLE
Update links in header

### DIFF
--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -4,12 +4,16 @@
     <nav id="proposition-menu">
       <a href="/" id="proposition-name">Digital Marketplace</a>
       <ul id="proposition-links">
-        {% if current_user.email_address %}
+        {% if current_user.is_authenticated() %}
+          {% if current_user.role == 'buyer' %}
+            <li><a href="{{ url_for('buyers.buyer_dashboard') }}">View your account</a></li>
+          {% elif current_user.role == 'supplier' %}
+            <li><a href="/suppliers">View your account</a></li>
+          {% endif %}
         <li><a class="home" href="{{ url_for('main.logout') }}">Log out</a></li>
         {% else %}
         <li><a class="home" href="{{ url_for('main.render_login') }}">Log in</a></li>
         {% endif %}
-        <li><a href="/suppliers/create">Create supplier account</a></li>
       </ul>
     </nav>
   </div>

--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -5,14 +5,10 @@
       <a href="/" id="proposition-name">Digital Marketplace</a>
       <ul id="proposition-links">
         {% if current_user.is_authenticated() %}
-          {% if current_user.role == 'buyer' %}
-            <li><a href="{{ url_for('buyers.buyer_dashboard') }}">View your account</a></li>
-          {% elif current_user.role == 'supplier' %}
-            <li><a href="/suppliers">View your account</a></li>
-          {% endif %}
-        <li><a class="home" href="{{ url_for('main.logout') }}">Log out</a></li>
+          <li><a href="{{ url_for('buyers.buyer_dashboard') if current_user.role == 'buyer' else '/suppliers' }}">View your account</a></li>
+          <li><a class="home" href="{{ url_for('main.logout') }}">Log out</a></li>
         {% else %}
-        <li><a class="home" href="{{ url_for('main.render_login') }}">Log in</a></li>
+          <li><a class="home" href="{{ url_for('main.render_login') }}">Log in</a></li>
         {% endif %}
       </ul>
     </nav>


### PR DESCRIPTION
Remove "Create supplier account" link from the header
Logged in users will now see "View your account" and take them to
their respective dashboard page.
View your account link comes before the Log out link.
We changed from current_user.email_address to
current_user.is_authenticated() to check if a user is logged in or
not.