### PR TITLE
Specialist briefs can be open for 1 or two weeks

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -51,6 +51,7 @@ $path: "/static/images/";
 
 @import "toolkit/forms/_hint.scss";
 @import "toolkit/forms/_questions.scss";
+@import "toolkit/shared_scss/_dmspeak.scss";
 
 // Buyers app styles
 @import "_brief_submission.scss";

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -10,11 +10,12 @@ from .. import buyers, content_loader
 from ...helpers.buyers_helpers import (
     all_essentials_are_true, counts_for_failed_and_eligible_brief_responses,
     get_framework_and_lot, get_sorted_responses_for_brief, count_unanswered_questions,
-    brief_can_be_edited, add_unanswered_counts_to_briefs, is_brief_correct, get_publishing_dates,
+    brief_can_be_edited, add_unanswered_counts_to_briefs, is_brief_correct,
     section_has_at_least_one_required_question
 )
 
 from dmapiclient import HTTPError
+from dmutils.dates import get_publishing_dates
 
 
 @buyers.route('/buyers')
@@ -362,6 +363,11 @@ def publish_brief(framework_slug, lot_slug, brief_id):
             question_and_answers['slug'] = section['id']
 
     unanswered_required, unanswered_optional = count_unanswered_questions(sections)
+
+    if sections.get_section('set-how-long-your-requirements-will-be-live-for') and \
+            sections.get_section('set-how-long-your-requirements-will-be-live-for').questions[0].answer_required:
+            unanswered_required -= 1
+
     if request.method == 'POST':
         if unanswered_required > 0:
             abort(400, 'There are still unanswered required questions')
@@ -372,7 +378,7 @@ def publish_brief(framework_slug, lot_slug, brief_id):
                     brief_id=brief['id'], published='true'))
     else:
         email_address = brief_users['emailAddress']
-        dates = get_publishing_dates()
+        dates = get_publishing_dates(brief)
 
         return render_template(
             "buyers/brief_publish_confirmation.html",
@@ -389,7 +395,6 @@ def publish_brief(framework_slug, lot_slug, brief_id):
 def view_brief_timeline(framework_slug, lot_slug, brief_id):
     get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
-
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or brief.get('status') != 'live':
         abort(404)
 

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -373,7 +373,6 @@ def publish_brief(framework_slug, lot_slug, brief_id):
             url_for('.view_brief_overview', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'],
                     brief_id=brief['id'], published='true'))
     else:
-
         #  requirements length is a required question but is handled separately to other
         #  required questions on the publish page if it's unanswered.
         if sections.get_section('set-how-long-your-requirements-will-be-live-for') and \

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -364,10 +364,6 @@ def publish_brief(framework_slug, lot_slug, brief_id):
 
     unanswered_required, unanswered_optional = count_unanswered_questions(sections)
 
-    if sections.get_section('set-how-long-your-requirements-will-be-live-for') and \
-            sections.get_section('set-how-long-your-requirements-will-be-live-for').questions[0].answer_required:
-            unanswered_required -= 1
-
     if request.method == 'POST':
         if unanswered_required > 0:
             abort(400, 'There are still unanswered required questions')
@@ -377,6 +373,13 @@ def publish_brief(framework_slug, lot_slug, brief_id):
             url_for('.view_brief_overview', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'],
                     brief_id=brief['id'], published='true'))
     else:
+
+        #  requirements length is a required question but is handled separately to other
+        #  required questions on the publish page if it's unanswered.
+        if sections.get_section('set-how-long-your-requirements-will-be-live-for') and \
+                sections.get_section('set-how-long-your-requirements-will-be-live-for').questions[0].answer_required:
+                unanswered_required -= 1
+
         email_address = brief_users['emailAddress']
         dates = get_publishing_dates(brief)
 

--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -88,23 +88,3 @@ def get_sorted_responses_for_brief(brief, data_api_client):
         )
     else:
         return brief_responses
