### PR TITLE
Link to correct call off contract and framework agreement on requirements page

### DIFF
--- a/app/assets/scss/_requirements-page.scss
+++ b/app/assets/scss/_requirements-page.scss
@@ -5,7 +5,7 @@
   padding-top: 25px;
 
   %meta-item {
-    margin-bottom: $gutter;
+    margin-bottom: 15px;
   }
 
   .framework-name {
@@ -18,7 +18,7 @@
 
   .sidebar-heading {
     @include bold-19;
-    margin-bottom: 5px;
+    margin-bottom: 0px;
   }
 
 }

--- a/app/assets/scss/_requirements-page.scss
+++ b/app/assets/scss/_requirements-page.scss
@@ -1,0 +1,24 @@
+// styles specific to requirements pages
+
+#requirements-meta {
+
+  padding-top: 25px;
+
+  %meta-item {
+    margin-bottom: $gutter;
+  }
+
+  .framework-name {
+    @extend %meta-item;
+  }
+
+  .sidebar-content {
+    @extend %meta-item;
+  }
+
+  .sidebar-heading {
+    @include bold-19;
+    margin-bottom: 5px;
+  }
+
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -67,6 +67,7 @@ $path: "/static/images/";
 @import "_supplier-a-to-z.scss";
 @import "_atoz_navigation.scss";
 @import "_error-pages.scss";
+@import "_requirements-page.scss";
 
 .return-to-top {
   display: block;

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -127,6 +127,9 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
     sections = content.summary(brief)
     delete_requested = True if request.args.get('delete_requested') else False
 
+    content_loader.load_messages(brief['frameworkSlug'], ['urls'])
+    call_off_contract_url = content_loader.get_message(brief['frameworkSlug'], 'urls', 'call_off_contract_url')
+
     completed_sections = {}
     for section in sections:
         required, optional = count_unanswered_questions([section])
@@ -149,6 +152,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
         completed_sections=completed_sections,
         step_sections=[section.step for section in sections if hasattr(section, 'step')],
         delete_requested=delete_requested,
+        call_off_contract_url=call_off_contract_url,
     ), 200
 
 

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -129,6 +129,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
 
     content_loader.load_messages(brief['frameworkSlug'], ['urls'])
     call_off_contract_url = content_loader.get_message(brief['frameworkSlug'], 'urls', 'call_off_contract_url')
+    framework_agreement_url = content_loader.get_message(brief['frameworkSlug'], 'urls', 'framework_agreement_url')
 
     completed_sections = {}
     for section in sections:
@@ -153,6 +154,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
         step_sections=[section.step for section in sections if hasattr(section, 'step')],
         delete_requested=delete_requested,
         call_off_contract_url=call_off_contract_url,
+        framework_agreement_url=framework_agreement_url,
     ), 200
 
 

--- a/app/templates/buyers/_requirements_meta.html
+++ b/app/templates/buyers/_requirements_meta.html
@@ -1,0 +1,8 @@
+<div id="requirements-meta">
+  <h2 class="sidebar-heading">Published</h2>
+  <p class="sidebar-content">{{ brief.publishedAt|dateformat }}</p>
+  <h2 class="sidebar-heading">Closing</h2>
+  <p class="sidebar-content">Tuesday 27 October 2017</p>
+  <h2 class="sidebar-heading">Framework</h2>
+  <p class="framework-name">{{ brief.frameworkName }}</p>
+</div>

--- a/app/templates/buyers/_requirements_meta.html
+++ b/app/templates/buyers/_requirements_meta.html
@@ -9,5 +9,5 @@
     <p class="sidebar-content">{{ brief.applicationsClosedAt|dateformat }}</p>
   {% endif %}
   <h2 class="sidebar-heading">Framework</h2>
-  <p class="framework-name">{{ brief.frameworkName }}</p>
+  <p class="framework-name"><a href="{{ framework_agreement_url }}">{{ brief.frameworkName }}</a></p>
 </div>

--- a/app/templates/buyers/_requirements_meta.html
+++ b/app/templates/buyers/_requirements_meta.html
@@ -1,8 +1,13 @@
 <div id="requirements-meta">
   <h2 class="sidebar-heading">Published</h2>
   <p class="sidebar-content">{{ brief.publishedAt|dateformat }}</p>
