### PR TITLE
Change two flows feature flag to true for QA

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,7 +63,7 @@ class Config(object):
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = False
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = True
 
     # LOGGING
     DM_LOG_LEVEL = 'DEBUG'

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -413,7 +413,7 @@ class TestBriefPage(BaseApplicationTest):
         assert len(document.xpath(
             '//a[@href="{0}"][contains(normalize-space(text()), normalize-space("{1}"))]'.format(
                 "/suppliers/opportunities/{}/responses/create".format(brief_id),
-                "Apply",
+                "Start application",
             )
         )) == 1
 
@@ -427,6 +427,7 @@ class TestBriefPage(BaseApplicationTest):
         )) == 1
 
     def test_unauthenticated_start_application(self):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
@@ -435,6 +436,7 @@ class TestBriefPage(BaseApplicationTest):
         self._assert_start_application(document, brief_id)
 
     def test_buyer_start_application(self):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         self.login_as_buyer()
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
@@ -444,6 +446,7 @@ class TestBriefPage(BaseApplicationTest):
         self._assert_start_application(document, brief_id)
 
     def test_supplier_start_application(self):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         self.login_as_supplier()
         # mocking that we haven't applied
         self._data_api_client.find_brief_responses.return_value = {

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -413,7 +413,7 @@ class TestBriefPage(BaseApplicationTest):
         assert len(document.xpath(
             '//a[@href="{0}"][contains(normalize-space(text()), normalize-space("{1}"))]'.format(
                 "/suppliers/opportunities/{}/responses/create".format(brief_id),
-                "Start application",
+                "Apply",
             )
         )) == 1
 


### PR DESCRIPTION
This is turning on the feature flag from a recent PR [here](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/394).

This is so it can be QA'd by Andrew. It will need switching off again with another PR before the buyer app is released to staging/prod.