### PR TITLE
Reduce effect of padding changes to footer-meta

### DIFF
--- a/app/assets/scss/_footer.scss
+++ b/app/assets/scss/_footer.scss
@@ -76,9 +76,11 @@
   }
 
   .footer-meta {
-    padding: 0 $gutter-half;
+    padding-left: $gutter-half;
+    padding-right: $gutter-half;
     @include media(tablet) {
-      padding: 0;
+      padding-left: 0;
+      padding-right: 0
     }
     /* Temporary fix:
        chrome is breaking this layout when font-size-adjust is set */


### PR DESCRIPTION
As noticed by @pcraig3 on the supplier app, recent changes have reduced the `padding-bottom` on the global footer:

![image](https://cloud.githubusercontent.com/assets/87140/16084234/eb72d588-330f-11e6-8c7a-d6ecf1328b82.png)

This fixes it:

![image](https://cloud.githubusercontent.com/assets/87140/16084218/dec3a092-330f-11e6-9339-a665d2e93b68.png)
