### PR TITLE
Turn feature flag on for preview and staging

### DIFF
--- a/config.py
+++ b/config.py
@@ -119,11 +119,11 @@ class Live(Config):
 
 
 class Preview(Live):
-    pass
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-10-26')
 
 
 class Staging(Live):
-    pass
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-10-26')
 
 
 class Production(Live):


### PR DESCRIPTION
For [this story on pivotal](https://www.pivotaltracker.com/story/show/129838641).

Turns the flag on in preview and staging so it can be signed off before it goes live on production.