### PR TITLE
Turn off new supplier flow feature flag on staging

### DIFF
--- a/config.py
+++ b/config.py
@@ -127,7 +127,7 @@ class Preview(Live):
 
 
 class Staging(Live):
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-10-26')
+    pass
 
 
 class Production(Live):


### PR DESCRIPTION
This is by request of Andrew so staging is the same as production and we can use it for testing the existing supplier flow.