### PR TITLE
key opportunities page of framework.framework instead of framework.slug

### DIFF
--- a/app/main/forms/brief_forms.py
+++ b/app/main/forms/brief_forms.py
@@ -22,11 +22,14 @@ class BriefSearchForm(Form):
         try:
             # popping this kwarg so we don't risk it getting fed to wtforms default implementation which might use it
             # as a data field if there were a name collision
-            framework = kwargs.pop("framework")
-            self._framework_slug = framework["slug"]
-            self.lot.choices = tuple((lot["slug"], lot["name"],) for lot in framework["lots"] if lot["allowsBrief"])
+            frameworks = kwargs.pop("frameworks")
+            self._framework_slug = ",".join(v["slug"] for v in frameworks)
+            seen = set()
+            self.lot.choices = tuple((v['slug'], v['name']) for f in frameworks
+                                     for v in f['lots'] if v['allowsBrief'] and
+                                     not (v['slug'] in seen or seen.add(v['slug'])))
         except KeyError:
-            raise TypeError("Expected keyword argument 'framework' with framework information")
+            raise TypeError("Expected keyword argument 'frameworks' with framework information")
         try:
             # data_api_client argument only needed so we can fit in with the current way the tests mock.patch the
             # the data_api_client directly on the view. would be nice to able to use the global reference to this

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -87,7 +87,7 @@ def terms_and_conditions():
 def get_brief_by_id(framework_slug, brief_id):
     briefs = data_api_client.get_brief(brief_id)
     brief = briefs.get('briefs')
-    if brief['status'] not in ['live', 'closed']:
+    if brief['status'] not in ['live', 'closed'] or brief['frameworkFramework'] != framework_slug:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
 
     if getattr(current_user, "supplier_id", None) is None:
@@ -101,7 +101,7 @@ def get_brief_by_id(framework_slug, brief_id):
         for index, question in enumerate(brief['clarificationQuestions'])
     ]
 
-    brief_content = content_loader.get_builder(framework_slug, 'display_brief').filter(
+    brief_content = content_loader.get_builder(brief['frameworkSlug'], 'display_brief').filter(
         brief
     )
 

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -83,11 +83,11 @@ def terms_and_conditions():
     return render_template('content/terms-and-conditions.html')
 
 
-@main.route('/<framework_slug>/opportunities/<brief_id>')
-def get_brief_by_id(framework_slug, brief_id):
+@main.route('/<framework_framework>/opportunities/<brief_id>')
+def get_brief_by_id(framework_framework, brief_id):
     briefs = data_api_client.get_brief(brief_id)
     brief = briefs.get('briefs')
-    if brief['status'] not in ['live', 'closed'] or brief['frameworkFramework'] != framework_slug:
+    if brief['status'] not in ['live', 'closed'] or brief['frameworkFramework'] != framework_framework:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
 
     if getattr(current_user, "supplier_id", None) is None:
@@ -119,15 +119,15 @@ def get_brief_by_id(framework_slug, brief_id):
     )
 
 
-@main.route('/<framework_slug>/opportunities')
-def list_opportunities(framework_slug):
+@main.route('/<framework_framework>/opportunities')
+def list_opportunities(framework_framework):
     frameworks = data_api_client.find_frameworks()['frameworks']
 
-    frameworks = [v for v in frameworks if v['framework'] == framework_slug]
+    frameworks = [v for v in frameworks if v['framework'] == framework_framework]
     frameworks.sort(key=lambda x: x['id'], reverse=True)
 
     if not frameworks:
-        abort(404, "No framework {}".format(framework_slug))
+        abort(404, "No framework {}".format(framework_framework))
 
     # disabling csrf protection as this should only ever be a GET request
     form = BriefSearchForm(request.args, frameworks=frameworks, data_api_client=data_api_client, csrf_enabled=False)

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -121,12 +121,15 @@ def get_brief_by_id(framework_slug, brief_id):
 
 @main.route('/<framework_slug>/opportunities')
 def list_opportunities(framework_slug):
