### PR TITLE
[#125881031]brief filtering template: put page heading, marketplace-paragraph in a 2/3 column as it should be

### DIFF
--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -17,12 +17,15 @@
 {% endblock %}
 
 {% block main_content %}
-
-    {% with heading="{} opportunities".format(framework.name) %}
-        {% include "toolkit/page-heading.html" %}
-    {% endwith %}
-    <div class="marketplace-paragraph">
-      <p>View buyer requirements for {{ lot_names | map('lower') | smartjoin }}.</p>
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        {% with heading="{} opportunities".format(framework.name) %}
+            {% include "toolkit/page-heading.html" %}
+        {% endwith %}
+        <div class="marketplace-paragraph">
+          <p>View buyer requirements for {{ lot_names | map('lower') | smartjoin }}.</p>
+        </div>
+      </div>
     </div>
 
     <div class="grid-row">


### PR DESCRIPTION
as per ralph's request.

Story https://www.pivotaltracker.com/story/show/125881031