### PR TITLE
[#127171827] Set Google Analytic custom dimensions for filtering opportunities

### DIFF
--- a/app/assets/javascripts/analytics/_events.js
+++ b/app/assets/javascripts/analytics/_events.js
@@ -1,19 +1,6 @@
 (function (root, GOVUK) {
   "use strict";
 
-  // wrapper around access to window.location
-  GOVUK.GDM.analytics.location = {
-    'hostname': function () {
-      return root.location.hostname;
-    },
-    'pathname': function () {
-      return root.location.pathname;
-    },
-    'protocol': function () {
-      return root.location.protocol;
-    }
-  };
-
   var LinkClick = function (e) {
       this.$target = $(e.target);
       this.text = this.$target.text(),

--- a/app/assets/javascripts/analytics/_pageViews.js
+++ b/app/assets/javascripts/analytics/_pageViews.js
@@ -1,7 +1,18 @@
 (function (GOVUK) {
   GOVUK.GDM.analytics.pageViews = {
     'init': function () {
+      this.setCustomDimensions();
       GOVUK.analytics.trackPageview();
+    },
+
+    'setCustomDimensions': function() {
+      // check that we're on the catalogue page for opportunites
+      if(GOVUK.GDM.analytics.location.pathname() === "/digital-outcomes-and-specialists/opportunities") {
+
+        // if it does, we want to send the current number of opportunites back to GA
+        numberOfOpportunites = $('.search-summary-count').text();
+        GOVUK.analytics.setDimension(21, numberOfOpportunites);
+      }
     }
   };
 })(window.GOVUK);

--- a/app/assets/javascripts/analytics/_pageViews.js
+++ b/app/assets/javascripts/analytics/_pageViews.js
@@ -7,8 +7,7 @@
 
     'setCustomDimensions': function() {
       var search = GOVUK.GDM.analytics.location.search(),
-          categoryParams = [],
-          statusParams = [],
+          filterGroupDimension = [],
           numberOfOpportunites,
           dimensions,
           pairs,
@@ -17,13 +16,13 @@
           j;
 
       // check that we're on the catalogue page for opportunites
-      if(GOVUK.GDM.analytics.location.pathname() === "/digital-outcomes-and-specialists/opportunities") {
+      if (GOVUK.GDM.analytics.location.pathname() === "/digital-outcomes-and-specialists/opportunities") {
 
         // if it does, we want to send the current number of opportunites back to GA
         numberOfOpportunites = $('.search-summary-count').text();
         GOVUK.analytics.setDimension(21, numberOfOpportunites);
 
-        if(search !== '') {
+        if (search !== '') {
           // clear the ? prefix
           search = search.split('?')[1];
           pairs = search.split('&');
@@ -32,31 +31,42 @@
             {
               dimensionId: 23,
               paramType:  'lot',
-              paramArray:  categoryParams,
+              paramArray:  [],
             },
             {
               dimensionId: 24,
               paramType:  'status',
-              paramArray:  statusParams,
+              paramArray:  [],
             },
           ]
 
-          // Using the pairs from the query string, assign them to the correct
-          // dimension
-          j = dimensions.length; while(j--) {
+          j = dimensions.length; while (j--) {
             setFilterDimension(pairs, dimensions[j]);
+
+            // Build array with the names of selected filter group(s) (ie, 'status', 'lot')
+            if (dimensions[j]['paramArray'].length) {
+              filterGroupDimension.push(dimensions[j]['paramType']);
+            }
+          }
+
+          if (filterGroupDimension.length) {
+            filterGroupDimension.sort();
+            GOVUK.analytics.setDimension(22, filterGroupDimension.join('|'));
           }
 
           function setFilterDimension(pairs, dimension) {
+            // If the pairs relate to the given dimension, add their values to the dimension's paramArray
             i = pairs.length;
-            while(i--) {
+            while (i--) {
               pair = pairs[i].split('=');
 
               if (pair[0] === dimension['paramType']) {
                 dimension['paramArray'].push(pair[1]);
               }
             }
-            if (dimension['paramArray'].length > 0) {
+
+            // Format paramArray to an ordered list for Google Analytics and set dimension
+            if (dimension['paramArray'].length) {
               dimension['paramArray'].sort();
               GOVUK.analytics.setDimension(dimension['dimensionId'], dimension['paramArray'].join('|'));
             }

--- a/app/assets/javascripts/analytics/_pageViews.js
+++ b/app/assets/javascripts/analytics/_pageViews.js
@@ -6,12 +6,62 @@
     },
 
     'setCustomDimensions': function() {
+      var search = GOVUK.GDM.analytics.location.search(),
+          categoryParams = [],
+          statusParams = [],
+          numberOfOpportunites,
+          dimensions,
+          pairs,
+          pair,
+          i,
+          j;
+
       // check that we're on the catalogue page for opportunites
       if(GOVUK.GDM.analytics.location.pathname() === "/digital-outcomes-and-specialists/opportunities") {
 
         // if it does, we want to send the current number of opportunites back to GA
         numberOfOpportunites = $('.search-summary-count').text();
         GOVUK.analytics.setDimension(21, numberOfOpportunites);
+
+        if(search !== '') {
+          // clear the ? prefix
+          search = search.split('?')[1];
+          pairs = search.split('&');
+
+          dimensions = [
+            {
+              dimensionId: 23,
+              paramType:  'lot',
+              paramArray:  categoryParams,
+            },
+            {
+              dimensionId: 24,
+              paramType:  'status',
+              paramArray:  statusParams,
+            },
+          ]
+
+          // Using the pairs from the query string, assign them to the correct
+          // dimension
+          j = dimensions.length; while(j--) {
+            setFilterDimension(pairs, dimensions[j]);
+          }
+
+          function setFilterDimension(pairs, dimension) {
+            i = pairs.length;
+            while(i--) {
+              pair = pairs[i].split('=');
+
+              if (pair[0] === dimension['paramType']) {
+                dimension['paramArray'].push(pair[1]);
+              }
+            }
+            if (dimension['paramArray'].length > 0) {
+              dimension['paramArray'].sort();
+              GOVUK.analytics.setDimension(dimension['dimensionId'], dimension['paramArray'].join('|'));
+            }
+          }
+        }
       }
     }
   };

--- a/app/assets/javascripts/analytics/_register.js
+++ b/app/assets/javascripts/analytics/_register.js
@@ -12,6 +12,19 @@
         universalId: universalId,
         cookieDomain: cookieDomain
       });
+    },
+
+    // wrapper around access to window.location
+    'location': {
+      'hostname': function () {
+        return root.location.hostname;
+      },
+      'pathname': function () {
+        return root.location.pathname;
+      },
+      'protocol': function () {
+        return root.location.protocol;
+      }
     }
   };
 })(window);

--- a/app/assets/javascripts/analytics/_register.js
+++ b/app/assets/javascripts/analytics/_register.js
@@ -24,6 +24,9 @@
       },
       'protocol': function () {
         return root.location.protocol;
+      },
+      'search': function () {
+        return root.location.search;
       }
     }
   };

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -205,104 +205,91 @@ describe("GOVUK.Analytics", function () {
 
     beforeEach(function () {
       $(document.body).append($counter);
+
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/digital-outcomes-and-specialists/opportunities');
     });
 
     afterEach(function () {
       $counter.remove();
     });
 
-    it('should send the number of results as a custom dimension', function() {
-      spyOn(GOVUK.GDM.analytics.location, "pathname")
+    setupQueryString = function (query_string) {
+      spyOn(GOVUK.GDM.analytics.location, "search")
         .and
-        .returnValue('/digital-outcomes-and-specialists/opportunities');
+        .returnValue(query_string);
 
+      window.GOVUK.GDM.analytics.pageViews.init();
+    };
+
+    it('should send the number of results as a custom dimension', function() {
       window.GOVUK.GDM.analytics.pageViews.init();
 
       expect(window.ga.calls.first().args).toEqual(['set', 'dimension21', '32']);
     });
 
     it('should send the category filters as a custom dimension if only one', function() {
-      spyOn(GOVUK.GDM.analytics.location, "pathname")
-        .and
-        .returnValue('/digital-outcomes-and-specialists/opportunities');
-
-      spyOn(GOVUK.GDM.analytics.location, "search")
-        .and
-        .returnValue('?lot=digital-outcomes');
-
-      window.GOVUK.GDM.analytics.pageViews.init();
+      setupQueryString('?lot=digital-outcomes');
 
       expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension23', 'digital-outcomes']);
     });
 
     it('should send the category filters as a custom dimension if multiple', function() {
-      spyOn(GOVUK.GDM.analytics.location, "pathname")
-        .and
-        .returnValue('/digital-outcomes-and-specialists/opportunities');
-
-      spyOn(GOVUK.GDM.analytics.location, "search")
-        .and
-        .returnValue('?lot=digital-outcomes&lot=digital-specialists');
-
-      window.GOVUK.GDM.analytics.pageViews.init();
+      setupQueryString('?lot=digital-outcomes&lot=digital-specialists');
 
       expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension23', 'digital-outcomes|digital-specialists']);
     });
 
     it('should send the category filters as a custom dimension if multiple and in wrong order', function() {
-      spyOn(GOVUK.GDM.analytics.location, "pathname")
-        .and
-        .returnValue('/digital-outcomes-and-specialists/opportunities');
-
-      spyOn(GOVUK.GDM.analytics.location, "search")
-        .and
-        .returnValue('?lot=digital-specialists&lot=digital-outcomes');
-
-      window.GOVUK.GDM.analytics.pageViews.init();
+      setupQueryString('?lot=digital-specialists&lot=digital-outcomes');
 
       expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension23', 'digital-outcomes|digital-specialists']);
     });
 
     it('should send the status filters as a custom dimension if only one', function() {
-      spyOn(GOVUK.GDM.analytics.location, "pathname")
-        .and
-        .returnValue('/digital-outcomes-and-specialists/opportunities');
-
-      spyOn(GOVUK.GDM.analytics.location, "search")
-        .and
-        .returnValue('?status=closed');
-
-      window.GOVUK.GDM.analytics.pageViews.init();
+      setupQueryString('?status=closed');
 
       expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed']);
     });
 
     it('should send the status filters as a custom dimension if multiple', function() {
-      spyOn(GOVUK.GDM.analytics.location, "pathname")
-        .and
-        .returnValue('/digital-outcomes-and-specialists/opportunities');
-
-      spyOn(GOVUK.GDM.analytics.location, "search")
-        .and
-        .returnValue('?status=closed&status=live');
-
-      window.GOVUK.GDM.analytics.pageViews.init();
+      setupQueryString('?status=closed&status=live');
 
       expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed|live']);
     });
 
     it('should send the status filters as a custom dimension if multiple and in wrong order', function() {
-      spyOn(GOVUK.GDM.analytics.location, "pathname")
-        .and
-        .returnValue('/digital-outcomes-and-specialists/opportunities');
-
-      spyOn(GOVUK.GDM.analytics.location, "search")
-        .and
-        .returnValue('?status=live&status=closed');
-
-      window.GOVUK.GDM.analytics.pageViews.init();
+      setupQueryString('?status=live&status=closed');
 
       expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed|live']);
+    });
+
+    it('should send the filter groups as a custom dimension if one', function() {
+      setupQueryString('?status=closed');
+
+      expect(window.ga.calls.all()[2].args).toEqual(['set', 'dimension22', 'status']);
+    });
+
+    it('should send the filter groups as a custom dimension if multiple', function() {
+      setupQueryString('?status=closed&lot=digital-specialists');
+
+      expect(window.ga.calls.all()[3].args).toEqual(['set', 'dimension22', 'lot|status']);
+    });
+
+    it('should send the filter groups as a custom dimension if multiple and wrong order', function() {
+      setupQueryString('?lot=digital-specialists&status=closed');
+
+      expect(window.ga.calls.all()[3].args).toEqual(['set', 'dimension22', 'lot|status']);
+    });
+
+    it('should send the correct custom dimension if all filters are used', function() {
+      setupQueryString('?lot=digital-specialists&status=closed&lot=digital-outcomes&status=live&lot=user-research-participants');
+
+      expect(window.ga.calls.first().args).toEqual(['set', 'dimension21', '32']);
+      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed|live']);
+      expect(window.ga.calls.all()[2].args).toEqual(['set', 'dimension23', 'digital-outcomes|digital-specialists|user-research-participants']);
+      expect(window.ga.calls.all()[3].args).toEqual(['set', 'dimension22', 'lot|status']);
     });
 
   });

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -1,7 +1,7 @@
 describe("GOVUK.Analytics", function () {
   var analytics,
       sortCalls;
-      
+
   SortCallsToGaByMethod = function (calls) {
     var gaMethodCalls = {},
         callNum = calls.length;
@@ -23,7 +23,7 @@ describe("GOVUK.Analytics", function () {
       return this._calls[method];
     }
     return [];
-  }; 
+  };
 
   beforeEach(function () {
     window.ga = function() {};
@@ -124,7 +124,7 @@ describe("GOVUK.Analytics", function () {
         'transport': 'beacon'
       }]);
     });
- 
+
     it('sends the right event when a list of user research participants download link is clicked', function() {
       spyOn(GOVUK.GDM.analytics.location, "pathname")
         .and
@@ -141,7 +141,7 @@ describe("GOVUK.Analytics", function () {
         'transport': 'beacon'
       }]);
     });
- 
+
     it('sends the right event when a list of suppliers for digital specialists download link is clicked', function() {
       spyOn(GOVUK.GDM.analytics.location, "pathname")
         .and
@@ -158,7 +158,7 @@ describe("GOVUK.Analytics", function () {
         'transport': 'beacon'
       }]);
     });
- 
+
     it('sends the right event when a list of suppliers for digital outcomes download link is clicked', function() {
       spyOn(GOVUK.GDM.analytics.location, "pathname")
         .and
@@ -198,5 +198,28 @@ describe("GOVUK.Analytics", function () {
       expect(window.ga.calls.first().args).toEqual([ 'send', 'pageview', { page: 'http://example.com' } ]);
       expect(window.ga.calls.count()).toEqual(1);
     });
+  });
+
+  describe("Opportunities search page", function() {
+    var $counter = $('<span class="search-summary-count">32</span>');
+
+    beforeEach(function () {
+      $(document.body).append($counter);
+    });
+
+    afterEach(function () {
+      $counter.remove();
+    });
+
+    it('should send the number of results as a custom dimension', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/digital-outcomes-and-specialists/opportunities');
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.first().args).toEqual(['set', 'dimension21', '32']);
+    });
+
   });
 });

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -221,5 +221,89 @@ describe("GOVUK.Analytics", function () {
       expect(window.ga.calls.first().args).toEqual(['set', 'dimension21', '32']);
     });
 