-    framework = data_api_client.get_framework(framework_slug)['frameworks']
-    if not framework:
+    frameworks = data_api_client.find_frameworks()['frameworks']
+
+    frameworks = [v for v in frameworks if v['framework'] == framework_slug]
+
+    if not frameworks:
         abort(404, "No framework {}".format(framework_slug))
 
     # disabling csrf protection as this should only ever be a GET request
-    form = BriefSearchForm(request.args, framework=framework, data_api_client=data_api_client, csrf_enabled=False)
+    form = BriefSearchForm(request.args, frameworks=frameworks, data_api_client=data_api_client, csrf_enabled=False)
     if not form.validate():
         abort(404, "Invalid form data")
 
@@ -148,7 +151,7 @@ def list_opportunities(framework_slug):
         next_link_args.setlist("page", api_next_link_args.get("page") or ())
 
     return render_template('search/briefs.html',
-                           framework=framework,
+                           framework=frameworks[-1],
                            form=form,
                            filters=form.get_filters(),
                            filters_applied=form.filters_applied(),

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -124,6 +124,7 @@ def list_opportunities(framework_slug):
     frameworks = data_api_client.find_frameworks()['frameworks']
 
     frameworks = [v for v in frameworks if v['framework'] == framework_slug]
+    frameworks.sort(key=lambda x: x['id'], reverse=True)
 
     if not frameworks:
         abort(404, "No framework {}".format(framework_slug))

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -12,7 +12,7 @@
           "label": "Digital Marketplace"
       },
       {
-          "link": url_for('.list_opportunities', framework_slug=brief.frameworkSlug),
+          "link": url_for('.list_opportunities', framework_slug=brief.frameworkFramework),
           "label": "Supplier opportunities"
       }
     ]

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -12,7 +12,7 @@
           "label": "Digital Marketplace"
       },
       {
-          "link": url_for('.list_opportunities', framework_slug=brief.frameworkFramework),
+          "link": url_for('.list_opportunities', framework_framework=brief.frameworkFramework),
           "label": "Supplier opportunities"
       }
     ]

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -92,7 +92,7 @@
                   'allowed_statuses': ['live']
                 },
                 {
-                  'href': url_for("main.get_brief_by_id", framework_slug=brief.frameworkSlug, brief_id=brief.id),
+                  'href': url_for("main.get_brief_by_id", framework_slug=brief.frameworkFramework, brief_id=brief.id),
                   'text': 'View your published requirements',
                   'allowed_statuses': ['live', 'closed']
                 }

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -92,7 +92,7 @@
                   'allowed_statuses': ['live']
                 },
                 {
-                  'href': url_for("main.get_brief_by_id", framework_slug=brief.frameworkFramework, brief_id=brief.id),
+                  'href': url_for("main.get_brief_by_id", framework_framework=brief.frameworkFramework, brief_id=brief.id),
                   'text': 'View your published requirements',
                   'allowed_statuses': ['live', 'closed']
                 }

--- a/app/templates/search/_briefs_pagination.html
+++ b/app/templates/search/_briefs_pagination.html
@@ -2,7 +2,7 @@
   <ul class="previous-next-navigation">
     {% if prev_link_args %}
       <li class="previous">
-          <a href="{{ url_for('.list_opportunities', framework_slug=framework.framework, **prev_link_args) }}">
+          <a href="{{ url_for('.list_opportunities', framework_framework=framework.framework, **prev_link_args) }}">
               Previous <span class="visuallyhidden">page</span>
           </a>
       </li>
@@ -10,7 +10,7 @@
 
     {% if next_link_args %}
       <li class="next">
-          <a href="{{ url_for('.list_opportunities', framework_slug=framework.framework, **next_link_args) }}">
+          <a href="{{ url_for('.list_opportunities', framework_framework=framework.framework, **next_link_args) }}">
               Next <span class="visuallyhidden">page</span>
           </a>
       </li>

--- a/app/templates/search/_briefs_pagination.html
+++ b/app/templates/search/_briefs_pagination.html
@@ -2,7 +2,7 @@
   <ul class="previous-next-navigation">
     {% if prev_link_args %}
       <li class="previous">
