### PR TITLE
Start page for suppliers

### DIFF
--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -80,7 +80,7 @@
     <div class="grid-row">
       <div class="column-one-third">
         {% with
-           url = "/suppliers/opportunities/{}/responses/create".format(brief.id),
+           url = "/suppliers/opportunities/{}/responses/start".format(brief.id),
            label = "Apply",
            advice = True
         %}

--- a/config.py
+++ b/config.py
@@ -95,6 +95,8 @@ class Test(Config):
     SHARED_EMAIL_KEY = "KEY"
     SECRET_KEY = "KEY"
 
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-10-26')
+
 
 class Development(Config):
     DEBUG = True
@@ -109,6 +111,8 @@ class Development(Config):
     DM_MANDRILL_API_KEY = "not_a_real_key"
     SECRET_KEY = "verySecretKey"
     SHARED_EMAIL_KEY = "very_secret"
+
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-10-26')
 
 
 class Live(Config):

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -377,13 +377,23 @@ class TestBriefPage(BaseApplicationTest):
 
         assert_equal(qa_link_text.strip(), "Ask a question")
 
-    def test_can_apply_to_live_brief(self):
+    def test_can_apply_to_live_brief_with_old_supplier_flow(self):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
         document = html.fromstring(res.get_data(as_text=True))
 
         apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/create"]'.format(brief_id))
+        assert len(apply_links) == 1
+
+    def test_can_apply_to_live_brief_with_new_supplier_flow(self):
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert_equal(200, res.status_code)
+        document = html.fromstring(res.get_data(as_text=True))
+
+        apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/start"]'.format(brief_id))
         assert len(apply_links) == 1
 
     def test_cannot_apply_to_closed_brief(self):


### PR DESCRIPTION
Part of this Pivotal story: [https://www.pivotaltracker.com/story/show/130018567](https://www.pivotaltracker.com/story/show/130018567)

The new supplier flow for responding to a brief is being built, with the majority of the functionality on the supplier app.

This PR is adding to the existing changes to the buyer app, and sending the supplier to the start page of the new supplier flow (if the feature is active).

It also activates the feature flag for the new flow in dev and test to make it easy to run and test the new flow locally.