### PR TITLE
Don't upload npm/bower directories during CloudFoundry release

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,5 @@
+node_modules/
+bower_components/
+
+*.pyc
+venv/


### PR DESCRIPTION
Since CloudFoundry push isn't tied to the list of files tracked by git it will add pyc file, venv, node_modules and bower_components to the release archive. They're not required, since we're running the frontend build locally anyway and nothing is loaded from bower_components on runtime.

Adding them to .cfignore reduces the size of the release from 49MB to 5MB.