### PR TITLE
Open not live requirements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.1.0"
+    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v2.1.2"
   }
 }

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1252,7 +1252,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
                 'Location',
                 'Description of work',
                 'Shortlist and evaluation process',
-                'Set how long your requirements will be live for',
+                'Set how long your requirements will be open for',
                 'Describe question and answer session',
                 'Review and publish your requirements',
                 'How to answer supplier questions',


### PR DESCRIPTION
For [this](https://www.pivotaltracker.com/story/show/123706751) story on Pivotal.

Briefs should be described as 'open' and not 'live'. The dm frameworks repo has been updated to reflect this, see [this](https://github.com/alphagov/digitalmarketplace-frameworks/pull/295) PR.

This PR is to bring in that new version of the frameworks, as well as a slight adjustment to a test.