### PR TITLE
Don't format links

### DIFF
--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -33,7 +33,7 @@
     ) %}
       {% call summary.row() %}
         {{ summary.field_name(item.label) }}
-        {{ summary[item.type](item.value) | format_links}}
+        {{ summary[item.type](item.value)}}
       {% endcall %}
     {% endcall %}
 {% endfor %}

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -27,7 +27,7 @@
       <span aria-label="question">{{ question.number }}.</span>
       {{ question.question }}
     {%- endcall %}
-    {{ summary.text(question.answer | format_links) }}
+    {{ summary.text(question.answer) }}
   {% endcall %}
 {% endcall %}
 


### PR DESCRIPTION
The `format_links` filter hangs indefinitely for some text strings.  Disabling it until it's fixed.