-  <h2 class="sidebar-heading">Closing</h2>
-  <p class="sidebar-content">Tuesday 27 October 2017</p>
+  {% if brief.status == 'closed' %}
+    <h2 class="sidebar-heading">Closed</h2>
+    <p class="sidebar-content">{{ brief.applicationsClosedAt|dateformat }}</p>
+  {% else %}
+    <h2 class="sidebar-heading">Closing</h2>
+    <p class="sidebar-content">{{ brief.applicationsClosedAt|dateformat }}</p>
+  {% endif %}
   <h2 class="sidebar-heading">Framework</h2>
   <p class="framework-name">{{ brief.frameworkName }}</p>
 </div>

--- a/app/templates/buyers/_requirements_meta.html
+++ b/app/templates/buyers/_requirements_meta.html
@@ -1,13 +1,8 @@
 <div id="requirements-meta">
   <h2 class="sidebar-heading">Published</h2>
   <p class="sidebar-content">{{ brief.publishedAt|dateformat }}</p>
-  {% if brief.status == 'closed' %}
-    <h2 class="sidebar-heading">Closed</h2>
-    <p class="sidebar-content">{{ brief.applicationsClosedAt|dateformat }}</p>
-  {% else %}
-    <h2 class="sidebar-heading">Closing</h2>
-    <p class="sidebar-content">{{ brief.applicationsClosedAt|dateformat }}</p>
-  {% endif %}
+  <h2 class="sidebar-heading">{% if brief.status == 'closed' %}Closed{% else %}Closing{% endif %}</h2>
+  <p class="sidebar-content">{{ brief.applicationsClosedAt|dateformat }}</p>
   <h2 class="sidebar-heading">Framework</h2>
   <p class="framework-name"><a href="{{ framework_agreement_url }}">{{ brief.frameworkName }}</a></p>
 </div>

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -161,7 +161,7 @@
                   'text': 'How to award a contract',
                 },
                 {
-                  'href': 'https://www.gov.uk/government/publications/digital-outcomes-and-specialists-call-off-contract',
+                  'href': call_off_contract_url,
                   'text': 'View the Digital Outcomes and Specialists contract',
                 },
               ]

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -165,7 +165,7 @@
                 },
                 {
                   'href': call_off_contract_url,
-                  'text': 'View the Digital Outcomes and Specialists contract',
+                  'text': "View the " + brief.frameworkName + " contract",
                 },
               ]
             }

--- a/app/templates/buyers/brief_overview.html
+++ b/app/templates/buyers/brief_overview.html
@@ -23,7 +23,6 @@
 
 {% block main_content %}
   <div class="grid-row">
-
     {% block before_heading %}
       {% if delete_requested %}
         <div class="column-one-whole">
@@ -40,6 +39,8 @@
         </div>
       {% endif %}
    {% endblock %}
