### PR TITLE
Get framework URLs from frameworks content instead of hard-coded in app

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "git://github.com/alphagov/digitalmarketplace-frameworks#v2.3.4"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v2.3.5"
   }
 }

--- a/tests/unit/test_service_presenters.py
+++ b/tests/unit/test_service_presenters.py
@@ -175,15 +175,15 @@ class TestMeta(unittest.TestCase):
 
     def test_external_framework_url_returns_correct_suffix(self):
         self.assertEqual(
-            self.meta.get_external_framework_url({'frameworkName': 'G-Cloud 7'}),
+            self.meta.get_external_framework_url({'frameworkSlug': 'g-cloud-7'}),
             'http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vii'
         )
         self.assertEqual(
-            self.meta.get_external_framework_url({'frameworkName': 'G-Cloud 6'}),
-            'http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vi'
+            self.meta.get_external_framework_url({'frameworkSlug': 'g-cloud-6'}),
+            None
         )
         self.assertEqual(
-            self.meta.get_external_framework_url({'frameworkName': 'None'}),
+            self.meta.get_external_framework_url({'frameworkSlug': 'None'}),
             None
         )
 


### PR DESCRIPTION
For this story: https://www.pivotaltracker.com/story/show/126767693

Depends on:
 - [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/297