### PR TITLE
Fix rendering of button and message for new supplier brief response flow

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from datetime import datetime
+
 from flask_login import current_user
 from flask import abort, current_app, render_template, request
+import flask_featureflags as feature
 
 from dmapiclient import APIError
 from dmcontent.content_loader import ContentNotFoundError
@@ -82,11 +85,18 @@ def get_brief_by_id(framework_slug, brief_id):
     brief_content = content_loader.get_builder('digital-outcomes-and-specialists', 'display_brief').filter(
         brief
     )
+
+    new_flow_brief = False
+    if feature.is_active('NEW_SUPPLIER_FLOW'):
+        new_flow_brief = (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
+                          <= datetime.strptime(brief['publishedAt'][0:10], "%Y-%m-%d"))
+
     return render_template(
         'brief.html',
         brief=brief,
         brief_responses=brief_responses,
         content=brief_content,
+        new_flow_brief=new_flow_brief,
     )
 
 

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -70,7 +70,7 @@
     </div>
   </div>
 {% elif brief.status == 'live' %}
-  {% if 'NEW_SUPPLIER_FLOW' is active_feature %}
+  {% if new_flow_brief %}
     <div class="grid-row">
       <div class="column-two-thirds">
         <h2 class="summary-item-heading">Apply for this opportunity</h2>

--- a/config.py
+++ b/config.py
@@ -95,7 +95,7 @@ class Test(Config):
     SHARED_EMAIL_KEY = "KEY"
     SECRET_KEY = "KEY"
 
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-10-26')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
 
 
 class Development(Config):
@@ -112,7 +112,7 @@ class Development(Config):
     SECRET_KEY = "verySecretKey"
     SHARED_EMAIL_KEY = "very_secret"
 
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-10-26')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
 
 
 class Live(Config):
@@ -123,7 +123,7 @@ class Live(Config):
 
 
 class Preview(Live):
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-10-26')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
 
 
 class Staging(Live):

--- a/config.py
+++ b/config.py
@@ -123,7 +123,7 @@ class Live(Config):
 
 
 class Preview(Live):
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
+    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-01')
 
 
 class Staging(Live):

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -407,10 +407,14 @@ class TestBriefPage(BaseApplicationTest):
 
     @staticmethod
     def _assert_start_application(document, brief_id):
+        message = document.xpath("//p[@class='dmspeak']/text()")[0]
+
+        assert message == "To apply, you must give evidence for all the essential and nice-to-have " \
+                  "skills and experience you have."
         assert len(document.xpath(
             '//a[@href="{0}"][contains(normalize-space(text()), normalize-space("{1}"))]'.format(
-                "/suppliers/opportunities/{}/responses/create".format(brief_id),
-                "Start application",
+                "/suppliers/opportunities/{}/responses/start".format(brief_id),
+                "Apply",
             )
         )) == 1
 

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -377,16 +377,6 @@ class TestBriefPage(BaseApplicationTest):
 
         assert_equal(qa_link_text.strip(), "Ask a question")
 
-    def test_can_apply_to_live_brief_with_legacy_supplier_flow(self):
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
-        brief_id = self.brief['briefs']['id']
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-        assert_equal(200, res.status_code)
-        document = html.fromstring(res.get_data(as_text=True))
-
-        apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/create"]'.format(brief_id))
-        assert len(apply_links) == 1
-
     def test_can_apply_to_live_brief(self):
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
@@ -482,63 +472,13 @@ class TestBriefPage(BaseApplicationTest):
         self._data_api_client.find_brief_responses.return_value = {
             "briefResponses": [{"lazy": "mock"}],
         }
-        brief = self.brief.copy()
-        brief['briefs']['status'] = "closed"
-        self._data_api_client.get_brief.return_value = brief
-        brief_id = brief['briefs']['id']
+        self.brief['briefs']['status'] = "closed"
+        brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
         document = html.fromstring(res.get_data(as_text=True))
 
         self._assert_view_application(document, brief_id)
