### PR TITLE
Quick fix: remove framework link if there is no framework page

### DIFF
--- a/app/assets/scss/_service-page.scss
+++ b/app/assets/scss/_service-page.scss
@@ -52,7 +52,7 @@
 
 #meta {
 
-  .meta-item {
+  %meta-item {
     margin-bottom: $gutter;
   }
   
@@ -64,12 +64,16 @@
     display: none;
   }
 
+  .framework-name {
+    @extend %meta-item;
+  }
+  
   .service-id {
-    @extend .meta-item;
+    @extend %meta-item;
   }
 
   .external-link-default {
-    @extend .meta-item;
+    @extend %meta-item;
   }
 }
 

--- a/app/assets/scss/_service-page.scss
+++ b/app/assets/scss/_service-page.scss
@@ -51,6 +51,11 @@
 }
 
 #meta {
+
+  .meta-item {
+    margin-bottom: $gutter;
+  }
+  
   .document-link-with-icon {
     font-size: 16px;
   }
@@ -60,11 +65,11 @@
   }
 
   .service-id {
-    margin-bottom: $gutter;
+    @extend .meta-item;
   }
 
   .external-link-default {
-    margin-bottom: $gutter;
+    @extend .meta-item;
   }
 }
 

--- a/app/presenters/service_presenters.py
+++ b/app/presenters/service_presenters.py
@@ -99,7 +99,7 @@ class Meta(object):
         elif service_data['frameworkName'] == 'G-Cloud 6':
             framework_url = external_url + 'rm1557vi'
         else:
-            framework_url = external_url
+            framework_url = None
         return framework_url
 
     def get_documents(self, service_data):

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -26,7 +26,7 @@
       {% include "toolkit/external-link.html" %}
     {% endwith %}
   {% else %}
-    <div class="meta-item">{{ service.frameworkName }}</div>
+    <p class="framework-name">{{ service.frameworkName }}</p>
   {% endif %}
   <h2 class="sidebar-heading">Service ID</h2>
   {% with id=service.meta.serviceId %}

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -18,12 +18,16 @@
   {% endfor %}
   </ul>
   <h2 class="sidebar-heading">Framework</h2>
-  {%
-    with
-    text=service.frameworkName,
-    link=service.meta.externalFrameworkUrl %}
-    {% include "toolkit/external-link.html" %}
-  {% endwith %}
+  {% if service.meta.externalFrameworkUrl is not none %}
+    {%
+      with
+      text=service.frameworkName,
+      link=service.meta.externalFrameworkUrl %}
+      {% include "toolkit/external-link.html" %}
+    {% endwith %}
+  {% else %}
+    <div class="meta-item">{{ service.frameworkName }}</div>
+  {% endif %}
   <h2 class="sidebar-heading">Service ID</h2>
   {% with id=service.meta.serviceId %}
     {% include "toolkit/service-id.html" %}

--- a/tests/unit/test_service_presenters.py
+++ b/tests/unit/test_service_presenters.py
@@ -180,7 +180,7 @@ class TestMeta(unittest.TestCase):
         )
         self.assertEqual(
             self.meta.get_external_framework_url({'frameworkName': 'None'}),
-            'http://ccs-agreements.cabinetoffice.gov.uk/contracts/'
+            None
         )
 
     def test_get_documents_returns_the_correct_document_information(self):


### PR DESCRIPTION
First version fix for this story: https://www.pivotaltracker.com/story/show/126767693

There is no point in linking to a generic list of CCS frameworks that doesn't even include the framework just clicked on.

This is a quick fix for G8 going live today.  The proper fix will move the URLs out to the frameworks repo.