### PR TITLE
Fix email validation bug

### DIFF
--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -10,7 +10,7 @@ class LoginForm(Form):
         'Email address', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            Regexp("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$",
+            Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
                    flags=re.IGNORECASE,
                    message="You must provide a valid email address")
         ]
@@ -28,7 +28,7 @@ class EmailAddressForm(Form):
         'Email address', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            Regexp("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$",
+            Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
                    flags=re.IGNORECASE,
                    message="You must provide a valid email address")
         ]

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,6 +1,7 @@
+import re
 from flask_wtf import Form
 from wtforms import PasswordField
-from wtforms.validators import DataRequired, Email, EqualTo, Length, Regexp
+from wtforms.validators import DataRequired, EqualTo, Length, Regexp
 from dmutils.forms import StripWhitespaceStringField, StringField
 
 
@@ -9,7 +10,9 @@ class LoginForm(Form):
         'Email address', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            Email(message="You must provide a valid email address")
+            Regexp("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$",
+                   flags=re.IGNORECASE,
+                   message="You must provide a valid email address")
         ]
     )
     password = PasswordField(
@@ -25,7 +28,9 @@ class EmailAddressForm(Form):
         'Email address', id="input_email_address",
         validators=[
             DataRequired(message="You must provide an email address"),
-            Email(message="You must provide a valid email address")
+            Regexp("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$",
+                   flags=re.IGNORECASE,
+                   message="You must provide a valid email address")
         ]
     )
 

--- a/app/main/forms/auth_forms.py
+++ b/app/main/forms/auth_forms.py
@@ -1,4 +1,3 @@
-import re
 from flask_wtf import Form
 from wtforms import PasswordField
 from wtforms.validators import DataRequired, EqualTo, Length, Regexp
@@ -11,7 +10,6 @@ class LoginForm(Form):
         validators=[
             DataRequired(message="You must provide an email address"),
             Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
-                   flags=re.IGNORECASE,
                    message="You must provide a valid email address")
         ]
     )
@@ -29,7 +27,6 @@ class EmailAddressForm(Form):
         validators=[
             DataRequired(message="You must provide an email address"),
             Regexp("^[^@^\s]+@[^@^\.^\s]+(\.[^@^\.^\s]+)+$",
-                   flags=re.IGNORECASE,
                    message="You must provide a valid email address")
         ]
     )

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -534,6 +534,17 @@ class TestBuyersCreation(BaseApplicationTest):
         assert 'Create a buyer account' in data
         assert 'You must provide a valid email address' in data
 
+    def test_should_raise_validation_error_for_email_address_with_two_at_symbols(self):
+        res = self.client.post(
+            '/buyers/create',
+            data={'email_address': 'not-an@email@gov.uk'},
+            follow_redirects=True
+        )
+        assert res.status_code == 400
+        data = res.get_data(as_text=True)
+        assert 'Create a buyer account' in data
+        assert 'You must provide a valid email address' in data
+
     def test_should_raise_validation_error_for_empty_email_address(self):
         res = self.client.post(
             '/buyers/create',


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/121730503) bug on Pivotal.

The WTForms inbuilt validator for Emails uses a very loose Regex (`'^.+@[^.].*\.[a-z]{2,10}$'`) which would allow an email address with two `@`'s to be used. This meant an invalid email could be passed down to the API which would throw a value error and pass it back up to the front end.

This PR changes the validation of email addresses from WTForms Email validation to a Regex validation which is a lot tighter and solves this issue, and probably many more undiscovered issues.

Another PR will be made on the API to catch the invalid format properly there.

![double 2](https://cloud.githubusercontent.com/assets/13836290/16192414/10d77b60-36e1-11e6-8f84-a579894e30e1.gif)
