### PR TITLE
Upgrade toolkit and remove superfluous "home" class from header/footer links

### DIFF
--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -24,7 +24,7 @@
         <a href="https://www.gov.uk/guidance/the-g-cloud-framework-on-the-digital-marketplace">G-Cloud framework</a>
       </li>
       <li>
-          <a class="home" href="{{ url_for('main.suppliers_list_by_prefix') }}">G-Cloud supplier A–Z</a>
+          <a href="{{ url_for('main.suppliers_list_by_prefix') }}">G-Cloud supplier A–Z</a>
       </li>
       <li>
         <a href="https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace">Crown Hosting framework</a>

--- a/app/templates/_proposition_header.html
+++ b/app/templates/_proposition_header.html
@@ -6,9 +6,9 @@
       <ul id="proposition-links">
         {% if current_user.is_authenticated() %}
           <li><a href="{{ url_for('buyers.buyer_dashboard') if current_user.role == 'buyer' else '/suppliers' }}">View your account</a></li>
-          <li><a class="home" href="{{ url_for('main.logout') }}">Log out</a></li>
+          <li><a href="{{ url_for('main.logout') }}">Log out</a></li>
         {% else %}
-          <li><a class="home" href="{{ url_for('main.render_login') }}">Log in</a></li>
+          <li><a href="{{ url_for('main.render_login') }}">Log in</a></li>
         {% endif %}
       </ul>
     </nav>

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.16.3",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.17.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.5.4"
   }


### PR DESCRIPTION
Upgrading the toolkit brings in the latest govuk frontend and slightly mitigates the problem where [the pricing field layout breaks if you have a scrollbar enabled on your browser](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/266).  

Also got rid of the `home` class which was being applied to a couple of header links and a footer link.
Very well researched.  Read the commit message.

I didn't notice any layout changes applying this pull request, so it should be totally invisible to users. 