### PR TITLE
Bump version to 5.1.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.1.3"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.1.4"
   }
 }


### PR DESCRIPTION
5.1.4 contains content changes to maximum number of suppliers content

For this story on Pivotal: https://www.pivotaltracker.com/story/show/134434563

This test won't go green until pull request on the frameworks is merged: alphagov/digitalmarketplace-frameworks#337

Note: this is a copy of https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/405 which was closed after getting out of sync with master.