### PR TITLE
Fix cryptography sub-interpreter error with mod_wsgi

### DIFF
--- a/.ebextensions/wsgigroup.config
+++ b/.ebextensions/wsgigroup.config
@@ -1,0 +1,26 @@
+commands:
+  create_app_hook_pre_dir:
+    command: "mkdir -p /opt/elasticbeanstalk/hooks/appdeploy/pre"
+    ignoreErrors: true
+
+  create_config_hook_pre_dir:
+    command: "mkdir -p /opt/elasticbeanstalk/hooks/configdeploy/pre"
+    ignoreErrors: true
+
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/pre/99wsgigroup.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      WSGI_FILE_PATH=$(/opt/elasticbeanstalk/bin/get-config container -k 'wsgi_staging_config')
+      echo 'WSGIApplicationGroup %{GLOBAL}' >> "$WSGI_FILE_PATH"
+  "/opt/elasticbeanstalk/hooks/configdeploy/pre/99wsgigroup.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      WSGI_FILE_PATH=$(/opt/elasticbeanstalk/bin/get-config container -k 'wsgi_staging_config')
+      echo 'WSGIApplicationGroup %{GLOBAL}' >> "$WSGI_FILE_PATH"


### PR DESCRIPTION
cryptography packages causes apache requests to fail for a few minutes after it's been invoked for the first time.

[cryptography docs](https://cryptography.io/en/latest/faq/#starting-cryptography-using-mod-wsgi-produces-an-internalerror-during-a-call-in-register-osrandom-engine) suggest setting global WSGIApplicationGroup to fix the issue.

This is also should be fixed in the next (seventeenth) release of cryptography.

mod_wsgi docs on the `%{GLOBAL}`:

> Any WSGI applications in the global application group will always be executed within the context
> of the first interpreter created by Python when it is initialised. Forcing a WSGI application to
> run within the first interpreter can be necessary when a third party C extension module for Python
> has used the simplified threading API for manipulation of the Python GIL and thus will not run
> correctly within any additional sub interpreters created by Python.

Since the option is set in the Elastic Beanstalk apache config we need to use the same approach we use for allowing Authorization headers in the api (alphagov/digitalmarketplace-api@336ae58).