### PR TITLE
Update utils version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@21.6.0#egg=digitalmarketplace-utils==21.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@22.0.0#egg=digitalmarketplace-utils==22.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.3#egg=digitalmarketplace-apiclient==6.3.3
 


### PR DESCRIPTION
This is technically a breaking change because it removes the `|markdown` filter from jinja, which means we can't use it in our templates in this app anymore.

Fortunately, we've removed all uses of `|markdown` in this app, so there aren't any changes needed.