### PR TITLE
Fix responses CSV for briefs with an empty list in nice to have requirements

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -295,7 +295,7 @@ def download_brief_responses(framework_slug, lot_slug, brief_id):
     # Build header row from manifest and add it to the list of rows
     for question in section.questions:
         question_key_sequence.append(question.id)
-        if question['type'] == 'boolean_list' and question.id in brief:
+        if question['type'] == 'boolean_list' and brief.get(question.id):
             column_headings.extend(brief[question.id])
             boolean_list_questions.append(question.id)
         else:

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1701,77 +1701,79 @@ class TestViewBriefResponsesPage(BaseApplicationTest):
 
 @mock.patch("app.buyers.views.buyers.data_api_client")
 class TestDownloadBriefResponsesCsv(BaseApplicationTest):
-    url = "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/responses" \
-          "/download"
-    brief = api_stubs.brief(status='closed')
-    brief['briefs']['essentialRequirements'] = ["E1", "E2"]
-    brief['briefs']['niceToHaveRequirements'] = ["Nice1", "Nice2", "Nice3"]
+    url = "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/responses/download"
 
-    brief_responses = {
-        "briefResponses": [
-            {
-                "supplierName": "Kev's Butties",
-                "availability": "Next Tuesday",
-                "dayRate": "£1.49",
-                "essentialRequirements": [True, True],
-                "niceToHaveRequirements": [True, False, False],
-                "respondToEmailAddress": "test1@email.com",
-            },
-            {
-                "supplierName": "Kev's Pies",
-                "availability": "A week Friday",
-                "dayRate": "£3.50",
-                "essentialRequirements": [True, True],
-                "niceToHaveRequirements": [False, True, True],
-                "respondToEmailAddress": "test2@email.com",
-            },
-            {
-                "supplierName": "Kev's Doughnuts",
-                "availability": "As soon as the sugar is delivered",
-                "dayRate": "£10 a dozen",
-                "essentialRequirements": [True, False],
-                "niceToHaveRequirements": [True, True, False],
-                "respondToEmailAddress": "test3@email.com",
-            },
-            {
-                "supplierName": "Kev's Fried Noodles",
-                "availability": "After Christmas",
-                "dayRate": "£12.35",
-                "essentialRequirements": [False, True],
-                "niceToHaveRequirements": [True, True, True],
-                "respondToEmailAddress": "test4@email.com",
-            },
-            {
-                "supplierName": "Kev's Pizza",
-                "availability": "Within the hour",
-                "dayRate": "£350",
-                "essentialRequirements": [False, False],
-                "niceToHaveRequirements": [False, False, False],
-                "respondToEmailAddress": "test5@email.com",
-            },
-        ]
-    }
+    def setup(self):
+        super(TestDownloadBriefResponsesCsv, self).setup()
+        self.brief = api_stubs.brief(status='closed')
+        self.brief['briefs']['essentialRequirements'] = ["E1", "E2"]
+        self.brief['briefs']['niceToHaveRequirements'] = ["Nice1", "Nice2", "Nice3"]
 