-
-    def test_opportunity_page_shows_correct_apply_message_and_button(self):
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = '2000-01-01'
-        brief_id = self.brief['briefs']['id']
-
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-        assert_equal(200, res.status_code)
-
-        text = res.get_data(as_text=True)
-        document = html.fromstring(text)
-        message = "To apply, you must give evidence for all the essential and nice-to-have " \
-                  "skills and experience you have."
-        button = document.xpath('//*[@class="link-button-with-advice"]')[0]
-
-        assert message in text
-        assert button.text == 'Apply'
-
-    def test_opportunity_page_shows_correct_button_and_no_message_for_legacy_brief(self):
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = '2010-01-01'
-        self.brief['briefs']['publishedAt'] = '2000-01-01T12:00:00.000000Z'
-        brief_id = self.brief['briefs']['id']
-
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-        assert_equal(200, res.status_code)
-
-        text = res.get_data(as_text=True)
-        document = html.fromstring(text)
-        message = "To apply, you must give evidence for all the essential and nice-to-have " \
-                  "skills and experience you have."
-        button = document.xpath('//*[@class="link-button"]')[0]
-
-        assert message not in text
-        assert button.text == 'Start application'
-
-    def test_opportunity_page_shows_correct_button_and_no_message_when_in_legacy_supplier_flow(self):
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
-        brief_id = self.brief['briefs']['id']
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-        assert_equal(200, res.status_code)
-        text = res.get_data(as_text=True)
-        document = html.fromstring(text)
-
-        message = "To apply, you must give evidence for all the essential and nice-to-have " \
-                  "skills and experience you have."
-        button = document.xpath('//*[@class="link-button"]')[0]
-
-        assert message not in text
-        assert button.text == 'Start application'
 
 
 class TestCatalogueOfBriefsPage(BaseApplicationTest):

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -314,7 +314,7 @@ class TestBriefPage(BaseApplicationTest):
         assert_equal(section_heading.get('id'), 'opportunity-attributes-1')
         assert_equal(section_heading.text.strip(), 'Overview')
         assert_equal(start_date_key[0], 'Latest start date')
-        assert_equal(start_date_value[0], '01/03/2016')
+        assert_equal(start_date_value[0], '01/03/2017')
         assert_equal(contract_length_key[0], 'Expected contract length')
         assert_equal(contract_length_value[0], '4 weeks')
 
@@ -388,7 +388,6 @@ class TestBriefPage(BaseApplicationTest):
         assert len(apply_links) == 1
 
     def test_can_apply_to_live_brief(self):
-        self.brief['briefs']['publishedAt'] = "2016-12-25T12:00:00.000000Z"
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
@@ -398,50 +397,16 @@ class TestBriefPage(BaseApplicationTest):
         assert len(apply_links) == 1
 
     def test_cannot_apply_to_closed_brief(self):
-        brief = self.brief.copy()
-        brief['briefs']['status'] = "closed"
-        brief['briefs']['publishedAt'] = "2016-12-01T12:00:00.000000Z"
-        brief['briefs']['applicationsClosedAt'] = "2016-12-02T12:00:00.000000Z"
-        self._data_api_client.get_brief.return_value = brief
-        brief_id = brief['briefs']['id']
+        self.brief['briefs']['status'] = "closed"
+        self.brief['briefs']['applicationsClosedAt'] = "2016-12-15T11:08:28.054129Z"
+        brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
         document = html.fromstring(res.get_data(as_text=True))
 
         apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/start"]'.format(brief_id))
         assert len(apply_links) == 0
-        assert '2 December 2016' in document.xpath('//p[@class="banner-message"]')[0].text_content()
-
-    def test_cannot_apply_to_closed_legacy_brief(self):
-        brief = self.brief.copy()
-        brief['briefs']['status'] = "closed"
-        brief['briefs']['publishedAt'] = "2016-11-20T12:00:00.000000Z"
-        brief['briefs']['applicationsClosedAt'] = "2016-11-21T12:00:00.000000Z"
-        self._data_api_client.get_brief.return_value = brief
-        brief_id = brief['briefs']['id']
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-        assert_equal(200, res.status_code)
-        document = html.fromstring(res.get_data(as_text=True))
-
-        apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/create"]'.format(brief_id))
-        assert len(apply_links) == 0
-        assert '21 November 2016' in document.xpath('//p[@class="banner-message"]')[0].text_content()
-
-    def test_cannot_apply_to_closed_brief_with_legacy_supplier_flow(self):
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
-        brief = self.brief.copy()
-        brief['briefs']['status'] = "closed"
-        brief['briefs']['publishedAt'] = "2016-12-01T12:00:00.000000Z"
-        brief['briefs']['applicationsClosedAt'] = "2016-12-02T12:00:00.000000Z"
-        self._data_api_client.get_brief.return_value = brief
-        brief_id = brief['briefs']['id']
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-        assert_equal(200, res.status_code)
-        document = html.fromstring(res.get_data(as_text=True))
-
-        apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/create"]'.format(brief_id))
-        assert len(apply_links) == 0
-        assert '2 December 2016' in document.xpath('//p[@class="banner-message"]')[0].text_content()
+        assert '15 December 2016' in document.xpath('//p[@class="banner-message"]')[0].text_content()
 
     def test_dos_brief_specialist_role_displays_label(self):
         brief_id = self.brief['briefs']['id']
