### PR TITLE
Feature flag for new supplier flow

### DIFF
--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -70,16 +70,36 @@
     </div>
   </div>
 {% elif brief.status == 'live' %}
-  <div class="grid-row">
-    <div class="column-one-third">
-      {% with
-         url = "/suppliers/opportunities/{}/responses/create".format(brief.id),
-         label = "Start application"
-      %}
-        {% include "toolkit/link-button.html" %}
-      {% endwith %}
+  {% if 'NEW_SUPPLIER_FLOW' is active_feature %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <h2 class="summary-item-heading">Apply for this opportunity</h2>
+        <p class="dmspeak">To apply, you must give evidence for all the essential and nice-to-have skills and experience you have.</p>
+      </div>
     </div>
-  </div>
+    <div class="grid-row">
+      <div class="column-one-third">
+        {% with
+           url = "/suppliers/opportunities/{}/responses/create".format(brief.id),
+           label = "Apply",
+           advice = True
+        %}
+          {% include "toolkit/link-button.html" %}
+        {% endwith %}
+      </div>
+    </div>
+  {% else %}
+    <div class="grid-row">
+      <div class="column-one-third">
+        {% with
+           url = "/suppliers/opportunities/{}/responses/create".format(brief.id),
+           label = "Start application"
+        %}
+          {% include "toolkit/link-button.html" %}
+        {% endwith %}
+      </div>
+    </div>
+  {% endif %}
 {% endif %}
 
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.1.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.2.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.3.0"
   }

--- a/config.py
+++ b/config.py
@@ -63,6 +63,7 @@ class Config(object):
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = False
 
     # LOGGING
     DM_LOG_LEVEL = 'DEBUG'

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -485,6 +485,36 @@ class TestBriefPage(BaseApplicationTest):
 
         self._assert_view_application(document, brief_id)
 
+    def test_new_supplier_flow_feature_flag_shows_correct_message_and_button_when_on(self):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = True
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert_equal(200, res.status_code)
+        text = res.get_data(as_text=True)
+        document = html.fromstring(text)
+
+        message = "To apply, you must give evidence for all the essential and nice-to-have " \
+                  "skills and experience you have."
+        button = document.xpath('//*[@class="link-button-with-advice"]')[0]
+
+        assert message in text
+        assert button.text == 'Apply'
+
+    def test_new_supplier_flow_feature_flag_does_not_show_message_when_off(self):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert_equal(200, res.status_code)
+        text = res.get_data(as_text=True)
+        document = html.fromstring(text)
+
+        message = "To apply, you must give evidence for all the essential and nice-to-have " \
+                  "skills and experience you have."
+        button = document.xpath('//*[@class="link-button"]')[0]
+
+        assert message not in text
+        assert button.text == 'Start application'
+
 
 class TestCatalogueOfBriefsPage(BaseApplicationTest):
     def setup(self):


### PR DESCRIPTION
For [this story on Pivotal](https://www.pivotaltracker.com/story/show/129838641).

This feature flag will render a new message and button before a supplier starts applying for a brief when turned on. It's currently only set in the base config and can be turned on in different environments when needed.

More feature flags will be needed in the supplier app, and the api when the actual new flow is being developed. This flag is in the buyer app, and clicking the button to start an application takes you to the supplier app. Therefore this flag can only be used for this message, which is a bit weird.

Feature flag not activated:
<img width="1440" alt="screen shot 2016-10-21 at 14 38 21" src="https://cloud.githubusercontent.com/assets/13836290/19600251/2027f0ce-979c-11e6-95d9-58d10d032270.png">

Feature flag activated:
<img width="1440" alt="screen shot 2016-10-21 at 14 37 34" src="https://cloud.githubusercontent.com/assets/13836290/19600258/285fec24-979c-11e6-8d8c-d0befaf7e905.png">

