### PR TITLE
[#131733667] Content loader to support jinja templating

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -26,7 +26,6 @@ $path: "/static/images/";
 @import "toolkit/_buttons.scss";
 @import "toolkit/_contact-details.scss";
 @import "toolkit/_document.scss";
-@import "toolkit/_framework-notice.scss";
 @import "toolkit/_grids.scss";
 @import "toolkit/_instruction-list.scss";
 @import "toolkit/_link-button.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -18,6 +18,7 @@ $path: "/static/images/";
 
 /* Blocks shared between multiple selectors */
 @import "shared_placeholders/_temporary-messages.scss";
+@import "shared_placeholders/_dm-typography.scss";
 
 // Digtial Marketplace Front-end toolkit styles
 @import "toolkit/_breadcrumb.scss";

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -445,7 +445,7 @@ def add_supplier_question(framework_slug, lot_slug, brief_id):
     if brief["status"] != "live":
         abort(404)
 
-    content = content_loader.get_manifest(brief['frameworkSlug'], "clarification_question")
+    content = content_loader.get_manifest(brief['frameworkSlug'], "clarification_question").filter({})
     section = content.get_section(content.get_next_editable_section_id())
     update_data = section.get_data(request.form)
 

--- a/app/templates/buyers/_base_edit_question_page.html
+++ b/app/templates/buyers/_base_edit_question_page.html
@@ -41,7 +41,7 @@
           {% else %}
             {% if question.question_advice %}
               <span class="question-advice">
-                {{ question.question_advice|markdown }}
+                {{ question.question_advice }}
               </span>
             {% endif %}
             {% for question in question.questions %}

--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -41,7 +41,7 @@
     {% if section.description %}
       <div class="column-two-thirds">
         <div class="section-description">
-          {{ section.description|markdown }}
+          {{ section.description }}
         </div>
       </div>
     {% endif %}

--- a/app/templates/macros/toolkit_forms.html
+++ b/app/templates/macros/toolkit_forms.html
@@ -1,7 +1,7 @@
 {% macro text(question_content, data, errors) -%}
   {%
     with
-    question=question_content.question|markdown,
+    question=question_content.question,
     question_advice=question_content.question_advice,
     hint=question_content.hint,
     optional=question_content.optional,
@@ -16,7 +16,7 @@
 {% macro textbox_large(question_content, data, errors) -%}
   {%
     with
-    question=question_content.question|markdown,
+    question=question_content.question,
     question_advice=question_content.question_advice,
     hint=question_content.hint,
     optional=question_content.optional,
@@ -35,7 +35,7 @@
     with
     name=question_content.id,
     number_of_items=question_content.get('number_of_items', 10),
-    question=question_content.question|markdown,
+    question=question_content.question,
     question_advice=question_content.question_advice,
     hint=question_content.hint,
     optional=question_content.optional,
@@ -51,7 +51,7 @@
   {%
     with
     name=question_content.id,
-    question=question_content.question|markdown,
+    question=question_content.question,
     question_advice=question_content.question_advice,
     hint=question_content.hint,
     optional=question_content.optional,
@@ -70,7 +70,7 @@
   {%
     with
     name=question_content.id,
-    question=question_content.question|markdown,
+    question=question_content.question,
     question_advice=question_content.question_advice,
     hint=question_content.hint,
     optional=question_content.optional,
@@ -90,7 +90,7 @@
   {%
     with
     name=question_content.id,
-    question=question_content.question|markdown,
+    question=question_content.question,
     question_advice=question_content.question_advice,
     hint=question_content.hint,
     optional=question_content.optional,
@@ -134,7 +134,7 @@
     unit_position=question_content.unit_position,
     unit=question_content.unit,
     smaller=True,
-    question=question_content.question|markdown,
+    question=question_content.question,
     question_advice=question_content.question_advice,
     hint=question_content.hint,
     optional=question_content.optional,

--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,8 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v17.2.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v18.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v3.3.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v4.0.2"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ unicodecsv==0.14.1
 werkzeug==0.10.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@21.6.0#egg=digitalmarketplace-utils==21.6.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@1.2.0#egg=digitalmarketplace-content-loader==1.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.3#egg=digitalmarketplace-apiclient==6.3.3
 
 # For Cloud Foundry

--- a/tests/app/views/test_buyers.py
+++ b/tests/app/views/test_buyers.py
@@ -495,10 +495,10 @@ class TestEditBriefSubmission(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
         assert document.xpath('//h1')[0].text_content().strip() == "Required 3"
         assert document.xpath(
-            '//*[@id="required3_1"]//span[contains(@class, "question-heading")]/p'
+            '//*[@id="required3_1"]//span[contains(@class, "question-heading")]'
         )[0].text_content().strip() == "Required 3_1"
         assert document.xpath(
-            '//*[@id="required3_2"]//span[contains(@class, "question-heading")]/p'
+            '//*[@id="required3_2"]//span[contains(@class, "question-heading")]'
         )[0].text_content().strip() == "Required 3_2"
 
     def test_404_if_brief_does_not_belong_to_user(self, data_api_client):

--- a/tests/unit/test_service_presenters.py
+++ b/tests/unit/test_service_presenters.py
@@ -24,7 +24,7 @@ class TestService(unittest.TestCase):
         self.fixture = _get_fixture_data()
         self.fixture = self.fixture['services']
         self.service = Service(
-            self.fixture, content_loader.get_builder('g-cloud-6', 'display_service')
+            self.fixture, content_loader.get_builder('g-cloud-6', 'display_service').filter({})
         )
 
     def tearDown(self):
@@ -47,17 +47,17 @@ class TestService(unittest.TestCase):
 
     def test_Service_works_if_supplierName_is_not_set(self):
         del self.fixture['supplierName']
-        self.service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'))
+        self.service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service').filter({}))
         self.assertFalse(hasattr(self.service, 'supplierName'))
 
     def test_Service_works_if_serviceFeatures_is_not_set(self):
         del self.fixture['serviceFeatures']
-        self.service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'))
+        self.service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service').filter({}))
         self.assertFalse(hasattr(self.service, 'features'))
 
     def test_Service_works_if_serviceBenefits_is_not_set(self):
         del self.fixture['serviceBenefits']
-        self.service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'))
+        self.service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service').filter({}))
         self.assertFalse(hasattr(self.service, 'benefits'))
 
     def test_features_attributes_are_correctly_set(self):
@@ -70,7 +70,7 @@ class TestService(unittest.TestCase):
 
     def test_attributes_are_correctly_set(self):
         service = Service(
-            self.fixture, content_loader.get_builder('g-cloud-6', 'display_service')
+            self.fixture, content_loader.get_builder('g-cloud-6', 'display_service').filter({'lot': 'iaas'})
         )
         self.assertEquals(
             service.attributes[0]['name'],
@@ -87,7 +87,7 @@ class TestService(unittest.TestCase):
 
     def test_the_support_attribute_group_is_not_there_if_no_attributes(self):
         del self.fixture['openStandardsSupported']
-        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'))
+        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service').filter({}))
         for group in service.attributes:
             if group['name'] == 'Open standards':
                 self.fail("Support group should not be found")
@@ -95,7 +95,7 @@ class TestService(unittest.TestCase):
     def test_only_attributes_with_a_valid_type_are_added_to_groups(self):
         invalidValue = (u'Manuals provided', u'CMS training')
         self.fixture['onboardingGuidance'] = invalidValue
-        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'))
+        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service').filter({}))
         for group in service.attributes:
             if (
                 (group['name'] == 'External interface protection') and
@@ -104,7 +104,7 @@ class TestService(unittest.TestCase):
                 self.fail("Attribute with tuple value should not be in group")
 
     def test_attributes_with_assurance_in_the_fields_add_it_correctly(self):
-        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'))
+        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service').filter({}))
         for group in service.attributes:
             if group['name'] == 'Data-in-transit protection':
                 for row in group['rows']:
@@ -124,7 +124,7 @@ class TestService(unittest.TestCase):
                         )
 
     def test_attributes_with_assurance_for_a_list_value_has_a_caveat(self):
-        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'))
+        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service').filter({}))
         for group in service.attributes:
             if group['name'] == 'Asset protection and resilience':
                 for row in group['rows']:


### PR DESCRIPTION
This pull request pulls in the latest content loader, frontend toolkit, and content (frameworks repo).
These are all breaking changes, so some fixes were needed.

- always calls `.filter` before displaying section data (this isn't strictly necessary anymore, but it's not a bad idea)
- stop using the `|markdown` filter in the frontend toolkit or the buyer templates
- fix test which expected the old markdown formatting

Everything should work as before, except now jinja templating (processed in the content-loader) will be supported by the buyer frontend.

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/131733667)