### PR TITLE
support in ODS for missing keys in brief response

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -452,20 +452,26 @@ class DownloadBriefResponsesView(View):
 
             for question in questions:
                 if question.type == 'dynamic_list':
+                    if not brief.get(question.id):
+                        continue
+
                     for i, item in enumerate(response[question.id]):
                         row = sheet.get_row("{0}[{1}]".format(question.id, i))
                         # TODO this is stupid, fix it (key should not be hard coded)
                         row.write_cell(item.get('evidence') or '',
                                        stylename="ce1")
 
-                elif question.type == 'boolean_list':
+                elif question.type == 'boolean_list' and brief.get(question.id):
+                    if not brief.get(question.id):
+                        continue
+
                     for i, item in enumerate(response[question.id]):
                         row = sheet.get_row("{0}[{1}]".format(question.id, i))
                         row.write_cell(str(bool(item)).lower(),
                                        stylename="ce1")
 
                 else:
-                    sheet.get_row(question.id).write_cell(response[question.id],
+                    sheet.get_row(question.id).write_cell(response.get(question.id, ''),
                                                           stylename="ce1")
 
         return doc

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -2215,6 +2215,33 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
                 for j, response in enumerate(self.responses):
                     assert sheet.read_cell(j + 2, k) == response[question['id']][l].get('evidence', '')
 
+    def test_generate_ods_missing_with_dynamic_list(self):
+        questions = [
+            {'id': 'niceToHaveRequirements', 'name': 'Nice-to-have skills & evidence', 'type': 'dynamic_list'},
+            {'id': 'essentialRequirements', 'name': 'Essential skills & evidence', 'type': 'dynamic_list'},
+        ]
+
+        self.instance.get_questions = mock.Mock(return_value=[
+            Question(question) for question in questions
+        ])
+
+        self.brief['niceToHaveRequirements'] = []
+
+        del self.responses[0]['niceToHaveRequirements']
+        del self.responses[1]['niceToHaveRequirements']
+
+        doc = self.instance.generate_ods(self.brief, self.responses)
+
+        sheet = doc.sheet("Supplier evidence")
+
+        k = 0
+
+        for l, name in enumerate(self.brief['essentialRequirements']):
+            k += 1
+
+            for j, response in enumerate(self.responses):
+                assert sheet.read_cell(j + 2, k) == response['essentialRequirements'][l].get('evidence', '')
+
     def test_create_ods_response(self):
         context = {'brief': api_stubs.brief(status='closed')['briefs'],
                    'responses': mock.Mock(),


### PR DESCRIPTION
add support for missing keys in the brief response

will now skip over complex questions with no content and insert empty strings for other questions