### PR TITLE
Fix supplier summary tables on mobile view

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -157,3 +157,9 @@ $path: "/static/images/";
     text-decoration: none;
   }
 }
+
+.summary-item-body {
+  a {
+    word-break: break-all;
+  }
+}

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -33,7 +33,7 @@
     ) %}
       {% call summary.row() %}
         {{ summary.field_name(item.label) }}
-        {{ summary[item.type](item.value) }}
+        {{ summary[item.type](item.value) | format_links }}
       {% endcall %}
     {% endcall %}
 {% endfor %}

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -23,11 +23,11 @@
     empty_message="No questions have been answered yet"
 ) %}
   {% call summary.row() %}
-    {% call summary.field(first=True, wide=False) -%} 
+    {% call summary.field(first=True, wide=False) -%}
       <span aria-label="question">{{ question.number }}.</span>
       {{ question.question }}
     {%- endcall %}
-    {{ summary.text(question.answer) }}
+    {{ summary.text(question.answer | format_links) }}
   {% endcall %}
 {% endcall %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.0.0#egg=digitalmarketplace-utils==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.1.0#egg=digitalmarketplace-utils==21.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0
 


### PR DESCRIPTION
Add new dm utils with format links filter.  Add css to break words for links in summary tables on supplier response pages.

Relies on:
https://github.com/alphagov/digitalmarketplace-utils/pull/267

Before:
<img width="376" alt="screen shot 2016-06-17 at 16 34 21" src="https://cloud.githubusercontent.com/assets/11633362/16155897/68a8cd74-34a9-11e6-8ed2-ffb35f7fe6c7.png">


After:
<img width="369" alt="screen shot 2016-06-17 at 16 34 10" src="https://cloud.githubusercontent.com/assets/11633362/16155902/6e20aa7e-34a9-11e6-9146-d826dcf2c94d.png">


