### PR TITLE
PROD BUGFIX: show all service ID digits for 15-digit IDs

### DIFF
--- a/app/helpers/shared_helpers.py
+++ b/app/helpers/shared_helpers.py
@@ -25,3 +25,7 @@ def get_one_framework_by_status_in_order_of_preference(frameworks, statuses_in_o
         for framework in frameworks:
             if framework.get('status') == status:
                 return framework
+
+
+def chunk_string(string, chunk_length):
+    return (string[0+i:chunk_length+i] for i in range(0, len(string), chunk_length))

--- a/app/presenters/service_presenters.py
+++ b/app/presenters/service_presenters.py
@@ -1,6 +1,6 @@
+from ..helpers.shared_helpers import chunk_string
 import os
 import re
-from jinja2 import Template
 from dmutils.service_attribute import Attribute
 from dmcontent.formats import format_service_price
 
@@ -90,7 +90,7 @@ class Meta(object):
         if re.findall("[a-zA-Z]", str(id)):
             return [id]
         else:
-            return re.findall("....", str(id))
+            return list(chunk_string(str(id), 4))
 
     def get_external_framework_url(self, service_data):
         external_url = 'http://ccs-agreements.cabinetoffice.gov.uk/contracts/'

--- a/tests/unit/test_service_presenters.py
+++ b/tests/unit/test_service_presenters.py
@@ -165,6 +165,10 @@ class TestMeta(unittest.TestCase):
             ['1234', '5678', '9012', '3456']
         )
         self.assertEqual(
+            self.meta.get_service_id({'id': 123456789012345}),
+            ['1234', '5678', '9012', '345']
+        )
+        self.assertEqual(
             self.meta.get_service_id({'id': '5-G4-1046-001'}),
             ['5-G4-1046-001']
         )

--- a/tests/unit/test_shared_helpers.py
+++ b/tests/unit/test_shared_helpers.py
@@ -1,0 +1,8 @@
+from app.helpers import shared_helpers
+
+
+def test_chunk_string():
+    assert list(shared_helpers.chunk_string("123456", 3)) == ["123", "456"]
+    assert list(shared_helpers.chunk_string("1234567", 3)) == ["123", "456", "7"]
+    assert list(shared_helpers.chunk_string("12345678910", 4)) == ["1234", "5678", "910"]
+    assert list(shared_helpers.chunk_string("123456789101", 4)) == ["1234", "5678", "9101"]


### PR DESCRIPTION
Fix for this bug: https://www.pivotaltracker.com/story/show/127547401

Previous G-Cloud iterations had 16-digit service IDs, which are displayed on the service page as four chunks of four digits.
For G-Cloud 8 we have moved to 15-digit IDs to help people using spreadsheets, but the method used to "chunk" the IDs for display on the service page dropped the final three digits as they did not match the regular expression that was being used to split the ID (`r'....'`).

This introduces a new method `chunk_string` that returns a generator for chunks of a specified length.  Unlike the old regular expression, this generator also returns smaller chunks at the end of the string, so that 15-digit IDs display as three chunks of four plus three digits at the end (e.g. 1111 2222 3333 444).

BEFORE
----------
![screen shot 2016-08-02 at 17 11 38](https://cloud.githubusercontent.com/assets/6525554/17336025/47a3d746-58d4-11e6-86a0-9010770394ab.png)

AFTER
--------
![screen shot 2016-08-02 at 17 10 25](https://cloud.githubusercontent.com/assets/6525554/17336029/4c82de10-58d4-11e6-83c7-23e87fa70e5f.png)