-
-
-def get_publishing_dates(brief=None):
-    application_open_days = 14
-    questions_open_days = application_open_days - 7
-    answers_open_days = application_open_days - 1
-
-    dates = {}
-    if brief is not None and brief.get('publishedAt'):
-        dates['questions_close'] = brief['clarificationQuestionsClosedAt']
-        dates['answers_close'] = brief['clarificationQuestionsPublishedBy']
-        dates['closing_date'] = brief['applicationsClosedAt']
-    else:
-        dates['today'] = datetime.utcnow().replace(hour=23, minute=59, second=59, microsecond=0)
-        dates['questions_close'] = dates['today'] + timedelta(days=questions_open_days)
-        dates['answers_close'] = dates['today'] + timedelta(days=answers_open_days)
-        dates['closing_date'] = dates['today'] + timedelta(days=application_open_days)
-        dates['application_open_weeks'] = application_open_days//7
-        dates['closing_time'] = '{d:%I:%M %p}'.format(d=dates['closing_date']).lower()
-    return dates

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -96,8 +96,8 @@ def list_opportunities(framework_slug):
     if not framework:
         abort(404, "No framework {}".format(framework_slug))
 
-    api_result = data_api_client.find_briefs(status='live,closed', framework=framework_slug, page=page)
-
+    api_result = data_api_client.find_briefs(status='live,closed', framework=framework_slug,
+                                             page=page, human=True)
     briefs = api_result["briefs"]
     links = api_result["links"]
 

--- a/app/templates/_briefs_list.html
+++ b/app/templates/_briefs_list.html
@@ -3,7 +3,7 @@
     <h2 class="search-result-title">
         <a href="{{ url_for('.get_brief_by_id', framework_slug=framework.slug, brief_id=brief.id) }}">{{ brief.title }}</a>
     </h2>
-    
+
     <ul class="search-result-important-metadata">
         <li class="search-result-metadata-item">
             {{ brief.organisation }}
@@ -12,18 +12,26 @@
             {{ brief.location }}
         </li>
     </ul>
-    
+
     <ul class="search-result-metadata">
         <li class="search-result-metadata-item">
             {{ brief.lotName }}
         </li>
-        <li class="search-result-metadata-item">
-            {% if brief.status == 'closed' %}
+    </ul>
+
+    <ul class="search-result-metadata">
+        {% if brief.status == 'closed' %}
+            <li class="search-result-metadata-item">
                 Closed
-            {% else %}
+            </li>
+        {% else %}
+            <li class="search-result-metadata-item">
+                Published: {{ brief.publishedAt|dateformat }}
+            </li>
+            <li class="search-result-metadata-item">
                 Closing: {{ brief.applicationsClosedAt|dateformat }}
-            {% endif %}
-        </li>
+            </li>
+        {% endif %}
     </ul>
     
     <p class="search-result-excerpt">

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -45,7 +45,7 @@
             <p>This will show you what the supplier application deadline will be if you publish your requirements today.</p>
           </div>
         {% else %}
-          <p>Your requirements will be open for {{ dates.application_open_weeks }} {{ pluralize(dates.application_open_weeks, "week", "weeks") }}.</p>
+          <p>Your requirements will be open for {{ dates.application_open_weeks }}.</p>
           <div class="dmspeak">
             <p>If you publish your requirements today ({{ dates.published_date | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date | shortdateformat}}.</p>
           </div>

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -34,20 +34,40 @@
     %}
         {% include "toolkit/page-heading.html" %}
     {% endwith %}
+
     {% if not published %}