@@ -469,7 +434,6 @@ class TestBriefPage(BaseApplicationTest):
         )) == 1
 
     def test_unauthenticated_start_application(self):
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
@@ -478,7 +442,6 @@ class TestBriefPage(BaseApplicationTest):
         self._assert_start_application(document, brief_id)
 
     def test_buyer_start_application(self):
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         self.login_as_buyer()
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
@@ -488,7 +451,6 @@ class TestBriefPage(BaseApplicationTest):
         self._assert_start_application(document, brief_id)
 
     def test_supplier_start_application(self):
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         self.login_as_supplier()
         # mocking that we haven't applied
         self._data_api_client.find_brief_responses.return_value = {

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -271,8 +271,8 @@ class TestBriefPage(BaseApplicationTest):
 
     def test_dos_brief_has_important_dates(self):
         brief_id = self.brief['briefs']['id']
-        self.brief['briefs']['clarificationQuestionsClosedAt'] = "2016-03-10T11:08:28.054129Z"
-        self.brief['briefs']['applicationsClosedAt'] = "2016-03-11T11:08:28.054129Z"
+        self.brief['briefs']['clarificationQuestionsClosedAt'] = "2016-12-14T11:08:28.054129Z"
+        self.brief['briefs']['applicationsClosedAt'] = "2016-12-15T11:08:28.054129Z"
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
 
@@ -282,18 +282,18 @@ class TestBriefPage(BaseApplicationTest):
             '(//table[@class="summary-item-body"])[1]/tbody/tr')
 
         assert_equal(len(brief_important_dates), 3)
