### PR TITLE
[#121961157] Re-add format_links filter now that it has been fixed

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -158,6 +158,10 @@ $path: "/static/images/";
   }
 }
 
+.break-link {
+  word-break: break-all;
+}
+
 .summary-item-body {
   a {
     word-break: break-all;

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -33,7 +33,7 @@
     ) %}
       {% call summary.row() %}
         {{ summary.field_name(item.label) }}
-        {{ summary[item.type](item.value) }}
+        {{ summary[item.type](item.value) | format_links}}
       {% endcall %}
     {% endcall %}
 {% endfor %}

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -27,7 +27,7 @@
       <span aria-label="question">{{ question.number }}.</span>
       {{ question.question }}
     {%- endcall %}
-    {{ summary.text(question.answer) }}
+    {{ summary.text(question.answer | format_links) }}
   {% endcall %}
 {% endcall %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.1.0#egg=digitalmarketplace-utils==21.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.1.1#egg=digitalmarketplace-utils==21.1.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0
 


### PR DESCRIPTION
Work done with @carolinegreen 

Fixes this bug: https://www.pivotaltracker.com/story/show/121961157

Pulls in latest utils with fixed filter, and re-adds the filter to templates where it should be added.