-      <p class="padding-bottom-small">All requirements are published on the Digital Marketplace where anyone can see them.</p>
-      <p class="padding-bottom-small">All requirements are open for {{ dates.application_open_weeks }} weeks.</p>
-      <p class="padding-bottom-small">If you publish your requirements today ({{ dates.today | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date | shortdateformat}}.</p>
+      <div class="dmspeak">
+        <p>All requirements are published on the Digital Marketplace where anyone can see them.</p>
+      </div>
+        {% if brief.lotSlug == 'digital-specialists' and not brief.requirementsLength %}
+          <p><strong>You must set how long your requirements will be open for.</strong></p>
+          <p>You must set how long your requirements will be open for so you can see the dates you need to be aware of if you publish today.</p>
+          <div class="dmspeak">
+            <p><a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-live-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
+          </div>
+        {% else %}
+          <p>Your requirements will be open for {{ dates.application_open_weeks }} {{ pluralize(dates.application_open_weeks, "week", "weeks") }}.</p>
+          <div class="dmspeak">
+            <p>If you publish your requirements today ({{ dates.today | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date | shortdateformat}}.</p>
+          </div>
+        {% endif %}
     {% endif %}
+
     <p><strong>Supplier questions will be sent to:</strong></p>
-    <p class="padding-bottom-small">{{ email_address }}</p>
-    <p class="padding-bottom-small">Ensure this email address {% if not published %}will be{% else %}is{% endif %} monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
+    <div class="dmspeak">
+      <p>{{ email_address }}</p>
+    </div>
+    <div class="dmspeak">
+      <p>Ensure this email address {% if not published %}will be{% else %}is{% endif %} monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
+    </div>
 
     {% if not published and unanswered_required > 0 %}
-      <p class="padding-bottom-small"><strong>You still need to complete the following questions before your requirements can be published:</strong></p>
+      <div class="dmspeak">
+        <p><strong>You still need to complete the following questions before your requirements can be published:</strong></p>
+      </div>
       {% for section in sections %}
         {% for question in section.questions %}
-          {% if question.answer_required %}
+          {% if question.answer_required and not question.id == 'requirementsLength' %}
             <ol>
               <li>
                 <a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
@@ -56,7 +76,7 @@
           {% endif %}
         {% endfor %}
       {% endfor %}
-    {% else %}
+    {% elif not brief.lotSlug == 'digital-specialists' or brief.requirementsLength %}
       {% import "toolkit/summary-table.html" as summary %}
         {% call summary.mapping_table(
         row_bold_borders=True,
@@ -94,11 +114,8 @@
           {{ summary.text("The last day suppliers can ask questions.") }}
         {% endcall %}
         {% call summary.row(bold_border=True) %}
-          {{ summary.field_heading_date(dates.answers_close | shortdateformat, rowspan='2', scope='row') }}
+          {{ summary.field_heading_date(dates.answers_close | shortdateformat, scope='row') }}
           {{ summary.text("You must have published answers to all suppliers’ questions.") }}
-        {% endcall %}
-        {% call summary.row(no_border=True) %}
-          {{ summary.text("If {} is a Saturday or Sunday, publish all questions and answers by the Friday before.".format(dates.answers_close | shortdateformat), border=True) }}
         {% endcall %}
         {% call summary.row(bold_border=True) %}
           {{ summary.field_heading_date(dates.closing_date | shortdateformat, scope='row') }}

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -40,10 +40,9 @@
         <p>All requirements are published on the Digital Marketplace where anyone can see them.</p>
       </div>
         {% if brief.lotSlug == 'digital-specialists' and not brief.requirementsLength %}
-          <p><strong>You must set how long your requirements will be open for.</strong></p>
-          <p>You must set how long your requirements will be open for so you can see the dates you need to be aware of if you publish today.</p>
+          <p><a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-live-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
           <div class="dmspeak">
-            <p><a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-live-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
+            <p>This will show you what the supplier application deadline will be if you publish your requirements today.</p>
           </div>
         {% else %}
           <p>Your requirements will be open for {{ dates.application_open_weeks }} {{ pluralize(dates.application_open_weeks, "week", "weeks") }}.</p>
@@ -53,12 +52,12 @@
         {% endif %}
     {% endif %}
 
-    <p><strong>Supplier questions will be sent to:</strong></p>
+    <p>Supplier questions will be sent to:</p>
     <div class="dmspeak">
       <p>{{ email_address }}</p>
     </div>
     <div class="dmspeak">
-      <p>Ensure this email address {% if not published %}will be{% else %}is{% endif %} monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
+      <p>Make sure this email address {% if not published %}will be{% else %}is{% endif %} monitored. If you’re away while suppliers can still ask questions, you should make sure your emails are forwarded to a colleague.</p>
     </div>
 
     {% if not published and unanswered_required > 0 %}

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -47,7 +47,7 @@
         {% else %}
           <p>Your requirements will be open for {{ dates.application_open_weeks }} {{ pluralize(dates.application_open_weeks, "week", "weeks") }}.</p>
           <div class="dmspeak">
-            <p>If you publish your requirements today ({{ dates.today | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date | shortdateformat}}.</p>
+            <p>If you publish your requirements today ({{ dates.published_date | shortdateformat }}), suppliers will be able to apply until {{ dates.closing_time }}, {{ dates.closing_date | shortdateformat}}.</p>
           </div>
         {% endif %}
     {% endif %}

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -75,7 +75,7 @@
           {% endif %}
         {% endfor %}
       {% endfor %}
-    {% elif not brief.lotSlug == 'digital-specialists' or brief.requirementsLength %}
+    {% elif brief.lotSlug != 'digital-specialists' or brief.requirementsLength %}
       {% import "toolkit/summary-table.html" as summary %}
         {% call summary.mapping_table(
         row_bold_borders=True,

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v16.0.0",
+    "digitalmarketplace-frontend-toolkit": "git://github.com/alphagov/digitalmarketplace-frontend-toolkit#v17.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v1.5.5"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v2.1.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ unicodecsv==0.14.1
 werkzeug==0.10.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.2.0#egg=digitalmarketplace-apiclient==5.2.0
 
 # For Cloud Foundry

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.2.3#egg=digitalmarketplace-utils==21.2.3
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.1.0#egg=digitalmarketplace-content-loader==1.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@3.7.0#egg=digitalmarketplace-apiclient==3.7.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.2.0#egg=digitalmarketplace-apiclient==5.2.0
 
 # For Cloud Foundry
 cffi==1.5.2

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1041,7 +1041,7 @@ class TestPublishBrief(BaseApplicationTest):
         page_html = res.get_data(as_text=True)
 
         assert res.status_code == 200
-        assert 'You must set how long your requirements will be open for ' not in page_html
+        assert 'This will show you what the supplier application deadline will be' not in page_html
         assert 'Your requirements will be open for 2 weeks' in page_html
 
     def test_correct_content_is_displayed_if_no_requirementLength_is_set(self, data_api_client):
@@ -1061,7 +1061,7 @@ class TestPublishBrief(BaseApplicationTest):
         page_html = res.get_data(as_text=True)
 
         assert res.status_code == 200
-        assert 'You must set how long your requirements will be open for' in page_html
+        assert 'This will show you what the supplier application deadline will be' in page_html
         assert 'Your requirements will be open for' not in page_html
 
     def test_correct_content_is_displayed_if_requirementLength_is_1_week(self, data_api_client):
@@ -1087,7 +1087,7 @@ class TestPublishBrief(BaseApplicationTest):
 
         assert res.status_code == 200
         assert 'Your requirements will be open for 1 week.' in page_html
-        assert 'You must set how long your requirements will be open for ' not in page_html
+        assert 'This will show you what the supplier application deadline will be' not in page_html
         assert 'Your requirements will be open for 2 weeks' not in page_html
 
     def test_correct_content_is_displayed_if_requirementLength_is_2_weeks(self, data_api_client):
@@ -1113,7 +1113,7 @@ class TestPublishBrief(BaseApplicationTest):
 
         assert res.status_code == 200
         assert 'Your requirements will be open for 2 weeks.' in page_html
-        assert 'You must set how long your requirements will be open for ' not in page_html
+        assert 'This will show you what the supplier application deadline will be' not in page_html
         assert 'Your requirements will be open for 1 week' not in page_html
 
     def test_correct_content_is_displayed_if_requirementLength_is_not_set(self, data_api_client):
@@ -1140,7 +1140,7 @@ class TestPublishBrief(BaseApplicationTest):
 
         assert res.status_code == 200
         assert 'Your requirements will be open for 2 weeks.' not in page_html
-        assert 'You must set how long your requirements will be open for ' in page_html
+        assert 'This will show you what the supplier application deadline will be' in page_html
         assert 'Your requirements will be open for 1 week' not in page_html
         assert not document.xpath('//a[contains(text(), "Set how long your requirements will be live for")]')
 

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -909,6 +909,7 @@ class TestPublishBrief(BaseApplicationTest):
             'technicalWeighting': 10,
             'workingArrangements': 'arrangements',
             'workplaceAddress': 'address',
+            'requirementsLength': '1 week'
         })
         data_api_client.get_brief.return_value = brief_json
 
@@ -966,7 +967,6 @@ class TestPublishBrief(BaseApplicationTest):
                 api_stubs.lot(slug='digital-specialists', allows_brief=True)
             ]
         )
-
         brief_json = api_stubs.brief(status="draft")
         brief_questions = brief_json['briefs']
         brief_questions.update({
@@ -989,6 +989,7 @@ class TestPublishBrief(BaseApplicationTest):
             'technicalWeighting': 10,
             'workingArrangements': 'arrangements',
             'workplaceAddress': 'address',
+            'requirementsLength': '1 week'
         })
         data_api_client.get_brief.return_value = brief_json
 
@@ -1009,7 +1010,12 @@ class TestPublishBrief(BaseApplicationTest):
             ]
         )
 
-        data_api_client.get_brief.return_value = api_stubs.brief(status="draft")
+        brief_json = api_stubs.brief(status="draft")
+        brief_questions = brief_json['briefs']
+        brief_questions.update({
+            'requirementsLength': '1 week'
+        })
+        data_api_client.get_brief.return_value = brief_json
 
         res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
                               "digital-specialists/1234/publish")
