### PR TITLE
Update fixtures as `frameworkFramework` is changing

### DIFF
--- a/tests/fixtures/dos_brief_fixture.json
+++ b/tests/fixtures/dos_brief_fixture.json
@@ -10,7 +10,7 @@
     "evaluationType": [
       "provide a case study or evidence of previous work"
     ],
-    "frameworkFramework": "dos",
+    "frameworkFramework": "digital-outcomes-and-specialists",
     "frameworkName": "Digital Outcomes and Specialists",
     "frameworkSlug": "digital-outcomes-and-specialists",
     "frameworkStatus": "live",

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -3,7 +3,7 @@
     {
       "clarificationQuestionsAreClosed":true,
       "status":"live",
-      "frameworkFramework":"dos",
+      "frameworkFramework":"digital-outcomes-and-specialists",
       "links":{
         "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists",
         "self":"http://localhost:5000/briefs/17"
@@ -51,7 +51,7 @@
       "id":4,
       "createdAt":"2016-02-12T16:30:55.808730Z",
       "clarificationQuestionsAreClosed":true,
-      "frameworkFramework":"dos",
+      "frameworkFramework":"digital-outcomes-and-specialists",
       "clarificationQuestionsClosedAt":"2016-03-15T00:00:00.000000Z",
       "lotSlug":"digital-specialists",
       "workingArrangements":"Work",


### PR DESCRIPTION
`frameworkFramework` will be changing from "dos" to "digital-outcomes-and-specialists" so have updated our fixtures to try and reduce inconsistencies across our apps.