+    it('should send the category filters as a custom dimension if only one', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/digital-outcomes-and-specialists/opportunities');
+
+      spyOn(GOVUK.GDM.analytics.location, "search")
+        .and
+        .returnValue('?lot=digital-outcomes');
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension23', 'digital-outcomes']);
+    });
+
+    it('should send the category filters as a custom dimension if multiple', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/digital-outcomes-and-specialists/opportunities');
+
+      spyOn(GOVUK.GDM.analytics.location, "search")
+        .and
+        .returnValue('?lot=digital-outcomes&lot=digital-specialists');
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension23', 'digital-outcomes|digital-specialists']);
+    });
+
+    it('should send the category filters as a custom dimension if multiple and in wrong order', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/digital-outcomes-and-specialists/opportunities');
+
+      spyOn(GOVUK.GDM.analytics.location, "search")
+        .and
+        .returnValue('?lot=digital-specialists&lot=digital-outcomes');
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension23', 'digital-outcomes|digital-specialists']);
+    });
+
+    it('should send the status filters as a custom dimension if only one', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/digital-outcomes-and-specialists/opportunities');
+
+      spyOn(GOVUK.GDM.analytics.location, "search")
+        .and
+        .returnValue('?status=closed');
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed']);
+    });
+
+    it('should send the status filters as a custom dimension if multiple', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/digital-outcomes-and-specialists/opportunities');
+
+      spyOn(GOVUK.GDM.analytics.location, "search")
+        .and
+        .returnValue('?status=closed&status=live');
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed|live']);
+    });
+
+    it('should send the status filters as a custom dimension if multiple and in wrong order', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/digital-outcomes-and-specialists/opportunities');
+
+      spyOn(GOVUK.GDM.analytics.location, "search")
+        .and
+        .returnValue('?status=live&status=closed');
+
+      window.GOVUK.GDM.analytics.pageViews.init();
+
+      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed|live']);
+    });
+
   });
 });


### PR DESCRIPTION
We added basic filtering to DOS opportunities in [this story](https://www.pivotaltracker.com/story/show/125881031). We wish to add some basic analytics to this new functionality, details can be found [in this analytics story](https://www.pivotaltracker.com/story/show/127171827).

We add custom dimensions for
- The number of opportunities found
- Which filter groups were used e.g. the lot type filter group
- When filtering by lot, which exact filters were used e.g. digital-specialists
- When filtering by status, which exact filters were used e.g. open

The custom dimension must be sent before the page view. ID's for each custom dimension have been set up by Ash.

For the filter and filter group dimensions, we wish to return the values in an alphabetically sorted list, separated by "|", e.g. "digital-outcomes|digital-specialists". This means Ash will have more consistent results.

