### PR TITLE
[#122036279] create_your_account_complete: don't unnecessarily clear session, simplify handling of email_sent_to

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -324,12 +324,7 @@ def submit_create_user(encoded_token):
 
 @main.route('/create-your-account-complete', methods=['GET'])
 def create_your_account_complete():
-    if 'email_sent_to' in session:
-        email_address = session['email_sent_to']
-    else:
-        email_address = "the email address you supplied"
-    session.clear()
-    session['email_sent_to'] = email_address
+    email_address = session.setdefault("email_sent_to", "the email address you supplied")
     return render_template(
         "auth/create-your-account-complete.html",
         email_address=email_address), 200


### PR DESCRIPTION
clearing the session had the inadvertent effect of resetting the user's csrf token, causing a users
cached forms (accessed through the back button) to no longer be accepted due to a "csrf error". confusing for users attempting to create multiple buyer accounts. this would appear to be a copypasta error resulting from the original code being copied from the supplier app which _does_ require an amount of session-clearing.

Story https://www.pivotaltracker.com/story/show/122036279

This is something that it might be nice to have a functional (regression) test for... (though this is reportedly a firefox-only issue and our functional tests only use webkit AFAIK)