+  </div>
+  <div class="grid-row">
     <div class="column-two-thirds">
       {% with
         heading = brief.get('title', brief['lotName']),
@@ -47,9 +48,11 @@
       %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
-
-    {% block before_sections %}{% endblock %}
-
+    </div>
+  </div>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {% block before_sections %}{% endblock %}
       <ol class="instruction-list steps">
 
         {% with
@@ -211,7 +214,11 @@
         {% endwith %}
       </ol>
     </div>
-
+    <div class="column-one-third">
+      {% if brief.publishedAt %}
+        {% include 'buyers/_requirements_meta.html' %}
+      {% endif %}
+    </div>
   </div>
   {% if not delete_requested %}
      <div class="grid-row">

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.11.3"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.14.0"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ odfpy==1.3.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.0.4#egg=digitalmarketplace-utils==24.0.4
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@7.12.0#egg=digitalmarketplace-apiclient==7.12.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.4.0#egg=digitalmarketplace-apiclient==8.4.0
 
 # For Cloud Foundry
 cffi==1.5.2

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -1528,7 +1528,34 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert section_4_link[0].get('href').strip() == \
                 '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-4'
 
-    def test_shows_correct_content_for_open_and_closed_dos_1_and_2_briefs(self, data_api_client):
+    def test_no_meta_data_is_shown_for_a_draft_brief(self, data_api_client):
+        with self.app.app_context():
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug="digital-outcomes-and-specialists-2",
+                status='live',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            data_api_client.get_brief.return_value = api_stubs.brief(
+                status="draft",
+                framework_slug="digital-outcomes-and-specialists-2",
+                framework_name="Digital Outcomes and Specialists 2",
+            )
+
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/1234"
+            )
+            assert res.status_code == 200
+
+            document = html.fromstring(res.get_data(as_text=True))
+
+            meta_data_container = document.xpath('//*[@id="requirements-meta"]')
+
+            assert not meta_data_container
+
+    def test_shows_correct_content_for_draft_open_and_closed_dos_1_and_2_briefs(self, data_api_client):
         framework_slugs = ["digital-outcomes-and-specialists", "digital-outcomes-and-specialists-2"]
         framework_names = ["Digital Outcomes and Specialists", "Digital Outcomes and Specialists 2"]
         sidebar_heading_content = ['Closing', 'Closed']

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -1564,7 +1564,6 @@ class TestBriefSummaryPage(BaseApplicationTest):
         for framework_slug, framework_name in zip(framework_slugs, framework_names):
             with self.app.app_context():
                 self.login_as_buyer()
-
                 for heading, brief_status in zip(sidebar_heading_content, brief_statuses):
                     data_api_client.get_framework.return_value = api_stubs.framework(
                         slug=framework_slug,
@@ -1589,12 +1588,10 @@ class TestBriefSummaryPage(BaseApplicationTest):
                     sidebar_headings = document.xpath('//*[@class="sidebar-heading"]/text()')
                     sidebar_content = document.xpath('//*[@class="sidebar-content"]/text()')
                     framework_name_content = document.xpath('//*[@class="framework-name"]/a/text()')[0]
-                    contract_link_text = document.xpath('//main[@id="content"]//ul/li/a/text()')[-1]
 
                     assert sidebar_headings == ['Published', heading, 'Framework']
                     assert sidebar_content == ['Tuesday 29 March 2016', 'Thursday 7 April 2016']
                     assert framework_name_content == framework_name
-                    assert contract_link_text == "View the {} contract".format(framework_name)
 
     def test_links_to_correct_call_off_contract_and_framework_agreement_for_briefs_framework(self, data_api_client):
         framework_slugs = ["digital-outcomes-and-specialists", "digital-outcomes-and-specialists-2"]
@@ -1636,9 +1633,11 @@ class TestBriefSummaryPage(BaseApplicationTest):
                         document.xpath('//main[@id="content"]//ul/li/a')[-1].values()[0]
                     framework_agreement_link_destination = \
                         document.xpath('//*[@class="framework-name"]/a')[0].values()[0]
+                    contract_link_text = document.xpath('//main[@id="content"]//ul/li/a/text()')[-1]
 
                     assert call_off_contract_link_destination == call_off_contract_url
                     assert framework_agreement_link_destination == framework_agreement_url
+                    assert contract_link_text == "View the {} contract".format(framework_name)
 
 
 @mock.patch("app.buyers.views.buyers.data_api_client")

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -1528,6 +1528,91 @@ class TestBriefSummaryPage(BaseApplicationTest):
             assert section_4_link[0].get('href').strip() == \
                 '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-4'
 
+    def test_shows_correct_content_for_open_and_closed_dos_1_and_2_briefs(self, data_api_client):
+        framework_slugs = ["digital-outcomes-and-specialists", "digital-outcomes-and-specialists-2"]
+        framework_names = ["Digital Outcomes and Specialists", "Digital Outcomes and Specialists 2"]
+        sidebar_heading_content = ['Closing', 'Closed']
+        brief_statuses = ['live', 'closed']
+
+        for framework_slug, framework_name in zip(framework_slugs, framework_names):
+            with self.app.app_context():
+                self.login_as_buyer()
+
+                for heading, brief_status in zip(sidebar_heading_content, brief_statuses):
+                    data_api_client.get_framework.return_value = api_stubs.framework(
+                        slug=framework_slug,
+                        status='live',
+                        lots=[
+                            api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                        ]
+                    )
+                    data_api_client.get_brief.return_value = api_stubs.brief(
+                        status=brief_status,
+                        framework_slug=framework_slug,
+                        framework_name=framework_name,
+                    )
+
+                    res = self.client.get(
+                        "/buyers/frameworks/{}/requirements/digital-specialists/1234".format(framework_slug)
+                    )
+                    assert res.status_code == 200
+
+                    document = html.fromstring(res.get_data(as_text=True))
+
+                    sidebar_headings = document.xpath('//*[@class="sidebar-heading"]/text()')
+                    sidebar_content = document.xpath('//*[@class="sidebar-content"]/text()')
+                    framework_name_content = document.xpath('//*[@class="framework-name"]/a/text()')[0]
+                    contract_link_text = document.xpath('//main[@id="content"]//ul/li/a/text()')[-1]
+
+                    assert sidebar_headings == ['Published', heading, 'Framework']
+                    assert sidebar_content == ['Tuesday 29 March 2016', 'Thursday 7 April 2016']
+                    assert framework_name_content == framework_name
+                    assert contract_link_text == "View the {} contract".format(framework_name)
+
+    def test_links_to_correct_call_off_contract_and_framework_agreement_for_briefs_framework(self, data_api_client):
+        framework_slugs = ["digital-outcomes-and-specialists", "digital-outcomes-and-specialists-2"]
+        framework_names = ["Digital Outcomes and Specialists", "Digital Outcomes and Specialists 2"]
+        call_off_contract_urls = [
+            "https://www.gov.uk/government/publications/digital-outcomes-and-specialists-call-off-contract",
+            "https://www.gov.uk/government/publications/digital-outcomes-and-specialists-2-call-off-contract"
+        ]
+        framework_agreement_urls = [
+            "https://www.gov.uk/government/publications/digital-outcomes-and-specialists-framework-agreement",
+            "https://www.gov.uk/government/publications/digital-outcomes-and-specialists-2-framework-agreement"
+        ]
+
+        for framework_slug, framework_name, call_off_contract_url, framework_agreement_url in \
+                zip(framework_slugs, framework_names, call_off_contract_urls, framework_agreement_urls):
+                with self.app.app_context():
+                    self.login_as_buyer()
+                    data_api_client.get_framework.return_value = api_stubs.framework(
+                        slug=framework_slug,
+                        status='live',
+                        lots=[
+                            api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                        ]
+                    )
+                    data_api_client.get_brief.return_value = api_stubs.brief(
+                        status='live',
+                        framework_slug=framework_slug,
+                        framework_name=framework_name,
+                    )
+
+                    res = self.client.get(
+                        "/buyers/frameworks/{}/requirements/digital-specialists/1234".format(framework_slug)
+                    )
+                    assert res.status_code == 200
+
+                    document = html.fromstring(res.get_data(as_text=True))
+
+                    call_off_contract_link_destination = \
+                        document.xpath('//main[@id="content"]//ul/li/a')[-1].values()[0]
+                    framework_agreement_link_destination = \
+                        document.xpath('//*[@class="framework-name"]/a')[0].values()[0]
+
+                    assert call_off_contract_link_destination == call_off_contract_url
+                    assert framework_agreement_link_destination == framework_agreement_url
+
 
 @mock.patch("app.buyers.views.buyers.data_api_client")
 class TestAddBriefClarificationQuestion(BaseApplicationTest):


### PR DESCRIPTION
For this story on Pivotal [https://www.pivotaltracker.com/story/show/139281415](https://www.pivotaltracker.com/story/show/139281415)

Will need a [PR on the apiclient](https://github.com/alphagov/digitalmarketplace-apiclient/pull/68) and a [PR on the frameworks repo](https://github.com/alphagov/digitalmarketplace-frameworks/pull/377) merging before tests will go green.

This PR adds meta information to give a buyer context when looking at one of their requirements page. It's modelled roughly on a similar thing we have when viewing a G-Cloud service, see the one third column [here](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/7959974558158858) for an example.

This meta information is only displayed if the brief is published and includes the name of the framework the brief is on. This will help the buyer understand what framework they've published their link under. It also links them to the framework agreement for that framework for further context.

The link to the call off contract is also updated depending on the framework. The link text is also changed to provide further context.

URL's have been added to the frameworks repo messages for both DOS frameworks and are pulled in and used from there.

Screen shots!

<img width="1440" alt="screen shot 2017-02-15 at 11 09 18" src="https://cloud.githubusercontent.com/assets/13836290/22971892/41bb9aea-f36f-11e6-9b37-29c5aa873bd0.png">

<img width="724" alt="screen shot 2017-02-15 at 11 09 22" src="https://cloud.githubusercontent.com/assets/13836290/22971902/4615cbf6-f36f-11e6-8a5c-e645854b62b1.png">