@@ -1017,6 +1023,126 @@ class TestPublishBrief(BaseApplicationTest):
 
         assert res.status_code == 200
         assert 'Publish requirements' not in page_html
+
+    def test_warning_about_setting_requirement_length_is_not_displayed_if_not_specialist_brief(self, data_api_client):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-outcomes', allows_brief=True)
+            ]
+        )
+
+        data_api_client.get_brief.return_value = api_stubs.brief(status="draft", lot_slug="digital-outcomes")
+
+        res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                              "digital-outcomes/1234/publish")
+        page_html = res.get_data(as_text=True)
+
+        assert res.status_code == 200
+        assert 'You must set how long your requirements will be open for ' not in page_html
+        assert 'Your requirements will be open for 2 weeks' in page_html
+
+    def test_correct_content_is_displayed_if_no_requirementLength_is_set(self, data_api_client):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
+
+        data_api_client.get_brief.return_value = api_stubs.brief(status="draft")
+
+        res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                              "digital-specialists/1234/publish")
+        page_html = res.get_data(as_text=True)
+
+        assert res.status_code == 200
+        assert 'You must set how long your requirements will be open for' in page_html
+        assert 'Your requirements will be open for' not in page_html
+
+    def test_correct_content_is_displayed_if_requirementLength_is_1_week(self, data_api_client):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
+
+        brief_json = api_stubs.brief(status="draft")
+        brief_questions = brief_json['briefs']
+        brief_questions.update({
+            'requirementsLength': '1 week'
+        })
+        data_api_client.get_brief.return_value = brief_json
+
+        res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                              "digital-specialists/1234/publish")
+        page_html = res.get_data(as_text=True)
+
+        assert res.status_code == 200
+        assert 'Your requirements will be open for 1 week.' in page_html
+        assert 'You must set how long your requirements will be open for ' not in page_html
+        assert 'Your requirements will be open for 2 weeks' not in page_html
+
+    def test_correct_content_is_displayed_if_requirementLength_is_2_weeks(self, data_api_client):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
+
+        brief_json = api_stubs.brief(status="draft")
+        brief_questions = brief_json['briefs']
+        brief_questions.update({
+            'requirementsLength': '2 weeks'
+        })
+        data_api_client.get_brief.return_value = brief_json
+
+        res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                              "digital-specialists/1234/publish")
+        page_html = res.get_data(as_text=True)
+
+        assert res.status_code == 200
+        assert 'Your requirements will be open for 2 weeks.' in page_html
+        assert 'You must set how long your requirements will be open for ' not in page_html
+        assert 'Your requirements will be open for 1 week' not in page_html
+
+    def test_correct_content_is_displayed_if_requirementLength_is_not_set(self, data_api_client):
+        self.login_as_buyer()
+        data_api_client.get_framework.return_value = api_stubs.framework(
+            slug='digital-outcomes-and-specialists',
+            status='live',
+            lots=[
+                api_stubs.lot(slug='digital-specialists', allows_brief=True)
+            ]
+        )
+
+        brief_json = api_stubs.brief(status="draft")
+        brief_questions = brief_json['briefs']
+        brief_questions.update({
+            'requirementsLength': ''
+        })
+        data_api_client.get_brief.return_value = brief_json
+
+        res = self.client.get("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                              "digital-specialists/1234/publish")
+        page_html = res.get_data(as_text=True)
+        document = html.fromstring(page_html)
+
+        assert res.status_code == 200
+        assert 'Your requirements will be open for 2 weeks.' not in page_html
+        assert 'You must set how long your requirements will be open for ' in page_html
+        assert 'Your requirements will be open for 1 week' not in page_html
+        assert not document.xpath('//a[contains(text(), "Set how long your requirements will be live for")]')
 
 
 @mock.patch('app.buyers.views.buyers.data_api_client')
@@ -1126,6 +1252,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
                 'Location',
                 'Description of work',
                 'Shortlist and evaluation process',
+                'Set how long your requirements will be live for',
                 'Describe question and answer session',
                 'Review and publish your requirements',
                 'How to answer supplier questions',
@@ -1892,10 +2019,11 @@ class TestViewQuestionAndAnswerDates(BaseApplicationTest):
                 ]
             )
             brief_json = api_stubs.brief(status="live")
