### PR TITLE
[#124104671]Revert "global footer: change visible text of support link to email address"

### DIFF
--- a/app/templates/_footer_categories.html
+++ b/app/templates/_footer_categories.html
@@ -5,7 +5,7 @@
     </h2>
     <ul>
       <li>
-        <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
+        <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">Digital Marketplace support</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
This reverts commit 0477458514a19e8421bf6db3571ce58998c7c621. Long email address determined ugly.