### PR TITLE
[#124752631]fix "edit" links being line-broken

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -145,10 +145,3 @@ $path: "/static/images/";
   display: inline-block;
   word-break: break-all;
 }
-
-.summary-item-body {
-  a {
-    display: inline-block;
-    word-break: break-all;
-  }
-}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.2.2#egg=digitalmarketplace-utils==21.2.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.2.3#egg=digitalmarketplace-utils==21.2.3
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0
 


### PR DESCRIPTION
Bump `-utils` dependency and remove our blanket-applied style.

Don't expect tests to pass till https://github.com/alphagov/digitalmarketplace-utils/pull/273 gets merged.

(story https://www.pivotaltracker.com/story/show/124752631)