-            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-            brief_json['briefs']['clarificationQuestionsClosedAt'] = "2016-04-12T23:59:00.00000Z"
-            brief_json['briefs']['clarificationQuestionsPublishedBy'] = "2016-04-14T23:59:00.00000Z"
-            brief_json['briefs']['applicationsClosedAt'] = "2016-04-16T23:59:00.00000Z"
+            brief_json['briefs']['requirementsLength'] = '2 weeks'
+            brief_json['briefs']['publishedAt'] = u"2016-04-02T20:10:00.00000Z"
+            brief_json['briefs']['clarificationQuestionsClosedAt'] = u"2016-04-12T23:59:00.00000Z"
+            brief_json['briefs']['clarificationQuestionsPublishedBy'] = u"2016-04-14T23:59:00.00000Z"
+            brief_json['briefs']['applicationsClosedAt'] = u"2016-04-16T23:59:00.00000Z"
             brief_json['briefs']['specialistRole'] = 'communicationsManager'
             brief_json['briefs']["clarificationQuestionsAreClosed"] = True
             data_api_client.get_brief.return_value = brief_json
@@ -1912,7 +2040,7 @@ class TestViewQuestionAndAnswerDates(BaseApplicationTest):
             assert all(
                 date in
                 [e.text_content() for e in document.xpath('//main[@id="content"]//th/span')]
-                for date in ['2 April', '12 April', '14 April', '16 April']
+                for date in ['2 April', '8 April', '15 April', '16 April']
             )
 
     def test_do_not_show_question_and_answer_dates_for_draft_brief(self, data_api_client):

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1129,7 +1129,7 @@ class TestPublishBrief(BaseApplicationTest):
         brief_json = api_stubs.brief(status="draft")
         brief_questions = brief_json['briefs']
         brief_questions.update({
-            'requirementsLength': ''
+            'requirementsLength': None
         })
         data_api_client.get_brief.return_value = brief_json
 

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -196,21 +196,3 @@ class TestBuyersHelpers(unittest.TestCase):
             {"id": "three"},
             {"id": "five"}
         ]
