### PR TITLE
Increase size of G-Cloud search button to fix bug

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -44,7 +44,7 @@
       height: 50px;
 
       @include media(tablet) {
-        margin-right: 8em;
+        margin-right: 8.5em;
       }
     }
 
@@ -53,10 +53,10 @@
       width: 100%;
 
       @include media(tablet) {
-        width: 8em;
+        width: 8.5em;
         position: absolute;
         top: 0;
-        right: -8em;
+        right: -8.5em;
         margin-right: $gutter-half;
       }
       padding-top: 5px;


### PR DESCRIPTION
Firefox's font rendering seems to need a bit more space. @andrewchong noticed the current styling fails at certain page zoom levels.

## Before (at 90% zoom)

![90_percent_before](https://cloud.githubusercontent.com/assets/87140/16050521/e04af9ae-3253-11e6-8f8f-b6838cb96d5f.png)

## After (at 90% zoom)

![90_percent_after](https://cloud.githubusercontent.com/assets/87140/16050565/16fb4b7a-3254-11e6-87d1-36cd77ce6e77.png)

## After (at 50% zoom)

![50_percent_before](https://cloud.githubusercontent.com/assets/87140/16050622/4b181c94-3254-11e6-971a-fe3d1e36d0a7.png)

## After (at 50% zoom)

![50_percent_after](https://cloud.githubusercontent.com/assets/87140/16050634/53f9927a-3254-11e6-901e-369a68bcfab5.png)