-        assert_true(brief_important_dates[0].xpath(
+        assert_equal(brief_important_dates[0].xpath(
             'td[@class="summary-item-field-first"]')[0].text_content().strip(), "Published")
-        assert_true(brief_important_dates[0].xpath(
-            'td[@class="summary-item-field"]')[0].text_content().strip(), "Thursday 25 February 2016")
-        assert_true(brief_important_dates[1].xpath(
+        assert_equal(brief_important_dates[0].xpath(
+            'td[@class="summary-item-field"]')[0].text_content().strip(), "Thursday 1 December 2016")
+        assert_equal(brief_important_dates[1].xpath(
             'td[@class="summary-item-field-first"]')[0].text_content().strip(), "Deadline for asking questions")
-        assert_true(brief_important_dates[1].xpath(
-            'td[@class="summary-item-field"]')[0].text_content().strip(), "Thursday 10 March 2016")
-        assert_true(brief_important_dates[2].xpath(
+        assert_equal(brief_important_dates[1].xpath(
+            'td[@class="summary-item-field"]')[0].text_content().strip(), "Wednesday 14 December 2016")
+        assert_equal(brief_important_dates[2].xpath(
             'td[@class="summary-item-field-first"]')[0].text_content().strip(), "Closing date for applications")
-        assert_true(brief_important_dates[2].xpath(
-            'td[@class="summary-item-field"]')[0].text_content().strip(), "Thursday 11 March 2016")
+        assert_equal(brief_important_dates[2].xpath(
+            'td[@class="summary-item-field"]')[0].text_content().strip(), "Thursday 15 December 2016")
 
     def test_dos_brief_has_at_least_one_section(self):
         brief_id = self.brief['briefs']['id']

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -388,6 +388,7 @@ class TestBriefPage(BaseApplicationTest):
         assert len(apply_links) == 1
 
     def test_can_apply_to_live_brief_with_new_supplier_flow(self):
+        self.brief['briefs']['publishedAt'] = "2016-12-25T12:00:00.000000Z"
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
@@ -498,20 +499,38 @@ class TestBriefPage(BaseApplicationTest):
 
         self._assert_view_application(document, brief_id)
 
-    def test_new_supplier_flow_feature_flag_shows_correct_message_and_button_when_on(self):
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = True
+    def test_new_supplier_flow_shows_correct_message_and_button_when_active_and_brief_published_after_flag_date(self):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = '2000-01-01'
         brief_id = self.brief['briefs']['id']
+
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert_equal(200, res.status_code)
+
         text = res.get_data(as_text=True)
         document = html.fromstring(text)
-
         message = "To apply, you must give evidence for all the essential and nice-to-have " \
                   "skills and experience you have."
         button = document.xpath('//*[@class="link-button-with-advice"]')[0]
 
         assert message in text
         assert button.text == 'Apply'
+
+    def test_new_supplier_flow_shows_correct_message_and_button_when_active_and_brief_published_before_flag_date(self):
+        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = '2010-01-01'
+        self.brief['briefs']['publishedAt'] = '2000-01-01T12:00:00.000000Z'
+        brief_id = self.brief['briefs']['id']
+
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert_equal(200, res.status_code)
+
+        text = res.get_data(as_text=True)
+        document = html.fromstring(text)
+        message = "To apply, you must give evidence for all the essential and nice-to-have " \
+                  "skills and experience you have."
+        button = document.xpath('//*[@class="link-button"]')[0]
+
+        assert message not in text
+        assert button.text == 'Start application'
 
     def test_new_supplier_flow_feature_flag_does_not_show_message_when_off(self):
         self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False

--- a/tests/app/views/test_marketplace.py
+++ b/tests/app/views/test_marketplace.py
@@ -377,7 +377,7 @@ class TestBriefPage(BaseApplicationTest):
 
         assert_equal(qa_link_text.strip(), "Ask a question")
 
-    def test_can_apply_to_live_brief_with_old_supplier_flow(self):
+    def test_can_apply_to_live_brief_with_legacy_supplier_flow(self):
         self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
@@ -387,7 +387,7 @@ class TestBriefPage(BaseApplicationTest):
         apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/create"]'.format(brief_id))
         assert len(apply_links) == 1
 
-    def test_can_apply_to_live_brief_with_new_supplier_flow(self):
+    def test_can_apply_to_live_brief(self):
         self.brief['briefs']['publishedAt'] = "2016-12-25T12:00:00.000000Z"
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
@@ -499,7 +499,7 @@ class TestBriefPage(BaseApplicationTest):
 
         self._assert_view_application(document, brief_id)
 
-    def test_new_supplier_flow_shows_correct_message_and_button_when_active_and_brief_published_after_flag_date(self):
+    def test_opportunity_page_shows_correct_apply_message_and_button(self):
         self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = '2000-01-01'
         brief_id = self.brief['briefs']['id']
 
@@ -515,7 +515,7 @@ class TestBriefPage(BaseApplicationTest):
         assert message in text
         assert button.text == 'Apply'
 
-    def test_new_supplier_flow_shows_correct_message_and_button_when_active_and_brief_published_before_flag_date(self):
+    def test_opportunity_page_shows_correct_button_and_no_message_for_legacy_brief(self):
         self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = '2010-01-01'
         self.brief['briefs']['publishedAt'] = '2000-01-01T12:00:00.000000Z'
         brief_id = self.brief['briefs']['id']
@@ -532,7 +532,7 @@ class TestBriefPage(BaseApplicationTest):
         assert message not in text
         assert button.text == 'Start application'
 
-    def test_new_supplier_flow_feature_flag_does_not_show_message_when_off(self):
+    def test_opportunity_page_shows_correct_button_and_no_message_when_in_legacy_supplier_flow(self):
         self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))

--- a/tests/fixtures/dos_brief_fixture.json
+++ b/tests/fixtures/dos_brief_fixture.json
@@ -2,7 +2,7 @@
   "briefs": {
     "backgroundInformation": "Testing the new platform.",
     "contractLength": "4 weeks",
-    "createdAt": "2016-02-25T10:47:23.126761Z",
+    "createdAt": "2016-11-25T10:47:23.126761Z",
     "essentialRequirements": [
       "Can write Capybara tests",
       "Is competent with Linux, Ruby and JavaScript"
@@ -29,13 +29,13 @@
       "Devops skills and experience"
     ],
     "organisation": "ByteMe IT",
-    "publishedAt": "2016-02-25T11:08:28.054129Z",
+    "publishedAt": "2016-12-01T11:09:28.054129Z",
     "questionAndAnswerSessionDetails": "session details",
     "specialistRole": "qualityAssurance",
-    "startDate": "01/03/2016",
+    "startDate": "01/03/2017",
     "status": "live",
     "title": "QA tester for next-gen web project",
-    "updatedAt": "2016-02-25T11:08:28.061327Z",
+    "updatedAt": "2016-12-01T11:08:28.061327Z",
     "users": [
       {
         "active": true,
@@ -46,7 +46,7 @@
       }
     ],
     "clarificationQuestions": [
-      {"question": "Why?", "answer": "Because", "publishedAt": "2016-02-26T00:00:00.000000Z"}
+      {"question": "Why?", "answer": "Because", "publishedAt": "2016-12-02T00:00:00.000000Z"}
     ]
   }
 }


### PR DESCRIPTION
Part of this story: [https://www.pivotaltracker.com/story/show/129843611](https://www.pivotaltracker.com/story/show/129843611)

There was an issue with the logic around deciding whether to render a link button that linked to the `/start` route or the `/create` route when viewing a brief and applying.

Previously, the page would have rendered the link-button pointing at the new `/start` view if the new supplier flow feature flag was active regardless of brief status. This is incorrect. If the flag is active, but a brief was published before it was made active, it should render the link-button pointing at the old `/create` view.

This will only need to be maintained for a couple of weeks after the new flow go's live, then it can be remove.