-    tricky_character_responses = {
-        "briefResponses": [
-            {
-                "supplierName": "K,ev’s \"Bu,tties",
-                "availability": "❝Next — Tuesday❞",
-                "dayRate": "¥1.49,",
-                "essentialRequirements": [True, True],
-                "niceToHaveRequirements": [True, False, False],
-                "respondToEmailAddress": "test1@email.com",
-            },
-            {
-                "supplierName": "Kev\'s \'Pies",
-                "availability": "&quot;A week Friday&rdquot;",
-                "dayRate": "&euro;3.50",
-                "essentialRequirements": [True, True],
-                "niceToHaveRequirements": [False, True, True],
-                "respondToEmailAddress": "te,st2@email.com",
-            },
-        ]
-    }
+        self.brief_responses = {
+            "briefResponses": [
+                {
+                    "supplierName": "Kev's Butties",
+                    "availability": "Next Tuesday",
+                    "dayRate": "£1.49",
+                    "essentialRequirements": [True, True],
+                    "niceToHaveRequirements": [True, False, False],
+                    "respondToEmailAddress": "test1@email.com",
+                },
+                {
+                    "supplierName": "Kev's Pies",
+                    "availability": "A week Friday",
+                    "dayRate": "£3.50",
+                    "essentialRequirements": [True, True],
+                    "niceToHaveRequirements": [False, True, True],
+                    "respondToEmailAddress": "test2@email.com",
+                },
+                {
+                    "supplierName": "Kev's Doughnuts",
+                    "availability": "As soon as the sugar is delivered",
+                    "dayRate": "£10 a dozen",
+                    "essentialRequirements": [True, False],
+                    "niceToHaveRequirements": [True, True, False],
+                    "respondToEmailAddress": "test3@email.com",
+                },
+                {
+                    "supplierName": "Kev's Fried Noodles",
+                    "availability": "After Christmas",
+                    "dayRate": "£12.35",
+                    "essentialRequirements": [False, True],
+                    "niceToHaveRequirements": [True, True, True],
+                    "respondToEmailAddress": "test4@email.com",
+                },
+                {
+                    "supplierName": "Kev's Pizza",
+                    "availability": "Within the hour",
+                    "dayRate": "£350",
+                    "essentialRequirements": [False, False],
+                    "niceToHaveRequirements": [False, False, False],
+                    "respondToEmailAddress": "test5@email.com",
+                },
+            ]
+        }
+
+        self.tricky_character_responses = {
+            "briefResponses": [
+                {
+                    "supplierName": "K,ev’s \"Bu,tties",
+                    "availability": "❝Next — Tuesday❞",
+                    "dayRate": "¥1.49,",
+                    "essentialRequirements": [True, True],
+                    "niceToHaveRequirements": [True, False, False],
+                    "respondToEmailAddress": "test1@email.com",
+                },
+                {
+                    "supplierName": "Kev\'s \'Pies",
+                    "availability": "&quot;A week Friday&rdquot;",
+                    "dayRate": "&euro;3.50",
+                    "essentialRequirements": [True, True],
+                    "niceToHaveRequirements": [False, True, True],
+                    "respondToEmailAddress": "te,st2@email.com",
+                },
+            ]
+        }
 
     def test_csv_includes_all_eligible_responses_and_no_ineligible_responses(self, data_api_client):
         data_api_client.find_brief_responses.return_value = self.brief_responses
@@ -1796,6 +1798,31 @@ class TestDownloadBriefResponsesCsv(BaseApplicationTest):
         assert lines[1] == "Kev's Pies,A week Friday,£3.50,False,True,True,test2@email.com"
         assert lines[2] == "Kev's Butties,Next Tuesday,£1.49,True,False,False,test1@email.com"
         assert lines[-1] == ""
+
+    def test_download_brief_responses_for_brief_without_nice_to_haves(self, data_api_client):
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True),
+            ]
+        )
+
+        for response in self.brief_responses['briefResponses']:
+            del response["niceToHaveRequirements"]
+        data_api_client.find_brief_responses.return_value = self.brief_responses
+
+        data_api_client.get_brief.return_value = self.brief
+
+        self.login_as_buyer()
+
+        del self.brief['briefs']['niceToHaveRequirements']
+        res = self.client.get(self.url)
+        assert res.status_code, 200
+
+        self.brief['briefs']['niceToHaveRequirements'] = []
+        res = self.client.get(self.url)
+        assert res.status_code, 200
 
     def test_csv_handles_tricky_characters(self, data_api_client):
         data_api_client.find_brief_responses.return_value = self.tricky_character_responses


### PR DESCRIPTION
It looks like at the moment our logic for removing empty items saves `[]` to optional list questions when the user submits an empty page, which breaks the CSV download, since the `niceToHaveRequirements` key is present in the brief data but not in any of the responses (since the forms aren't rendered).

What happens with the brief data right now:

1. User clicks "Save" without entering any of the nice to have requirements
2. Buyer frontend recieves form data with two `""` form fields
3. Buyer frontend submits `{"niceToHaveRequirements": ["", ""]}` to the API
4. API runs `utils.strip_whitespace_from_data` and drops empty strings from `niceToHaveRequirements`, replacing `["", ""]` with `[]`
5. `{"niceToHaveRequirements": []}` is stored to the database

I'm not sure if that's a result of a recent change in content loader or if it's caused by users submitting nice-to-have requirements when they submit essentials since they're now on one page.

It feels like we don't want a key to exist when there are no values, but that requires some more digging and we'd need to run a migration to update existing brief, so for now I'm fixing the broken behaviour in the buyer frontend to support both missing key an an empty list.