### PR TITLE
Pass slug of newest live dos framework to index

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -47,8 +47,23 @@ def index():
             "framework {} status {}".format(framework.get('slug'), framework.get('status')))
         abort(500)
 
+    live_dos_frameworks = filter(
+        lambda framework: framework['framework'] == 'digital-outcomes-and-specialists'
+        and framework['status'] == 'live',
+        frameworks,
+    )
+
+    # Capture the slug for the most recent live framework. There will only be multiple if currently transitioning
+    # between frameworks and more than one has a `live` status.
+    dos_slug = sorted(
+        live_dos_frameworks,
+        reverse=True,
+        key=lambda framework: framework['id'],
+    )[0]['slug']
+
     return render_template(
         'index.html',
+        dos_slug=dos_slug,
         frameworks={framework['slug']: framework for framework in frameworks},
         temporary_message=temporary_message
     )

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -47,10 +47,12 @@ def index():
             "framework {} status {}".format(framework.get('slug'), framework.get('status')))
         abort(500)
 
-    live_dos_frameworks = filter(
-        lambda framework: framework['framework'] == 'digital-outcomes-and-specialists'
-        and framework['status'] == 'live',
-        frameworks,
+    live_dos_frameworks = list(
+        filter(
+            lambda framework: framework['framework'] == 'digital-outcomes-and-specialists'
+            and framework['status'] == 'live',
+            frameworks,
+        )
     )
 
     # Capture the slug for the most recent live framework. There will only be multiple if currently transitioning

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -55,11 +55,13 @@ def index():
 
     # Capture the slug for the most recent live framework. There will only be multiple if currently transitioning
     # between frameworks and more than one has a `live` status.
-    dos_slug = sorted(
-        live_dos_frameworks,
-        reverse=True,
-        key=lambda framework: framework['id'],
-    )[0]['slug']
+    dos_slug = None
+    if live_dos_frameworks:
+        dos_slug = sorted(
+            live_dos_frameworks,
+            reverse=True,
+            key=lambda framework: framework['id'],
+        )[0]['slug']
 
     return render_template(
         'index.html',

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,42 +22,61 @@
 {% endif %}
   <div class="column-two-thirds">
     <h2>Find technology or people for digital projects in the public sector</h2>
-    {% with
-      items = [
-        {
-          "link": url_for("dos.info_page_for_starting_a_brief", framework_slug=dos_slug, lot_slug='digital-specialists'),
-          "title": "Find an individual specialist",
-          "body": "eg a developer or user researcher",
-        },
-        {
-          "link": url_for("dos.info_page_for_starting_a_brief", framework_slug=dos_slug, lot_slug='digital-outcomes'),
-          "title": "Find a team to provide an outcome",
-          "body": "eg a booking system or accessibility audit",
-        },
-        {
-          "link": url_for("dos.info_page_for_starting_a_brief", framework_slug=dos_slug, lot_slug='user-research-participants'),
-          "title": "Find user research participants",
-          "body": "eg people from a specific user group to test your service",
-        },
-        {
-          "link": url_for("dos.studios_start_page", framework_slug=dos_slug),
-          "title": "Find a user research lab",
-          "body": "eg a room to conduct research sessions",
-        },
-        {
-          "link": "/g-cloud",
-          "title": "Find cloud technology and support",
-          "body": "eg web hosting or IT health checks",
-        },
-        {
-          "link": "/crown-hosting",
-          "title": "Buy physical datacentre space for legacy systems",
-          "body": "eg for services that can’t be migrated to the cloud",
-        },
-      ]
-    %}
-      {% include "toolkit/browse-list.html" %}
-    {% endwith %}
+      {% if dos_slug %}
+        {% with
+          items = [
+            {
+              "link": url_for("dos.info_page_for_starting_a_brief", framework_slug=dos_slug, lot_slug='digital-specialists'),
+              "title": "Find an individual specialist",
+              "body": "eg a developer or user researcher",
+            },
+            {
+              "link": url_for("dos.info_page_for_starting_a_brief", framework_slug=dos_slug, lot_slug='digital-outcomes'),
+              "title": "Find a team to provide an outcome",
+              "body": "eg a booking system or accessibility audit",
+            },
+            {
+              "link": url_for("dos.info_page_for_starting_a_brief", framework_slug=dos_slug, lot_slug='user-research-participants'),
+              "title": "Find user research participants",
+              "body": "eg people from a specific user group to test your service",
+            },
+            {
+              "link": url_for("dos.studios_start_page", framework_slug=dos_slug),
+              "title": "Find a user research lab",
+              "body": "eg a room to conduct research sessions",
+            },
+            {
+              "link": "/g-cloud",
+              "title": "Find cloud technology and support",
+              "body": "eg web hosting or IT health checks",
+            },
+            {
+              "link": "/crown-hosting",
+              "title": "Buy physical datacentre space for legacy systems",
+              "body": "eg for services that can’t be migrated to the cloud",
+            },
+          ]
+        %}
+          {% include "toolkit/browse-list.html" %}
+        {% endwith %}
+      {% else %}
+        {% with
+          items = [
+            {
+              "link": "/g-cloud",
+              "title": "Find cloud technology and support",
+              "body": "eg web hosting or IT health checks",
+            },
+            {
+              "link": "/crown-hosting",
+              "title": "Buy physical datacentre space for legacy systems",
+              "body": "eg for services that can’t be migrated to the cloud",
+            },
+          ]
+        %}
+          {% include "toolkit/browse-list.html" %}
+        {% endwith %}
+      {% endif %}
   </div>
 
   <div class="supplier-messages column-one-third">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -15,8 +15,6 @@
 
 {% block main_content %}
 
-{% set dos_slug = 'digital-outcomes-and-specialists' %}
-
 {% if 'account-created' in get_flashed_messages(category_filter=["flag"]) %}
 <div class="index-page grid-row" data-analytics="trackPageView" data-url="/vpv/?account-created=true">
 {% else %}

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -186,7 +186,6 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         _frameworks = []
 
         for index, framework_slug_and_status in enumerate(framework_slugs_and_statuses):
-
             framework_slug, framework_status = framework_slug_and_status
             _frameworks.append({
                 'framework': 'framework',
@@ -258,7 +257,6 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
         framework_slugs_and_statuses = [
             ('g-cloud-7', 'pending'),
-            ('digital-outcomes-and-specialists', 'live')
         ]
         framework_messages = [
             u"G‑Cloud 7 is closed for applications",


### PR DESCRIPTION
For this story on Pivotal: [https://www.pivotaltracker.com/story/show/139283877](https://www.pivotaltracker.com/story/show/139283877)

Currently the home page has links to create DOS opportunities for the different lots. The framework slug used in the url is hardcoded to `digital-outcomes-and-specialists`.

When DOS2 goes live this slug needs to be `digital-outcomes-and-specialists-2`.

This PR updates the buyer app to check for all live DOS frameworks and passes the slug of the most recent (judged by the greatest ID) to the index template to correctly render the links. This handles the edge case of when we have two DOS frameworks live (the short period when transitioning that DOS1 is live at the same time as DOS 2).

FUNCTIONAL TESTS:

Those on the master branch will break when we transition, but this is due to briefs that are created as part of the flow being on the DOS1 framework. Can easily be updated.

Those on the jenkins branch also break a bit. I'm investigating why...

UPDATE:

Functional tests will break on master and live only when DOS 1 is expired. They'll be fine of DOS1 and DOS2 are live. They break when DOS1 is expired due to a mix of being unable to create briefs on an expired framework, and hardcoded references to dos1 links (especially in the admin app). Should be fairly straightforward to fix, I've got a list on my machine of where/why they're breaking.