### PR TITLE
Fix wrong url on publish page

### DIFF
--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -40,7 +40,7 @@
         <p>All requirements are published on the Digital Marketplace where anyone can see them.</p>
       </div>
         {% if brief.lotSlug == 'digital-specialists' and not brief.requirementsLength %}
-          <p><a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-live-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
+          <p><a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-open-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
           <div class="dmspeak">
             <p>This will show you what the supplier application deadline will be if you publish your requirements today.</p>
           </div>

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1061,6 +1061,7 @@ class TestPublishBrief(BaseApplicationTest):
         page_html = res.get_data(as_text=True)
 
         assert res.status_code == 200
+        assert 'href="/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/edit/set-how-long-your-requirements-will-be-open-for/requirementsLength"' in page_html  # noqa
         assert 'This will show you what the supplier application deadline will be' in page_html
         assert 'Your requirements will be open for' not in page_html
 


### PR DESCRIPTION
After changing the text from 
`set how long your requirements will be live for` 
to 
`set how long your requirements will be open for`, 
the url we used to get to the requirementsLength page changed with it.

Since we've been treating the requirementsLength question in a special way where we don't use the rest of the content-loaded stuff, we're actually hard-coding the url string into the publish page. Unfortunately, when we updated the content, this broke the link because we didn't update the link along with it.

This pull request fixes the broken link, but it doesn't really address the problem of hardcoding links into our template.

Not sure there is a solution for that, incidentally.