### PR TITLE
[#128509823] Suppliers should be able to view their response for any brief state

### DIFF
--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -57,26 +57,29 @@
   </div>
 </div>
 
-{% if brief.status == 'live' %}
-<div class="grid-row">
-  <div class="column-one-third">
-    {% if brief_responses %}
-      {% with
-         url = "/suppliers/opportunities/{}/responses/result".format(brief.id),
-         text = "View your application",
-         bigger = True
-      %}
-        {% include "toolkit/secondary-action-link.html" %}
-      {% endwith %}
-    {% else %}
+{% if brief_responses %}
+  <div class="grid-row">
+    <div class="column-one-third">
+        {% with
+           url = "/suppliers/opportunities/{}/responses/result".format(brief.id),
+           text = "View your application",
+           bigger = True
+        %}
+          {% include "toolkit/secondary-action-link.html" %}
+        {% endwith %}
+    </div>
+  </div>
+{% elif brief.status == 'live' %}
+  <div class="grid-row">
+    <div class="column-one-third">
       {% with
          url = "/suppliers/opportunities/{}/responses/create".format(brief.id),
          label = "Start application"
       %}
         {% include "toolkit/link-button.html" %}
       {% endwith %}
-    {% endif %}
+    </div>
   </div>
-</div>
 {% endif %}
+
 {% endblock %}

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -456,13 +456,29 @@ class TestBriefPage(BaseApplicationTest):
 
         self._assert_start_application(document, brief_id)
 
-    def test_supplier_applied_view_application(self):
+    def test_supplier_applied_view_application_for_live_opportunity(self):
         self.login_as_supplier()
         # mocking that we have applied
         self._data_api_client.find_brief_responses.return_value = {
             "briefResponses": [{"lazy": "mock"}],
         }
         brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert_equal(200, res.status_code)
+        document = html.fromstring(res.get_data(as_text=True))
+
+        self._assert_view_application(document, brief_id)
+
+    def test_supplier_applied_view_application_for_closed_opportunity(self):
+        self.login_as_supplier()
+        # mocking that we have applied
+        self._data_api_client.find_brief_responses.return_value = {
+            "briefResponses": [{"lazy": "mock"}],
+        }
+        brief = self.brief.copy()
+        brief['briefs']['status'] = "closed"
+        self._data_api_client.get_brief.return_value = brief
+        brief_id = brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
         document = html.fromstring(res.get_data(as_text=True))


### PR DESCRIPTION
Part 1 bug fix for this: https://www.pivotaltracker.com/story/show/128509823

The "View your response" link was only being shown on the opportunity page while the opportunity is live.  Suppliers need to revisit their responses after the opportunity has closed too.

This will need to be released AFTER the supplier app fix (coming soon!), as otherwise the shiny new link here will 404.