-          <a href="{{ url_for('.list_opportunities', framework_slug=framework.slug, **prev_link_args) }}">
+          <a href="{{ url_for('.list_opportunities', framework_slug=framework.framework, **prev_link_args) }}">
               Previous <span class="visuallyhidden">page</span>
           </a>
       </li>
@@ -10,7 +10,7 @@
 
     {% if next_link_args %}
       <li class="next">
-          <a href="{{ url_for('.list_opportunities', framework_slug=framework.slug, **next_link_args) }}">
+          <a href="{{ url_for('.list_opportunities', framework_slug=framework.framework, **next_link_args) }}">
               Next <span class="visuallyhidden">page</span>
           </a>
       </li>

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -1,7 +1,7 @@
 {% for brief in briefs %}
 <div class="search-result">
     <h2 class="search-result-title">
-        <a href="{{ url_for('.get_brief_by_id', framework_slug=framework.slug, brief_id=brief.id) }}">{{ brief.title }}</a>
+        <a href="{{ url_for('.get_brief_by_id', framework_slug=framework.framework, brief_id=brief.id) }}">{{ brief.title }}</a>
     </h2>
 
     <ul class="search-result-important-metadata">
@@ -33,7 +33,7 @@
             </li>
         {% endif %}
     </ul>
-    
+
     <p class="search-result-excerpt">
         {{ brief.summary }}
     </p>

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -1,7 +1,7 @@
 {% for brief in briefs %}
 <div class="search-result">
     <h2 class="search-result-title">
-        <a href="{{ url_for('.get_brief_by_id', framework_slug=framework.framework, brief_id=brief.id) }}">{{ brief.title }}</a>
+        <a href="{{ url_for('.get_brief_by_id', framework_framework=framework.framework, brief_id=brief.id) }}">{{ brief.title }}</a>
     </h2>
 
     <ul class="search-result-important-metadata">

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -636,16 +636,41 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self.briefs = self._get_dos_brief_fixture_data(multi=True)
         self._data_api_client.find_briefs.return_value = self.briefs
 
-        self._data_api_client.get_framework.return_value = {'frameworks': {
-            'name': "Digital Outcomes and Specialists",
-            'slug': "digital-outcomes-and-specialists",
-            'lots': [
-                {'name': 'Lot 1', 'slug': 'lot-one', 'allowsBrief': True},
-                {'name': 'Lot 2', 'slug': 'lot-two', 'allowsBrief': False},
-                {'name': 'Lot 3', 'slug': 'lot-three', 'allowsBrief': True},
-                {'name': 'Lot 4', 'slug': 'lot-four', 'allowsBrief': True},
-            ]
-        }}
+        self._data_api_client.find_frameworks.return_value = {'frameworks': [
+            {
+                'name': "Digital Outcomes and Specialists 2",
+                'slug': "digital-outcomes-and-specialists-2",
+                'framework': "digital-outcomes-and-specialists",
+                'lots': [
+                    {'name': 'Lot 1', 'slug': 'lot-one', 'allowsBrief': True},
+                    {'name': 'Lot 2', 'slug': 'lot-two', 'allowsBrief': False},
+                    {'name': 'Lot 3', 'slug': 'lot-three', 'allowsBrief': True},
+                    {'name': 'Lot 4', 'slug': 'lot-four', 'allowsBrief': True},
+                ]
+            },
+            {
+                'name': "Digital Outcomes and Specialists",
+                'slug': "digital-outcomes-and-specialists",
+                'framework': "digital-outcomes-and-specialists",
+                'lots': [
+                    {'name': 'Lot 1', 'slug': 'lot-one', 'allowsBrief': True},
+                    {'name': 'Lot 2', 'slug': 'lot-two', 'allowsBrief': False},
+                    {'name': 'Lot 3', 'slug': 'lot-three', 'allowsBrief': True},
+                    {'name': 'Lot 4', 'slug': 'lot-four', 'allowsBrief': True},
+                ]
+            },
+            {
+                'name': "Foobar",
+                'slug': "foobar",
+                'framework': "foobar",
+                'lots': [
+                    {'name': 'Lot 1', 'slug': 'lot-one', 'allowsBrief': True},
+                    {'name': 'Lot 2', 'slug': 'lot-two', 'allowsBrief': False},
+                    {'name': 'Lot 3', 'slug': 'lot-three', 'allowsBrief': True},
+                    {'name': 'Lot 4', 'slug': 'lot-four', 'allowsBrief': True},
+                ]
+            }
+        ]}
 
     def teardown_method(self, method):
         self._data_api_client.stop()
