### PR TITLE
remove email from reset password token

### DIFF
--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -88,8 +88,7 @@ def send_reset_password_email():
 
             token = generate_token(
                 {
-                    "user": user.id,
-                    "email": user.email_address
+                    "user": user.id
                 },
                 current_app.config['SECRET_KEY'],
                 current_app.config['RESET_PASSWORD_SALT']

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -140,7 +140,7 @@ def send_reset_password_email():
 @main.route('/reset-password/<token>', methods=["GET"])
 def reset_password(token):
     decoded = decode_password_reset_token(token, data_api_client)
-    if decoded.get('error', None):
+    if 'error' in decoded:
         flash(decoded['error'], 'error')
         return redirect(url_for('.request_password_reset'))
 
@@ -156,7 +156,7 @@ def reset_password(token):
 def update_password(token):
     form = ChangePasswordForm()
     decoded = decode_password_reset_token(token, data_api_client)
-    if decoded.get('error', None):
+    if 'error' in decoded:
         flash(decoded['error'], 'error')
         return redirect(url_for('.request_password_reset'))
 
@@ -211,7 +211,7 @@ def submit_create_buyer_account():
             )
             url = url_for('main.create_user', encoded_token=token, _external=True)
             email_body = render_template("emails/create_buyer_user_email.html", url=url)
-            # print("CREATE ACCOUNT URL: {}".format(url))
+
             try:
                 send_email(
                     email_address,
@@ -258,7 +258,7 @@ def create_user(encoded_token):
             "auth/create-buyer-user-error.html",
             token=None), 400
 
-    user_json = data_api_client.get_user(email_address=token.get("email_address"))
+    user_json = data_api_client.get_user(email_address=token["email_address"])
 
     if not user_json:
         return render_template(
@@ -295,14 +295,14 @@ def submit_create_user(encoded_token):
                 "auth/create-user.html",
                 form=form,
                 token=encoded_token,
-                email_address=token.get('email_address')), 400
+                email_address=token['email_address']), 400
 
         try:
             user = data_api_client.create_user({
                 'name': form.name.data,
                 'password': form.password.data,
                 'phoneNumber': form.phone_number.data,
-                'emailAddress': token.get('email_address'),
+                'emailAddress': token['email_address'],
                 'role': 'buyer'
             })
 

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -249,7 +249,7 @@ def submit_create_buyer_account():
 def create_user(encoded_token):
     form = CreateUserForm()
 
-    token = decode_invitation_token(encoded_token, role='buyer')
+    token = decode_invitation_token(encoded_token)
     if token is None:
         current_app.logger.warning(
             "createuser.token_invalid: {encoded_token}",
@@ -277,8 +277,7 @@ def create_user(encoded_token):
 @main.route('/create-user/<string:encoded_token>', methods=["POST"])
 def submit_create_user(encoded_token):
     form = CreateUserForm()
-
-    token = decode_invitation_token(encoded_token, role='buyer')
+    token = decode_invitation_token(encoded_token)
     if token is None:
         current_app.logger.warning("createuser.token_invalid: {encoded_token}",
                                    extra={'encoded_token': encoded_token})

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -17,14 +17,9 @@
                         If the email address you've entered belongs to a Digital Marketplace account,
                         we'll send a link to reset the password.
 
-                        {% elif message == 'token_expired' %}
+                        {% elif message == 'token_expired' or message == 'token_invalid' %}
                         This password reset link has expired. Enter your email address and we’ll send you a new one.
                         Password reset links are only valid for 24 hours.
-
-                        {% elif message == 'token_invalid' %}
-                        This password reset link is invalid. Enter your email address and we’ll send you a new one.
-                        Password reset links are only valid for 24 hours.
-
                         {% else %}
                         {{ message }}
                         {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@22.0.0#egg=digitalmarketplace-utils==22.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@22.1.0#egg=digitalmarketplace-utils==22.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.3#egg=digitalmarketplace-apiclient==6.3.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@22.1.0#egg=digitalmarketplace-utils==22.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@23.0.0#egg=digitalmarketplace-utils==23.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@6.3.3#egg=digitalmarketplace-apiclient==6.3.3
 

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -8,6 +8,7 @@ from ...helpers import BaseApplicationTest
 from lxml import html, cssselect
 import mock
 from flask import session
+import pytest
 
 EMAIL_EMPTY_ERROR = "You must provide an email address"
 EMAIL_INVALID_ERROR = "You must provide a valid email address"
@@ -644,7 +645,7 @@ class TestCreateUser(BaseApplicationTest):
         assert res.location == 'http://localhost/create-user'
 
     @mock.patch('app.main.views.login.data_api_client')
-    def test_should_be_an_error_for_invalid_token_contents(self, data_api_client):
+    def test_invalid_token_contents_500s(self, data_api_client):
         token = generate_token(
             {
                 'this_is_not_expected': 1234
@@ -653,11 +654,10 @@ class TestCreateUser(BaseApplicationTest):
             self.app.config['INVITE_EMAIL_SALT']
         )
 
-        res = self.client.get(
-            '/create-user/{}'.format(token)
-        )
-        assert res.status_code == 400
-        assert data_api_client.get_user.called is False
+        with pytest.raises(KeyError):
+            self.client.get(
+                '/create-user/{}'.format(token)
+            )
 
     def test_should_be_a_bad_request_if_token_expired(self):
         res = self.client.get(

--- a/tests/app/views/test_login.py
+++ b/tests/app/views/test_login.py
@@ -5,7 +5,7 @@ from dmapiclient import HTTPError
 from dmapiclient.audit import AuditTypes
 from dmutils.email import generate_token, MandrillException
 from ...helpers import BaseApplicationTest
-from lxml import html
+from lxml import html, cssselect
 import mock
 from flask import session
 
@@ -21,7 +21,7 @@ NEW_PASSWORD_CONFIRM_EMPTY_ERROR = "Please confirm your new password"
 USER_CREATION_EMAIL_ERROR = "Failed to send user creation email."
 PASSWORD_RESET_EMAIL_ERROR = "Failed to send password reset."
 
-TOKEN_CREATED_BEFORE_PASSWORD_LAST_CHANGED_ERROR = "This password reset link is invalid."
+TOKEN_CREATED_BEFORE_PASSWORD_LAST_CHANGED_ERROR = "This password reset link has expired."
 USER_LINK_EXPIRED_ERROR = "The link you used to create an account may have expired."
 
 
@@ -395,7 +395,11 @@ class TestResetPassword(BaseApplicationTest):
             }, follow_redirects=True)
 
             assert res.status_code == 200
-            assert TOKEN_CREATED_BEFORE_PASSWORD_LAST_CHANGED_ERROR in res.get_data(as_text=True)
+            document = html.fromstring(res.get_data(as_text=True))
+            error_selector = cssselect.CSSSelector('div.banner-destructive-without-action')
+            error_elements = error_selector(document)
+            assert len(error_elements) == 1
+            assert TOKEN_CREATED_BEFORE_PASSWORD_LAST_CHANGED_ERROR in error_elements[0].text_content()
 
     @mock.patch('app.main.views.login.send_email')
     def test_should_call_send_email_with_correct_params(


### PR DESCRIPTION
~~with dmutils 22.1.0 (https://github.com/alphagov/digitalmarketplace-utils/pull/287), it's no longer required - removing it means that we no longer store user email addresses unencrypted in logs and such. Yay!~~

encrypt all tokens.

depends on dmutils 23.0.0

- [ ] https://github.com/alphagov/digitalmarketplace-utils/pull/288

