### PR TITLE
Update apiclient to latest

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -351,7 +351,7 @@ def publish_brief(framework_slug, lot_slug, brief_id):
     if request.method == 'POST':
         if unanswered_required > 0:
             abort(400, 'There are still unanswered required questions')
-        data_api_client.update_brief_status(brief_id, 'live', brief_user_name)
+        data_api_client.publish_brief(brief_id, brief_user_name)
         return redirect(
             # the 'published' parameter is for tracking this request by analytics
             url_for('.view_brief_overview', framework_slug=brief['frameworkSlug'], lot_slug=brief['lotSlug'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ werkzeug==0.10.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.6.0#egg=digitalmarketplace-utils==21.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@5.2.0#egg=digitalmarketplace-apiclient==5.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.3#egg=digitalmarketplace-apiclient==6.3.3
 
 # For Cloud Foundry
 cffi==1.5.2

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -916,7 +916,7 @@ class TestPublishBrief(BaseApplicationTest):
         res = self.client.post("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
                                "digital-specialists/1234/publish")
         assert res.status_code == 302
-        assert data_api_client.update_brief_status.called
+        assert data_api_client.publish_brief.called
         assert res.location == "http://localhost/buyers/frameworks/digital-outcomes-and-specialists/" \
                                "requirements/digital-specialists/1234?published=true"
 
@@ -935,7 +935,7 @@ class TestPublishBrief(BaseApplicationTest):
         res = self.client.post("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
                                "digital-specialists/1234/publish")
         assert res.status_code == 400
-        assert not data_api_client.update_brief_status.called
+        assert not data_api_client.publish_brief.called
 
     def test_404_if_brief_does_not_belong_to_user(self, data_api_client):
         self.login_as_buyer()


### PR DESCRIPTION
Updating the apiclient lets us get rid of a bunch of dead code in the API.

The jump from 5.x to 6.x gets rid of the `update_brief_status` method in favour of `publish_brief`.

[See here for more info](https://github.com/alphagov/digitalmarketplace-apiclient/pull/31).