### PR TITLE
Replace in-app beta banner with new toolkit version

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -2,6 +2,11 @@
 
 .index-page {
 
+  h2 {
+    @include bold-27;
+    margin-bottom: $gutter;
+  }
+
   .browse-list {
     .browse-list-item {
       margin-bottom: 20px;
@@ -66,10 +71,6 @@
   }
 
   .supplier-messages {
-    h2 {
-      @include bold-27;
-      margin-bottom: $gutter;
-    }
 
     p {
       margin: 0;
@@ -149,11 +150,4 @@
       color: $light-blue-50;
     }
   }
-}
-
-.marketplace-homepage-subheading {
-
-  @include bold-27;
-  padding-bottom: 30px;
-
 }

--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -113,3 +113,47 @@
   }
 
 }
+
+.marketplace-homepage-heading {
+
+  background-color: $govuk-blue;
+  width: 100%;
+  margin: -10px 0 40px;
+  padding: 0 0 20px;
+  color: white;
+
+  h1 {
+    @extend %site-width-container;
+    @include bold-48;
+    padding-top: 7px;
+    padding-bottom: 13px;
+  }
+
+  .phase-banner {
+    border-bottom: 0px;
+
+    .phase-tag {
+      margin-left: 3px;
+    }
+  }
+
+  .phase-banner p {
+    margin: -6px 0 10px;
+    color: white;
+
+    a, a:visited {
+        color: $white;
+      }
+
+    a:hover, a:active {
+      color: $light-blue-50;
+    }
+  }
+}
+
+.marketplace-homepage-subheading {
+
+  @include bold-27;
+  padding-bottom: 30px;
+
+}

--- a/app/assets/scss/_phase_banner.scss
+++ b/app/assets/scss/_phase_banner.scss
@@ -1,6 +1,0 @@
-@import "design-patterns/_alpha-beta.scss";
-
-.phase-banner  {
-  @include phase-banner(beta);
-  @extend %site-width-container;
-}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -31,6 +31,7 @@ $path: "/static/images/";
 @import "toolkit/_link-button.scss";
 @import "toolkit/_notification-banners.scss";
 @import "toolkit/_page-headings.scss";
+@import "toolkit/_phase-banner.scss";
 @import "toolkit/_secondary-action-link.scss";
 @import "toolkit/_service-id.scss";
 @import "toolkit/_temporary-message.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -1,5 +1,4 @@
 // GOVUK Front-end toolkit styles
-@import "_phase_banner.scss";
 @import "_grid_layout.scss";
 @import "_typography.scss";
 @import "_url-helpers.scss";
@@ -73,50 +72,6 @@ $path: "/static/images/";
   display: block;
   @include core-19;
   margin: (1.5 * $gutter) 0 (2 * $gutter);
-}
-
-.marketplace-homepage-heading {
-
-  background-color: $govuk-blue;
-  width: 100%;
-  margin: -10px 0 40px;
-  padding: 0 0 20px;
-  color: white;
-
-  h1 {
-    @extend %site-width-container;
-    @include bold-48;
-    padding-top: 7px;
-    padding-bottom: 13px;
-  }
-
-  .phase-banner {
-    border-bottom: 0px;
-
-    .phase-tag {
-      margin-left: 3px;
-    }
-  }
-
-  .phase-banner p {
-    margin: -6px 0 10px;
-    color: white;
-
-    a, a:visited {
-        color: $white;
-      }
-
-    a:hover, a:active {
-      color: $light-blue-50;
-    }
-  }
-}
-
-.marketplace-homepage-subheading {
-
-  @include bold-27;
-  padding-bottom: 30px;
-
 }
 
 .marketplace-paragraph {

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -18,7 +18,7 @@
     {% block top_header %}
     {% endblock %}
 {% block phase_banner %}
-  {% include "_phase_banner.html" %}
+  {% include "toolkit/phase-banner.html" %}
 {% endblock %}
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">

--- a/app/templates/_phase_banner.html
+++ b/app/templates/_phase_banner.html
@@ -1,6 +1,0 @@
-
-<div class="phase-banner">
-  <p>
-     <strong class="phase-tag">BETA</strong> This is a <a href="https://www.gov.uk/help/beta">beta service</a>  – please send your feedback to  <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-  </p>
-</div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,7 +4,7 @@
 
 {% block top_header %}
 <header class="marketplace-homepage-heading">
-  {% include "_phase_banner.html" %}
+  {% include "toolkit/phase-banner.html" %}
   <h1>
     Digital Marketplace
   </h1>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -23,7 +23,7 @@
 <div class="index-page grid-row">
 {% endif %}
   <div class="column-two-thirds">
-    <h2 class="marketplace-homepage-subheading">Find technology or people for digital projects in the public sector</h2>
+    <h2>Find technology or people for digital projects in the public sector</h2>
     {% with
       items = [
         {
@@ -64,7 +64,7 @@
 
   <div class="supplier-messages column-one-third">
     <aside role="complementary" aria-labelledby="supplier-message-heading">
-      <h2 id="supplier-message-heading">Sell services</h2>
+      <h2>Sell services</h2>
       <div class="padding-bottom-small">
           <p>
             <a href="/digital-outcomes-and-specialists/opportunities" class="top-level-link">

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v18.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v4.0.2"
   }


### PR DESCRIPTION
Replaces the in-app beta banner with the new toolkit version.

Also removes some of the classnames for the subheadings on the homepage. 
@tombye might have opinions about that.