### PR TITLE
Generate csv files using dmutils

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -16,6 +16,7 @@ from ...helpers.buyers_helpers import (
 
 from dmapiclient import HTTPError
 from dmutils.dates import get_publishing_dates
+from dmutils import csv_generator
 
 
 @buyers.route('/buyers')
@@ -314,25 +315,8 @@ def download_brief_responses(framework_slug, lot_slug, brief_id):
                     row.append(brief_response.get(key))
             csv_rows.append(row)
 
-    def iter_csv(rows):
-        class Line(object):
-            def __init__(self):
-                self._line = None
-
-            def write(self, line):
-                self._line = line
-
-            def read(self):
-                return self._line
-
-        line = Line()
-        writer = unicodecsv.writer(line, lineterminator='\n')
-        for row in rows:
-            writer.writerow(row)
-            yield line.read()
-
     return Response(
-        iter_csv(csv_rows),
+        csv_generator.iter_csv(csv_rows),
         mimetype='text/csv',
         headers={
             "Content-Disposition": "attachment;filename=responses-to-requirements-{}.csv".format(brief['id']),

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.4.0#egg=digitalmarketplace-utils==21.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@21.6.0#egg=digitalmarketplace-utils==21.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.2.0#egg=digitalmarketplace-apiclient==5.2.0
 

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -1964,15 +1964,13 @@ class TestDownloadBriefResponsesCsv(BaseApplicationTest):
         self.login_as_buyer()
         res = self.client.get(self.url)
         page = res.get_data(as_text=True)
-        lines = page.split('\n')
-
+        lines = page.splitlines()
         # There are only the two eligible responses included
-        assert len(lines) == 4
+        assert len(lines) == 3
         assert lines[0] == "Supplier,Date the specialist can start work,Day rate,Nice1,Nice2,Nice3,Email address"
         # The response with two nice-to-haves is sorted to above the one with only one
         assert lines[1] == "Kev's Pies,A week Friday,£3.50,False,True,True,test2@email.com"
         assert lines[2] == "Kev's Butties,Next Tuesday,£1.49,True,False,False,test1@email.com"
-        assert lines[-1] == ""
 
     def test_download_brief_responses_for_brief_without_nice_to_haves(self, data_api_client):
         data_api_client.get_framework.return_value = api_stubs.framework(
@@ -2013,14 +2011,13 @@ class TestDownloadBriefResponsesCsv(BaseApplicationTest):
         self.login_as_buyer()
         res = self.client.get(self.url)
         page = res.get_data(as_text=True)
-        lines = page.split('\n')
+        lines = page.splitlines()
 
-        assert len(lines) == 4
+        assert len(lines) == 3
         assert lines[0] == "Supplier,Date the specialist can start work,Day rate,Nice1,Nice2,Nice3,Email address"
         # The values with internal commas are surrounded by quotes, and all other characters appear as in the data
         assert lines[1] == 'Kev\'s \'Pies,&quot;A week Friday&rdquot;,&euro;3.50,False,True,True,"te,st2@email.com"'
         assert lines[2] == '"K,ev’s ""Bu,tties",❝Next — Tuesday❞,"¥1.49,",True,False,False,test1@email.com'
-        assert lines[-1] == ""
 
     def test_404_if_brief_does_not_belong_to_buyer(self, data_api_client):
         data_api_client.get_framework.return_value = api_stubs.framework(


### PR DESCRIPTION
Part of this [story](https://www.pivotaltracker.com/story/show/124104161) on Pivotal.

The logic for creating csv files was extracted to dmutils as it's shared by the buyer frontend and the admin frontend.

PR for the logic being added to dmutils is [here](https://github.com/alphagov/digitalmarketplace-utils/pull/278) and will need merging before tests go green here.