### PR TITLE
Fix break words

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -159,11 +159,13 @@ $path: "/static/images/";
 }
 
 .break-link {
+  display: inline-block;
   word-break: break-all;
 }
 
 .summary-item-body {
   a {
+    display: inline-block;
     word-break: break-all;
   }
 }


### PR DESCRIPTION
Fix break words in firefox.  Break-all only works in table cells in firefox if it is displayed as an inline block.