@@ -655,12 +680,12 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        self._data_api_client.get_framework.assert_called_once_with("digital-outcomes-and-specialists")
+        self._data_api_client.find_frameworks.assert_called_once_with()
         regular_args = {
             k: v for k, v in iteritems(self._data_api_client.find_briefs.call_args[1]) if k not in ("status", "lot",)
         }
         assert regular_args == {
-            "framework": "digital-outcomes-and-specialists",
+            "framework": "digital-outcomes-and-specialists-2,digital-outcomes-and-specialists",
             "page": 1,
             "human": True,
         }
@@ -698,12 +723,12 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        self._data_api_client.get_framework.assert_called_once_with("digital-outcomes-and-specialists")
+        self._data_api_client.find_frameworks.assert_called_once_with()
         regular_args = {
             k: v for k, v in iteritems(self._data_api_client.find_briefs.call_args[1]) if k not in ("status", "lot",)
         }
         assert regular_args == {
-            "framework": "digital-outcomes-and-specialists",
+            "framework": "digital-outcomes-and-specialists-2,digital-outcomes-and-specialists",
             "page": 2,
             "human": True,
         }
@@ -755,12 +780,12 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        self._data_api_client.get_framework.assert_called_once_with("digital-outcomes-and-specialists")
+        self._data_api_client.find_frameworks.assert_called_once_with()
         regular_args = {
             k: v for k, v in iteritems(self._data_api_client.find_briefs.call_args[1]) if k not in ("status", "lot",)
         }
         assert regular_args == {
-            "framework": "digital-outcomes-and-specialists",
+            "framework": "digital-outcomes-and-specialists-2,digital-outcomes-and-specialists",
             "page": 1,
             "human": True,
         }
@@ -834,8 +859,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert '<li class="next">' not in page
 
     def test_catalogue_of_briefs_page_404_for_framework_that_does_not_exist(self):
-        self._data_api_client.get_framework.return_value = {'frameworks': {}}
         res = self.client.get('/digital-giraffes-and-monkeys/opportunities')
 
         assert res.status_code == 404
-        self._data_api_client.get_framework.assert_called_once_with('digital-giraffes-and-monkeys')
+        self._data_api_client.find_frameworks.assert_called_once_with()

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -638,6 +638,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
 
         self._data_api_client.find_frameworks.return_value = {'frameworks': [
             {
+                'id': 3,
                 'name': "Digital Outcomes and Specialists 2",
                 'slug': "digital-outcomes-and-specialists-2",
                 'framework': "digital-outcomes-and-specialists",
@@ -649,6 +650,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
                 ]
             },
             {
+                'id': 1,
                 'name': "Digital Outcomes and Specialists",
                 'slug': "digital-outcomes-and-specialists",
                 'framework': "digital-outcomes-and-specialists",
@@ -660,6 +662,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
                 ]
             },
             {
+                'id': 2,
                 'name': "Foobar",
                 'slug': "foobar",
                 'framework': "foobar",
@@ -669,7 +672,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
                     {'name': 'Lot 3', 'slug': 'lot-three', 'allowsBrief': True},
                     {'name': 'Lot 4', 'slug': 'lot-four', 'allowsBrief': True},
                 ]
-            }
+            },
         ]}
 
     def teardown_method(self, method):


### PR DESCRIPTION
this will switch the opportunities endpoints to use framework.framework instead of framework.slug ~, it cant be merged yet though, it needs a data migration and API changes to switch the value of framework from `dos` to `digital-outcomes-and-specialists` first~.

both endpoints now use the framework.framework slug instead of the framework.slug slug