### PR TITLE
[#119728323] Make sure withdrawn briefs can not be accessed

### DIFF
--- a/app/helpers/buyers_helpers.py
+++ b/app/helpers/buyers_helpers.py
@@ -18,9 +18,12 @@ def get_framework_and_lot(framework_slug, lot_slug, data_api_client, status=None
 
 
 def is_brief_correct(brief, framework_slug, lot_slug, current_user_id):
-    return brief['frameworkSlug'] == framework_slug and \
-        brief['lotSlug'] == lot_slug and \
-        is_brief_associated_with_user(brief, current_user_id)
+    return (
+        brief['frameworkSlug'] == framework_slug
+        and brief['lotSlug'] == lot_slug
+        and is_brief_associated_with_user(brief, current_user_id)
+        and not brief_is_withdrawn(brief)
+    )
 
 
 def is_brief_associated_with_user(brief, current_user_id):
@@ -30,6 +33,10 @@ def is_brief_associated_with_user(brief, current_user_id):
 
 def brief_can_be_edited(brief):
     return brief.get('status') == 'draft'
+
+
+def brief_is_withdrawn(brief):
+    return brief.get('status') == 'withdrawn'
 
 
 def section_has_at_least_one_required_question(section):

--- a/tests/unit/test_buyers_helpers.py
+++ b/tests/unit/test_buyers_helpers.py
@@ -65,6 +65,32 @@ class TestBuyersHelpers(unittest.TestCase):
         self.assertRaises(NotFound, helpers.buyers_helpers.get_framework_and_lot, 'digital-outcomes-and-specialists',
                           'digital-specialists', data_api_client, {'must_allow_brief': True})
 
+    def test_is_brief_correct(self):
+        brief = api_stubs.brief(user_id=123, status='live')['briefs']
+
+        assert helpers.buyers_helpers.is_brief_correct(
+            brief, 'digital-outcomes-and-specialists', 'digital-specialists', 123
+        ) is True
+
+        assert helpers.buyers_helpers.is_brief_correct(
+            brief, 'not-digital-outcomes-and-specialists', 'digital-specialists', 123
+        ) is False
+
+        assert helpers.buyers_helpers.is_brief_correct(
+            brief, 'digital-outcomes-and-specialists', 'not-digital-specialists', 123
+        ) is False
+
+        assert helpers.buyers_helpers.is_brief_correct(
+            brief, 'digital-outcomes-and-specialists', 'not-digital-specialists', 124
+        ) is False
+
+        assert helpers.buyers_helpers.is_brief_correct(
+            api_stubs.brief(user_id=123, status='withdrawn')['briefs'],
+            'digital-outcomes-and-specialists',
+            'digital-specialists',
+            123
+        ) is False
+
     def test_is_brief_associated_with_user(self):
         brief = api_stubs.brief(user_id=123)['briefs']
         assert helpers.buyers_helpers.is_brief_associated_with_user(brief, 123) is True
@@ -73,6 +99,10 @@ class TestBuyersHelpers(unittest.TestCase):
     def test_brief_can_be_edited(self):
         assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='draft')['briefs']) is True
         assert helpers.buyers_helpers.brief_can_be_edited(api_stubs.brief(status='live')['briefs']) is False
+
+    def test_brief_is_withdrawn(self):
+        assert helpers.buyers_helpers.brief_is_withdrawn(api_stubs.brief(status='withdrawn')['briefs']) is True
+        assert helpers.buyers_helpers.brief_is_withdrawn(api_stubs.brief(status='live')['briefs']) is False
 
     def test_section_has_at_least_one_required_question(self):
         content = content_loader.get_manifest('dos', 'edit_brief').filter(


### PR DESCRIPTION
With a new status being introduced that allows a brief's status to be "withdrawn", we wish to make sure that withdrawn briefs are no longer accessible to users. Behaviour we want to happen across our app's is described in [this comment](https://www.pivotaltracker.com/story/show/119728323/comments/145270949) in the relevant pivotal story.

Most pages at the moment would not show the user a withdrawn brief and would instead 404, however there are a couple of routes that would show the brief and not 404:

`view_brief_overview `
`view_brief_responses`

Instead of adding a specific check to each view, we will add the check to the widely used `is_brief_correct` function. This should remove the responsibility that a developer must remember to check if a brief is withdrawn or not.

Note, `is_brief_correct` is used for when users related to the brief are interacting with the brief i.e. viewing their brief's responses. This function is not used for parts of the app such as the marketplace showing all briefs but these parts of the app already have sufficient brief status checks and so have remained unchanged.