### PR TITLE
Update toolkit to 16.0.0

### DIFF
--- a/app/assets/scss/_brief_submission.scss
+++ b/app/assets/scss/_brief_submission.scss
@@ -1,3 +1,20 @@
+.instruction-list-item {
+
+  h2 {
+    @include bold-27;
+    margin-bottom: 10px;
+  }
+
+  .instruction-list-item-top {
+    @include core-19;
+    display: block;
+  }
+
+  a {
+    text-decoration: none;
+  }
+}
+
 .last-edited {
     margin: 10px 0 15px 0;
 }
@@ -29,8 +46,8 @@
   }
 }
 
-ul.instruction-list-item-extra-information li,
-ol.instruction-list-item-extra-information li {
+ul.instruction-list-item-top li,
+ol.instruction-list-item-top li {
   margin-bottom: 0;
 }
 
@@ -38,7 +55,7 @@ ol.steps {
   list-style: none;
   padding-left: 0;
 
-  .instruction-list-item-extra-information {
+  .instruction-list-item-top {
     margin-left: (30 / 19) * 1em; // 25px in ems
   }
 

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -141,23 +141,6 @@ $path: "/static/images/";
   }
 }
 
-.instruction-list-item {
-
-  h2 {
-    @include bold-27;
-    margin-bottom: 10px;
-  }
-
-  .instruction-list-item-extra-information {
-    @include core-19;
-    display: block;
-  }
-
-  a {
-    text-decoration: none;
-  }
-}
-
 .break-link {
   display: inline-block;
   word-break: break-all;

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -172,11 +172,11 @@
               <span class="step-number" role="presentation">{{ step_number }}. </span>
               {{ step.title }}</h2>
             {% if step.description %}
-              <p class="instruction-list-item-extra-information">{{ step.description[brief.status] }}</p>
+              <p class="instruction-list-item-top">{{ step.description[brief.status] }}</p>
             {% endif %}
             {% if step_number in step_sections and brief.status == 'draft' %}
 
-                <ul class="instruction-list-item-extra-information">
+                <ul class="instruction-list-item-top">
                   {% for section in sections %}
                     {% if section.step == step_number %}
                     <li>
@@ -192,7 +192,7 @@
                 </ul>
             {% endif %}
             {% if step.links %}
-              <ul class="instruction-list-item-extra-information">
+              <ul class="instruction-list-item-top">
                 {% for link in step.links %}
                   {% if not link.allowed_statuses or brief.status in link.allowed_statuses %}
                     <li>

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v15.17.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v16.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.5.5"
   }


### PR DESCRIPTION
**Note: needs https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/269 to be merged first.**

Changes a class name to match the new one in the updated `instruction-list` pattern, used on the brief overview page. No other breaking changes.