### PR TITLE
[#127062871] Track account creation using GA virtual page views

### DIFF
--- a/app/assets/javascripts/_analytics.js
+++ b/app/assets/javascripts/_analytics.js
@@ -1,6 +1,5 @@
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js
-//= include analytics/_dm-analytics.js
 //= include analytics/_register.js
 //= include analytics/_pageViews.js
 //= include analytics/_events.js

--- a/app/assets/javascripts/_analytics.js
+++ b/app/assets/javascripts/_analytics.js
@@ -4,4 +4,5 @@
 //= include analytics/_register.js
 //= include analytics/_pageViews.js
 //= include analytics/_events.js
+//= include analytics/_virtualPageViews.js
 //= include analytics/_init.js

--- a/app/assets/javascripts/analytics/_init.js
+++ b/app/assets/javascripts/analytics/_init.js
@@ -5,5 +5,6 @@
     this.register();
     this.pageViews.init();
     this.events.init();
+    this.virtualPageViews();
   };
 })(window);

--- a/app/assets/javascripts/analytics/_virtualPageViews.js
+++ b/app/assets/javascripts/analytics/_virtualPageViews.js
@@ -1,0 +1,16 @@
+(function (GOVUK) {
+  "use strict";
+
+  var sendVirtualPageView = function() {
+    var $element = $(this);
+    var url = $element.data('url');
+    if (GOVUK.analytics  && url){
+      GOVUK.analytics.trackPageview(url);
+    }
+  };
+
+  GOVUK.GDM.analytics.virtualPageViews = function() {
+    $('[data-analytics=trackPageView]').each(sendVirtualPageView);
+  };
+
+})(window.GOVUK);

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -319,6 +319,7 @@ def submit_create_user(encoded_token):
                 error=e.message,
                 token=None), 400
 
+        flash('account-created', 'flag')
         return redirect_logged_in_user()
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -46,7 +46,11 @@
   %}
 {% endif %}
 
+{% if 'account-created' in get_flashed_messages(category_filter=["flag"]) %}
+<div class="index-page grid-row" data-analytics="trackPageView" data-url="/vpv/?account-created=true">
+{% else %}
 <div class="index-page grid-row">
+{% endif %}
   <div class="column-two-thirds">
     <h2 class="marketplace-homepage-subheading">Find technology or people for digital projects in the public sector</h2>
     {% with

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -4,7 +4,6 @@ var manifest = {
     '../../../bower_components/jquery/dist/jquery.js',
     '../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js',
     '../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js',
-    '../../../app/assets/javascripts/analytics/_dm-analytics.js',
     '../../../app/assets/javascripts/analytics/_register.js',
     '../../../app/assets/javascripts/analytics/_pageViews.js',
     '../../../app/assets/javascripts/analytics/_events.js',

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -8,6 +8,7 @@ var manifest = {
     '../../../app/assets/javascripts/analytics/_register.js',
     '../../../app/assets/javascripts/analytics/_pageViews.js',
     '../../../app/assets/javascripts/analytics/_events.js',
+    '../../../app/assets/javascripts/analytics/_virtualPageViews.js',
     '../../../app/assets/javascripts/analytics/_init.js'
   ],
   test : [

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -176,4 +176,27 @@ describe("GOVUK.Analytics", function () {
       }]);
     });
   });
+
+  describe("Virtual Page Views", function () {
+    var $analyticsString;
+
+    afterEach(function () {
+      $analyticsString.remove();
+    });
+
+    it("Should not call google analytics without a url", function () {
+      $analyticsString = $("<div data-analytics='trackPageView'/>");
+      $(document.body).append($analyticsString);
+      window.GOVUK.GDM.analytics.virtualPageViews();
+      expect(window.ga.calls.any()).toEqual(false);
+    });
+
+    it("Should call google analytics if url exists", function () {
+      $analyticsString = $("<div data-analytics='trackPageView' data-url='http://example.com'/>");
+      $(document.body).append($analyticsString);
+      window.GOVUK.GDM.analytics.virtualPageViews();
+      expect(window.ga.calls.first().args).toEqual([ 'send', 'pageview', { page: 'http://example.com' } ]);
+      expect(window.ga.calls.count()).toEqual(1);
+    });
+  });
 });

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -895,6 +895,7 @@ class TestCreateUser(BaseApplicationTest):
 
         assert res.status_code == 302
         assert res.location == 'http://localhost/'
+        self.assert_flashes('account-created', 'flag')
 
     @mock.patch('app.main.views.login.data_api_client')
     def test_should_return_an_error_if_user_exists(self, data_api_client):

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -29,6 +29,25 @@ class TestApplication(BaseApplicationTest):
         )
 
 
+class TestHomepageAccountCreationVirtualPageViews(BaseApplicationTest):
+    @mock.patch('app.main.views.marketplace.data_api_client')
+    def test_data_analytics_track_page_view_is_shown_if_account_created_flag_flash_message(self, data_api_client):
+        with self.client.session_transaction() as session:
+            session['_flashes'] = [('flag', 'account-created')]
+
+        res = self.client.get("/")
+        data = res.get_data(as_text=True)
+
+        assert 'data-analytics="trackPageView" data-url="/vpv/?account-created=true"' in data
+
+    @mock.patch('app.main.views.marketplace.data_api_client')
+    def test_data_analytics_track_page_view_not_shown_if_no_account_created_flag_flash_message(self, data_api_client):
+        res = self.client.get("/")
+        data = res.get_data(as_text=True)
+
+        assert 'data-analytics="trackPageView" data-url="/vpv/?account-created=true"' not in data
+
+
 class TestHomepageBrowseList(BaseApplicationTest):
     @mock.patch('app.main.views.marketplace.data_api_client')
     def test_dos_links_not_shown_when_dos_is_pending(self, data_api_client):


### PR DESCRIPTION
Currently, we are not able to tell using GA how many user accounts have been created. We could try to use a page view of the URL after an account is created to indicate this, however the URL is also accessible from other user flows and will not therefore be an accurate count of how many user accounts have been created.

Therefore, as part of this pivotal story, we wish to send a GA virtual page view every time a buyer account is successfully created. By embedding

`data-analytics="trackPageView" data-url="/vpv/?account-created=true"`

into our template, we will send the required virtual page view on the success page. This behaviour [already exists](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/assets/javascripts/analytics/_virtualPageViews.js) in the supplier front end but did not yet exist in the buyer front end. I have added it here but this may be something that should be moved into the front end toolkit as there is some code duplication?

This tracking tag will only be embedded if they have come through the account creation process (indicated by setting a flash message).

Note, a similar process [has been created](https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/517) for the creation of supplier accounts.