### PR TITLE
Remove duplicated links to buyer or supplier dashboards

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -18,7 +18,6 @@
 {% set dos_slug = 'digital-outcomes-and-specialists' %}
 {% set dos_is_live = frameworks.get('digital-outcomes-and-specialists', {}).status == "live" %}
 {% set dos_items = [] %}
-{% set buyer_dashboard = [] %}
 
 {% if dos_is_live %}
   {% set
@@ -45,15 +44,6 @@
       },
     ]
   %}
-  {% if current_user.role == 'buyer' %}
-    {% set buyer_dashboard = [
-        {
-          "link": "/buyers",
-          "title": "View your requirements and supplier responses",
-        },
-      ]
-    %}
-  {% endif %}
 {% endif %}
 
 <div class="index-page grid-row">
@@ -71,7 +61,7 @@
           "title": "Buy physical datacentre space for legacy systems",
           "body": "eg for services that can’t be migrated to the cloud",
         },
-      ] + buyer_dashboard
+      ]
     %}
       {% include "toolkit/browse-list.html" %}
     {% endwith %}
@@ -115,14 +105,6 @@
           </a>
         </p>
         <p>Get updates about opportunities to sell on the Digital Marketplace.</p>
-      </div>
-    {% elif current_user.role == 'supplier' %}
-      <div class="padding-bottom-small">
-        <p>
-          <a href="/suppliers" class="top-level-link">
-            View your services and account information
-          </a>
-        </p>
       </div>
     {% endif %}
 

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -63,23 +63,6 @@ class TestHomepageBrowseList(BaseApplicationTest):
             assert link_texts[-1] == "Buy physical datacentre space for legacy systems"
             assert "Find specialists to work on digital projects" not in link_texts
 
-    @mock.patch('app.main.views.marketplace.data_api_client')
-    def test_buyer_dashboard_link_exists_when_dos_is_live_and_buyer_logged_in(self, data_api_client):
-        with self.app.app_context():
-            data_api_client.find_frameworks.return_value = {"frameworks": [
-                {"slug": "digital-outcomes-and-specialists",
-                 "status": "live"}
-            ]}
-            self.login_as_buyer()
-
-            res = self.client.get("/")
-            document = html.fromstring(res.get_data(as_text=True))
-
-            assert res.status_code == 200
-
-            link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
-            assert link_texts[-1] == "View your requirements and supplier responses"
-
 
 class TestHomepageSidebarMessage(BaseApplicationTest):
     def setup(self):
@@ -189,7 +172,6 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
         assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
         assert 'Create a supplier account' in sidebar_link_texts
-        assert 'View your services and account information' not in sidebar_link_texts
 
     @mock.patch('app.main.views.marketplace.data_api_client')
     def test_homepage_sidebar_messages_when_logged_in(self, data_api_client):
@@ -210,7 +192,6 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         sidebar_link_texts = [str(item).strip() for item in sidebar_links]
 
         assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
-        assert 'View your services and account information' in sidebar_link_texts
         assert 'Create a supplier account' not in sidebar_link_texts
 
     # here we've given an valid framework with a valid status but there is no message.yml file to read from


### PR DESCRIPTION
Links for 'View your services and account information' and 'View your requirements and supplier responses' have been removed from the index page. These links have been removed as now we provide a link to 'View your account' in the page header and do not wish to have duplicates. I have updated/removed corresponding tests for these changes.