-
-    def test_get_publishing_dates_formats_time(self):
-        with mock.patch('app.helpers.buyers_helpers.datetime') as mock_date:
-            mock_date.utcnow.return_value = datetime.datetime(2015, 5, 22, 20, 39, 39, 417900)
-
-            assert helpers.buyers_helpers.datetime.utcnow() == datetime.datetime(2015, 5, 22, 20, 39, 39, 417900)
-            assert helpers.buyers_helpers.get_publishing_dates()['closing_time'] == '11:59 pm'
-
-    def test_get_publish_dates_are_correct(self):
-        with mock.patch('app.helpers.buyers_helpers.datetime') as mock_date:
-            mock_date.utcnow.return_value = datetime.datetime(2015, 5, 22, 20, 39, 39, 417900)
-
-            assert helpers.buyers_helpers.get_publishing_dates()['questions_close'] == datetime.datetime(
-                2015, 5, 29, 23, 59, 59)
-            assert helpers.buyers_helpers.get_publishing_dates()['answers_close'] == datetime.datetime(
-                2015, 6, 4, 23, 59, 59)
-            assert helpers.buyers_helpers.get_publishing_dates()['closing_date'] == datetime.datetime(
-                2015, 6, 5, 23, 59, 59)


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/123706751) story on Pivotal.

Will need separate PR's on [utils](https://github.com/alphagov/digitalmarketplace-utils/pull/275), [apiclient](https://github.com/alphagov/digitalmarketplace-apiclient/pull/30), [api](https://github.com/alphagov/digitalmarketplace-api/pull/422) and [frameworks](https://github.com/alphagov/digitalmarketplace-frameworks/pull/294) to be accepted before this one.

The logic for calculating dates has been moved to dmutils so that it can be used by other apps, specifically the api app.

The dates are shown on the publishing page when the buyer is creating a brief and are dependent on the brief length chosen during creation of the brief. If that question hasn't been answered yet a link to the question is shown instead.

The catalogue of briefs is ordered slightly differently now; by live then closed, and by publishing date within that. The published date is also displayed for briefs to give more context.

The dmspeak styles have been imported from the frontend toolkit for use on the publishing page, which was using prototype styles which had leaked into the app.

Screenshots
---------------

Requirements length question in overview.

<img width="736" alt="screen shot 2016-07-25 at 13 26 53" src="https://cloud.githubusercontent.com/assets/13836290/17101469/a8ed532e-526c-11e6-98a8-4c29394a2fe8.png">
---------------
Selecting length

<img width="698" alt="screen shot 2016-07-25 at 13 27 22" src="https://cloud.githubusercontent.com/assets/13836290/17101485/bd729d4a-526c-11e6-96bf-5b9a8108a574.png">
---------------
Publishing page with no length set

<img width="662" alt="screen shot 2016-07-25 at 13 28 58" src="https://cloud.githubusercontent.com/assets/13836290/17101500/dceb663e-526c-11e6-8856-88869dcbe336.png">
---------------
Publishing page with length set

<img width="686" alt="screen shot 2016-07-25 at 13 27 45" src="https://cloud.githubusercontent.com/assets/13836290/17101522/f6b60290-526c-11e6-899e-4a61e8a508a8.png">
----------------
Publishing page with length set and no outstanding required questions.

<img width="664" alt="screen shot 2016-07-25 at 13 30 42" src="https://cloud.githubusercontent.com/assets/13836290/17101539/132899ec-526d-11e6-8ff4-455aebba1bd7.png">
----------------
Dates post publishing

<img width="670" alt="screen shot 2016-07-25 at 13 31 07" src="https://cloud.githubusercontent.com/assets/13836290/17101561/34ebfb8c-526d-11e6-9a79-eb2bd5788b51.png">
---------------
Briefs catalogue
<img width="771" alt="screen shot 2016-07-25 at 13 31 20" src="https://cloud.githubusercontent.com/assets/13836290/17101641/957472f4-526d-11e6-8ce3-05ce3fc48e7d.png">
<img width="725" alt="screen shot 2016-07-25 at 13 31 37" src="https://cloud.githubusercontent.com/assets/13836290/17101648/98a00ce0-526d-11e6-9b2d-694a9977a81c.png">



