### PR TITLE
Dos1 functional when expired

### DIFF
--- a/app/buyers/helpers/buyers_helpers.py
+++ b/app/buyers/helpers/buyers_helpers.py
@@ -2,14 +2,14 @@ from flask import abort
 from datetime import datetime, timedelta
 
 
-def get_framework_and_lot(framework_slug, lot_slug, data_api_client, status=None, must_allow_brief=False):
+def get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses=None, must_allow_brief=False):
     framework = data_api_client.get_framework(framework_slug)['frameworks']
     try:
         lot = next(lot for lot in framework['lots'] if lot['slug'] == lot_slug)
     except StopIteration:
         abort(404)
 
-    if status and framework['status'] != status:
+    if allowed_statuses and framework['status'] not in allowed_statuses:
         abort(404)
     if must_allow_brief and not lot['allowsBrief']:
         abort(404)

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -117,7 +117,12 @@ def create_new_brief(framework_slug, lot_slug):
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>', methods=['GET'])
 def view_brief_overview(framework_slug, lot_slug, brief_id):
     framework, lot = get_framework_and_lot(
-        framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+        framework_slug,
+        lot_slug,
+        data_api_client,
+        allowed_statuses=['live', 'expired'],
+        must_allow_brief=True
+    )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -51,7 +51,7 @@ def buyer_dashboard():
 def start_new_brief(framework_slug, lot_slug):
 
     framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
-                                           allowed_statuses='live', must_allow_brief=True)
+                                           allowed_statuses=['live'], must_allow_brief=True)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
         {'lot': lot['slug']}
@@ -73,7 +73,7 @@ def start_new_brief(framework_slug, lot_slug):
 def create_new_brief(framework_slug, lot_slug):
 
     framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
-                                           allowed_statuses='live', must_allow_brief=True)
+                                           allowed_statuses=['live'], must_allow_brief=True)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
         {'lot': lot['slug']}
@@ -195,7 +195,7 @@ def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_slug)
     '/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_slug>/<question_id>',
     methods=['GET'])
 def edit_brief_question(framework_slug, lot_slug, brief_id, section_slug, question_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses=['live'], must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):
@@ -224,7 +224,7 @@ def edit_brief_question(framework_slug, lot_slug, brief_id, section_slug, questi
     '/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_id>/<question_id>',
     methods=['POST'])
 def update_brief_submission(framework_slug, lot_slug, brief_id, section_id, question_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses=['live'], must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):
@@ -549,7 +549,7 @@ buyers.add_url_rule('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/publish', methods=['GET', 'POST'])
 def publish_brief(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses=['live'], must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -165,7 +165,13 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/<section_slug>', methods=['GET'])
 def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_slug):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+    get_framework_and_lot(
+        framework_slug,
+        lot_slug,
+        data_api_client,
+        allowed_statuses=['live', 'expired'],
+        must_allow_brief=True
+    )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -51,7 +51,7 @@ def buyer_dashboard():
 def start_new_brief(framework_slug, lot_slug):
 
     framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
-                                           status='live', must_allow_brief=True)
+                                           allowed_statuses='live', must_allow_brief=True)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
         {'lot': lot['slug']}
@@ -73,7 +73,7 @@ def start_new_brief(framework_slug, lot_slug):
 def create_new_brief(framework_slug, lot_slug):
 
     framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
-                                           status='live', must_allow_brief=True)
+                                           allowed_statuses='live', must_allow_brief=True)
 
     content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
         {'lot': lot['slug']}
@@ -117,7 +117,7 @@ def create_new_brief(framework_slug, lot_slug):
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>', methods=['GET'])
 def view_brief_overview(framework_slug, lot_slug, brief_id):
     framework, lot = get_framework_and_lot(
-        framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+        framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
@@ -160,7 +160,7 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/<section_slug>', methods=['GET'])
 def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_slug):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):
@@ -184,7 +184,7 @@ def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_slug)
     '/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_slug>/<question_id>',
     methods=['GET'])
 def edit_brief_question(framework_slug, lot_slug, brief_id, section_slug, question_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):
@@ -213,7 +213,7 @@ def edit_brief_question(framework_slug, lot_slug, brief_id, section_slug, questi
     '/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_id>/<question_id>',
     methods=['POST'])
 def update_brief_submission(framework_slug, lot_slug, brief_id, section_id, question_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):
@@ -273,7 +273,7 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id, ques
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/responses', methods=['GET'])
 def view_brief_responses(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
@@ -310,7 +310,7 @@ class DownloadBriefResponsesView(View):
 
     def get_context_data(self, **kwargs):
         get_framework_and_lot(kwargs['framework_slug'], kwargs['lot_slug'],
-                              self.data_api_client, status='live',
+                              self.data_api_client, allowed_statuses='live',
                               must_allow_brief=True)
 
         brief = self.data_api_client.get_brief(kwargs['brief_id'])["briefs"]
@@ -528,7 +528,7 @@ buyers.add_url_rule('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/publish', methods=['GET', 'POST'])
 def publish_brief(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):
@@ -580,7 +580,7 @@ def publish_brief(framework_slug, lot_slug, brief_id):
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/timeline', methods=['GET'])
 def view_brief_timeline(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or brief.get('status') != 'live':
         abort(404)
@@ -598,7 +598,7 @@ def view_brief_timeline(framework_slug, lot_slug, brief_id):
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/delete', methods=['POST'])
 def delete_a_brief(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):
@@ -613,7 +613,7 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
     "/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/supplier-questions",
     methods=["GET"])
 def supplier_questions(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
@@ -637,7 +637,7 @@ def supplier_questions(framework_slug, lot_slug, brief_id):
     "/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/supplier-questions/answer-question",
     methods=["GET", "POST"])
 def add_supplier_question(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, status='live', must_allow_brief=True)
+    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -591,7 +591,13 @@ def publish_brief(framework_slug, lot_slug, brief_id):
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/timeline', methods=['GET'])
 def view_brief_timeline(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+    get_framework_and_lot(
+        framework_slug,
+        lot_slug,
+        data_api_client,
+        allowed_statuses=['live', 'expired'],
+        must_allow_brief=True
+    )
     brief = data_api_client.get_brief(brief_id)["briefs"]
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or brief.get('status') != 'live':
         abort(404)
@@ -624,7 +630,13 @@ def delete_a_brief(framework_slug, lot_slug, brief_id):
     "/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/supplier-questions",
     methods=["GET"])
 def supplier_questions(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+    get_framework_and_lot(
+        framework_slug,
+        lot_slug,
+        data_api_client,
+        allowed_statuses=['live', 'expired'],
+        must_allow_brief=True
+    )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
@@ -648,7 +660,12 @@ def supplier_questions(framework_slug, lot_slug, brief_id):
     "/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/supplier-questions/answer-question",
     methods=["GET", "POST"])
 def add_supplier_question(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+    get_framework_and_lot(
+        framework_slug,
+        lot_slug, data_api_client,
+        allowed_statuses=['live', 'expired'],
+        must_allow_brief=True
+    )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -619,7 +619,13 @@ def view_brief_timeline(framework_slug, lot_slug, brief_id):
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/delete', methods=['POST'])
 def delete_a_brief(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+    get_framework_and_lot(
+        framework_slug,
+        lot_slug,
+        data_api_client,
+        allowed_statuses=['live', 'expired'],
+        must_allow_brief=True
+    )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id) or not brief_can_be_edited(brief):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -273,7 +273,13 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id, ques
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/responses', methods=['GET'])
 def view_brief_responses(framework_slug, lot_slug, brief_id):
-    get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses='live', must_allow_brief=True)
+    get_framework_and_lot(
+        framework_slug,
+        lot_slug,
+        data_api_client,
+        allowed_statuses=['live', 'expired'],
+        must_allow_brief=True,
+    )
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -320,9 +320,13 @@ class DownloadBriefResponsesView(View):
         return get_sorted_responses_for_brief(brief, self.data_api_client)
 
     def get_context_data(self, **kwargs):
-        get_framework_and_lot(kwargs['framework_slug'], kwargs['lot_slug'],
-                              self.data_api_client, allowed_statuses='live',
-                              must_allow_brief=True)
+        get_framework_and_lot(
+            kwargs['framework_slug'],
+            kwargs['lot_slug'],
+            self.data_api_client,
+            allowed_statuses=['live', 'expired'],
+            must_allow_brief=True,
+        )
 
         brief = self.data_api_client.get_brief(kwargs['brief_id'])["briefs"]
 

--- a/app/buyers/views/digital_outcomes_and_specialists.py
+++ b/app/buyers/views/digital_outcomes_and_specialists.py
@@ -11,7 +11,7 @@ from ..helpers.buyers_helpers import get_framework_and_lot
 @dos.route('/frameworks/<framework_slug>/requirements/user-research-studios', methods=['GET'])
 def studios_start_page(framework_slug):
     # Check framework is live and has the user-research-studios lot
-    get_framework_and_lot(framework_slug, 'user-research-studios', data_api_client, status='live')
+    get_framework_and_lot(framework_slug, 'user-research-studios', data_api_client, allowed_statuses='live')
 
     return render_template(
         "buyers/studios_start_page.html"
@@ -21,7 +21,7 @@ def studios_start_page(framework_slug):
 @dos.route('/frameworks/<framework_slug>/requirements/<lot_slug>', methods=['GET'])
 def info_page_for_starting_a_brief(framework_slug, lot_slug):
     framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
-                                           status='live', must_allow_brief=True)
+                                           allowed_statuses='live', must_allow_brief=True)
     return render_template(
         "buyers/start_brief_info.html",
         framework=framework,

--- a/app/buyers/views/digital_outcomes_and_specialists.py
+++ b/app/buyers/views/digital_outcomes_and_specialists.py
@@ -11,7 +11,7 @@ from ..helpers.buyers_helpers import get_framework_and_lot
 @dos.route('/frameworks/<framework_slug>/requirements/user-research-studios', methods=['GET'])
 def studios_start_page(framework_slug):
     # Check framework is live and has the user-research-studios lot
-    get_framework_and_lot(framework_slug, 'user-research-studios', data_api_client, allowed_statuses='live')
+    get_framework_and_lot(framework_slug, 'user-research-studios', data_api_client, allowed_statuses=['live'])
 
     return render_template(
         "buyers/studios_start_page.html"
@@ -21,7 +21,7 @@ def studios_start_page(framework_slug):
 @dos.route('/frameworks/<framework_slug>/requirements/<lot_slug>', methods=['GET'])
 def info_page_for_starting_a_brief(framework_slug, lot_slug):
     framework, lot = get_framework_and_lot(framework_slug, lot_slug, data_api_client,
-                                           allowed_statuses='live', must_allow_brief=True)
+                                           allowed_statuses=['live'], must_allow_brief=True)
     return render_template(
         "buyers/start_brief_info.html",
         framework=framework,

--- a/tests/buyers/helpers/test_buyers_helpers.py
+++ b/tests/buyers/helpers/test_buyers_helpers.py
@@ -55,7 +55,7 @@ class TestBuyersHelpers(object):
                 'digital-outcomes-and-specialists',
                 'digital-specialists',
                 data_api_client,
-                allowed_statuses='live',
+                allowed_statuses=['live'],
             )
 
     def test_get_framework_and_lot_404s_if_allows_brief_required(self):

--- a/tests/buyers/helpers/test_buyers_helpers.py
+++ b/tests/buyers/helpers/test_buyers_helpers.py
@@ -55,7 +55,7 @@ class TestBuyersHelpers(object):
                 'digital-outcomes-and-specialists',
                 'digital-specialists',
                 data_api_client,
-                status='live',
+                allowed_statuses='live',
             )
 
     def test_get_framework_and_lot_404s_if_allows_brief_required(self):

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -91,20 +91,21 @@ class TestStartNewBrief(BaseApplicationTest):
             assert res.status_code == 404
 
     def test_404_if_framework_status_is_not_live(self, data_api_client):
-        with self.app.app_context():
-            self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='open',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                ]
-            )
+        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+            with self.app.app_context():
+                self.login_as_buyer()
+                data_api_client.get_framework.return_value = api_stubs.framework(
+                    slug='digital-outcomes-and-specialists',
+                    status=framework_status,
+                    lots=[
+                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                    ]
+                )
 
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/create")
+                res = self.client.get(
+                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/create")
 
-            assert res.status_code == 404
+                assert res.status_code == 404
 
     def test_404_if_lot_does_not_exist(self, data_api_client):
         with self.app.app_context():
@@ -271,18 +272,15 @@ class TestCreateNewBrief(BaseApplicationTest):
 
 
 class TestEveryDamnPage(BaseApplicationTest):
-
-    # @mock.patch("app.buyers.views.buyers.content_loader")
-    def _load_page(self, url, status_code, method='get', data=None):
+    def _load_page(self, url, status_code, method='get', data=None, framework_status='live'):
         data = {} if data is None else data
         baseurl = "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-
         with mock.patch('app.buyers.views.buyers.content_loader') as content_loader, \
                 mock.patch('app.buyers.views.buyers.data_api_client') as data_api_client:
             self.login_as_buyer()
             data_api_client.get_framework.return_value = api_stubs.framework(
                 slug='digital-outcomes-and-specialists',
-                status='live',
+                status=framework_status,
                 lots=[
                     api_stubs.lot(slug='digital-specialists', allows_brief=True),
                     api_stubs.lot(slug='digital-outcomes', allows_brief=True)
@@ -300,53 +298,90 @@ class TestEveryDamnPage(BaseApplicationTest):
 
     # These should all work as expected
 
-    def test_wrong_lot_get_view_brief_overview(self):
-        self._load_page("/digital-specialists/1234", 200)
+    def test_get_view_brief_overview(self):
+        for framework_status in ['live', 'expired']:
+            self._load_page("/digital-specialists/1234", 200, framework_status=framework_status)
 
-    def test_wrong_lot_get_view_section_summary(self):
+    def test_get_view_section_summary(self):
         self._load_page("/digital-specialists/1234/section-1", 200)
 
-    def test_wrong_lot_get_edit_brief_question(self):
+    def test_get_edit_brief_question(self):
         self._load_page("/digital-specialists/1234/edit/section-1/required1", 200)
 
-    def test_wrong_lot_post_edit_brief_question(self):
+    def test_post_edit_brief_question(self):
         data = {"required1": True}
         self._load_page("/digital-specialists/1234/edit/section-1/required1", 302, method='post', data=data)
 
-    def test_wrong_lot_get_view_brief_responses(self):
-        self._load_page("/digital-specialists/1234/responses", 200)
+    def test_get_view_brief_responses(self):
+        for framework_status in ['live', 'expired']:
+            self._load_page("/digital-specialists/1234/responses", 200)
 
     # get and post are the same for publishing
 
-    def test_wrong_lot_post_delete_a_brief(self):
+    def test_post_delete_a_brief(self):
         data = {"delete_confirmed": True}
         self._load_page("/digital-specialists/1234/delete", 302, method='post', data=data)
 
     # Wrong lots
 
-    def test_get_view_brief_overview(self):
+    def test_wrong_lot_get_view_brief_overview(self):
         self._load_page("/digital-outcomes/1234", 404)
 
-    def test_get_view_section_summary(self):
+    def test_wrong_lot_get_view_section_summary(self):
         self._load_page("/digital-outcomes/1234/section-1", 404)
 
-    def test_get_edit_brief_question(self):
+    def test_wrong_lot_get_edit_brief_question(self):
         self._load_page("/digital-outcomes/1234/edit/section-1/required1", 404)
 
-    def test_post_edit_brief_question(self):
+    def test_wrong_lot_post_edit_brief_question(self):
         data = {"required1": True}
         self._load_page("/digital-outcomes/1234/edit/section-1/required1", 404, method='post', data=data)
 
-    def test_get_view_brief_responses(self):
+    def test_wrong_lot_get_view_brief_responses(self):
         self._load_page("/digital-outcomes/1234/responses", 404)
 
     # get and post are the same for publishing
-    def test_publish_brief(self):
+    def test_wrong_lot_publish_brief(self):
         self._load_page("/digital-outcomes/1234/publish", 404)
 
-    def test_post_delete_a_brief(self):
+    def test_wrong_lot_post_delete_a_brief(self):
         data = {"delete_confirmed": True}
         self._load_page("/digital-outcomes/1234/delete", 404, method='post', data=data)
+
+    # not allowed for expired framework_slug
+
+    def test_expired_framework_get_edit_brief_question(self):
+        self._load_page("/digital-specialists/1234/edit/section-1/required1", 404, framework_status='expired')
+
+    def test_expired_framework_post_edit_brief_question(self):
+        data = {"required1": True}
+        self._load_page(
+            "/digital-outcomes/1234/edit/section-1/required1",
+            404,
+            method='post',
+            data=data,
+            framework_status='expired'
+        )
+
+    def test_expired_framework_post_edit_brief_question(self):
+        data = {"required1": True}
+        self._load_page(
+            "/digital-outcomes/1234/edit/section-1/required1",
+            404,
+            method='post',
+            data=data,
+            framework_status='expired'
+        )
+
+    def test_expired_framework_post_edit_brief_question(self):
+        data = {"required1": True}
+        self._load_page(
+            "/digital-specialists/1234/edit/section-1/required1",
+            404,
+            method='post',
+            data=data,
+            framework_status='expired'
+        )
 
 
 @mock.patch('app.buyers.views.buyers.data_api_client')
@@ -564,20 +599,21 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert res.status_code == 404
 
     def test_404_if_framework_status_is_not_live(self, data_api_client):
-        self.login_as_buyer()
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug='digital-outcomes-and-specialists',
-            status='open',
-            lots=[
-                api_stubs.lot(slug='digital-specialists', allows_brief=True)
-            ]
-        )
+        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True)
+                ]
+            )
 
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists"
-            "/1234/edit/description-of-work/organisation")
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists"
+                "/1234/edit/description-of-work/organisation")
 
-        assert res.status_code == 404
+            assert res.status_code == 404
 
     def test_404_if_brief_has_published_status(self, data_api_client):
         self.login_as_buyer()
@@ -825,25 +861,26 @@ class TestUpdateBriefSubmission(BaseApplicationTest):
         assert not data_api_client.update_brief.called
 
     def test_404_if_framework_status_is_not_live(self, data_api_client):
-        self.login_as_buyer()
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug='digital-outcomes-and-specialists',
-            status='open',
-            lots=[
-                api_stubs.lot(slug='digital-specialists', allows_brief=True)
-            ]
-        )
-        data_api_client.get_brief.return_value = api_stubs.brief()
+        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status='open',
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True)
+                ]
+            )
+            data_api_client.get_brief.return_value = api_stubs.brief()
 
-        res = self.client.post(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
-            "digital-specialists/1234/edit/description-of-work/organisation",
-            data={
-                "title": "A new title"
-            })
+            res = self.client.post(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                "digital-specialists/1234/edit/description-of-work/organisation",
+                data={
+                    "title": "A new title"
+                })
 
-        assert res.status_code == 404
-        assert not data_api_client.update_brief.called
+            assert res.status_code == 404
+            assert not data_api_client.update_brief.called
 
     def test_404_if_brief_is_already_live(self, data_api_client):
         self.login_as_buyer()
@@ -970,6 +1007,48 @@ class TestPublishBrief(BaseApplicationTest):
 
         assert res.status_code == 404
         assert not data_api_client.update_brief.called
+
+    def test_404_if_framework_status_is_not_live(self, data_api_client):
+        for framework_status in ['coming', 'open', 'pending', 'standstill', 'expired']:
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True)
+                ]
+            )
+
+            brief_json = api_stubs.brief(status="draft")
+            brief_questions = brief_json['briefs']
+            brief_questions.update({
+                'backgroundInformation': 'test background info',
+                'contractLength': 'A very long time',
+                'culturalFitCriteria': ['CULTURAL', 'FIT'],
+                'culturalWeighting': 10,
+                'essentialRequirements': 'Everything',
+                'evaluationType': ['test evaluation type'],
+                'existingTeam': 'team team team',
+                'importantDates': 'Near future',
+                'numberOfSuppliers': 5,
+                'location': 'somewhere',
+                'organisation': 'test organisation',
+                'priceWeighting': 80,
+                'specialistRole': 'communicationsManager',
+                'specialistWork': 'work work work',
+                'startDate': 'startDate',
+                'summary': 'blah',
+                'technicalWeighting': 10,
+                'workingArrangements': 'arrangements',
+                'workplaceAddress': 'address',
+                'requirementsLength': '1 week'
+            })
+            data_api_client.get_brief.return_value = brief_json
+
+            res = self.client.post("/buyers/frameworks/digital-outcomes-and-specialists/requirements/"
+                                   "digital-specialists/1234/publish")
+            assert res.status_code == 404
+            assert not data_api_client.publish_brief.called
 
     def test_publish_button_available_if_questions_answered(self, data_api_client):
         self.login_as_buyer()
@@ -1206,41 +1285,43 @@ class TestPublishBrief(BaseApplicationTest):
 @mock.patch('app.buyers.views.buyers.data_api_client')
 class TestDeleteBriefSubmission(BaseApplicationTest):
     def test_delete_brief_submission(self, data_api_client):
-        self.login_as_buyer()
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug='digital-outcomes-and-specialists',
-            status='live',
-            lots=[
-                api_stubs.lot(slug='digital-specialists', allows_brief=True)
-            ]
-        )
-        data_api_client.get_brief.return_value = api_stubs.brief()
+        for framework_status in ['live', 'expired']:
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True)
+                ]
+            )
+            data_api_client.get_brief.return_value = api_stubs.brief()
 
-        res = self.client.post(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/delete"
-        )
+            res = self.client.post(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/delete"
+            )
 
-        assert res.status_code == 302
-        assert data_api_client.delete_brief.called
-        assert res.location == "http://localhost/buyers"
+            assert res.status_code == 302
+            assert data_api_client.delete_brief.called
+            assert res.location == "http://localhost/buyers"
 
-    def test_404_if_framework_is_not_live(self, data_api_client):
-        self.login_as_buyer()
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug='digital-outcomes-and-specialists',
-            status='standstill',
-            lots=[
-                api_stubs.lot(slug='digital-specialists', allows_brief=True)
-            ]
-        )
-        data_api_client.get_brief.return_value = api_stubs.brief()
+    def test_404_if_framework_is_not_live_or_expired(self, data_api_client):
+        for framework_status in ['coming', 'open', 'pending', 'standstill']:
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True)
+                ]
+            )
+            data_api_client.get_brief.return_value = api_stubs.brief()
 
-        res = self.client.post(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/delete",
-        )
-
-        assert res.status_code == 404
-        assert not data_api_client.delete_brief.called
+            res = self.client.post(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/delete",
+            )
+            print(framework_status)
+            assert res.status_code == 404
+            assert not data_api_client.delete_brief.called
 
     def test_cannot_delete_live_brief(self, data_api_client):
         self.login_as_buyer()
@@ -1322,135 +1403,143 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
             assert document.xpath('//a[contains(text(), "Delete")]')
 
-    def test_show_live_brief_summary_page(self, data_api_client):
+    def test_show_live_brief_summary_page_for_live_and_expired_framework(self, data_api_client):
+        framework_statuses = ['live', 'expired']
         with self.app.app_context():
             self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='live',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+            for framework_status in framework_statuses:
+                data_api_client.get_framework.return_value = api_stubs.framework(
+                    slug='digital-outcomes-and-specialists',
+                    status=framework_status,
+                    lots=[
+                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                    ]
+                )
+                brief_json = api_stubs.brief(status="live")
+                brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+                brief_json['briefs']['specialistRole'] = 'communicationsManager'
+                brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+                data_api_client.get_brief.return_value = brief_json
+
+                res = self.client.get(
+                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
+                )
+
+                assert res.status_code == 200
+                page_html = res.get_data(as_text=True)
+                document = html.fromstring(page_html)
+
+                assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
+                assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
+                    'View question and answer dates',
+                    'View your published requirements',
+                    'Publish questions and answers',
+                    'How to answer supplier questions',
+                    'How to shortlist suppliers',
+                    'How to evaluate suppliers',
+                    'How to award a contract',
+                    'View the Digital Outcomes and Specialists contract',
                 ]
-            )
-            brief_json = api_stubs.brief(status="live")
-            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-            brief_json['briefs']['specialistRole'] = 'communicationsManager'
-            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-            data_api_client.get_brief.return_value = brief_json
 
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
-            )
+                assert not document.xpath('//a[contains(text(), "Delete")]')
 
-            assert res.status_code == 200
-            page_html = res.get_data(as_text=True)
-            document = html.fromstring(page_html)
-
-            assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-            assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
-                'View question and answer dates',
-                'View your published requirements',
-                'Publish questions and answers',
-                'How to answer supplier questions',
-                'How to shortlist suppliers',
-                'How to evaluate suppliers',
-                'How to award a contract',
-                'View the Digital Outcomes and Specialists contract',
-            ]
-
-            assert not document.xpath('//a[contains(text(), "Delete")]')
-
-    def test_show_closed_brief_summary_page(self, data_api_client):
+    def test_show_closed_brief_summary_page_for_live_and_expired_framework(self, data_api_client):
+        framework_statuses = ['live', 'expired']
         with self.app.app_context():
             self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='live',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+            for framework_status in framework_statuses:
+                data_api_client.get_framework.return_value = api_stubs.framework(
+                    slug='digital-outcomes-and-specialists',
+                    status=framework_status,
+                    lots=[
+                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                    ]
+                )
+                brief_json = api_stubs.brief(status="closed")
+                brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+                brief_json['briefs']['specialistRole'] = 'communicationsManager'
+                brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+                data_api_client.get_brief.return_value = brief_json
+
+                res = self.client.get(
+                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
+                )
+
+                assert res.status_code == 200
+                page_html = res.get_data(as_text=True)
+                document = html.fromstring(page_html)
+
+                assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
+                assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
+                    'View your published requirements',
+                    'View and shortlist suppliers',
+                    'How to shortlist suppliers',
+                    'How to evaluate suppliers',
+                    'How to award a contract',
+                    'View the Digital Outcomes and Specialists contract',
                 ]
-            )
-            brief_json = api_stubs.brief(status="closed")
-            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-            brief_json['briefs']['specialistRole'] = 'communicationsManager'
-            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-            data_api_client.get_brief.return_value = brief_json
 
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234"
-            )
-
-            assert res.status_code == 200
-            page_html = res.get_data(as_text=True)
-            document = html.fromstring(page_html)
-
-            assert (document.xpath('//h1')[0]).text_content().strip() == "I need a thing to do a thing"
-            assert [e.text_content() for e in document.xpath('//main[@id="content"]//ul/li/a')] == [
-                'View your published requirements',
-                'View and shortlist suppliers',
-                'How to shortlist suppliers',
-                'How to evaluate suppliers',
-                'How to award a contract',
-                'View the Digital Outcomes and Specialists contract',
-            ]
-
-            assert not document.xpath('//a[contains(text(), "Delete")]')
+                assert not document.xpath('//a[contains(text(), "Delete")]')
 
     def test_show_clarification_questions_page_for_live_brief_with_no_questions(self, data_api_client):
+        framework_statuses = ['live', 'expired']
         with self.app.app_context():
             self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='live',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                ]
-            )
-            brief_json = api_stubs.brief(status="live")
-            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-            brief_json['briefs']["clarificationQuestionsAreClosed"] = False
-            data_api_client.get_brief.return_value = brief_json
+            for framework_status in framework_statuses:
+                data_api_client.get_framework.return_value = api_stubs.framework(
+                    slug='digital-outcomes-and-specialists',
+                    status=framework_status,
+                    lots=[
+                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                    ]
+                )
+                brief_json = api_stubs.brief(status="live")
+                brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+                brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+                data_api_client.get_brief.return_value = brief_json
 
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
-            )
+                res = self.client.get(
+                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
+                )
 
-            assert res.status_code == 200
-            page_html = res.get_data(as_text=True)
-            assert "Supplier questions" in page_html
-            assert "No questions or answers have been published" in page_html
-            assert "Answer a supplier question" in page_html
+                assert res.status_code == 200
+                page_html = res.get_data(as_text=True)
+                assert "Supplier questions" in page_html
+                assert "No questions or answers have been published" in page_html
+                assert "Answer a supplier question" in page_html
 
     def test_show_clarification_questions_page_for_live_brief_with_one_question(self, data_api_client):
+        framework_statuses = ['live', 'expired']
         with self.app.app_context():
             self.login_as_buyer()
-            data_api_client.get_framework.return_value = api_stubs.framework(
-                slug='digital-outcomes-and-specialists',
-                status='live',
-                lots=[
-                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
-                ]
-            )
-            brief_json = api_stubs.brief(status="live", clarification_questions=[
-                {"question": "Why is my question a question?",
-                 "answer": "Because",
-                 "publishedAt": "2016-01-01T00:00:00.000000Z"}
-            ])
-            brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
-            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-            data_api_client.get_brief.return_value = brief_json
+            for framework_status in framework_statuses:
+                data_api_client.get_framework.return_value = api_stubs.framework(
+                    slug='digital-outcomes-and-specialists',
+                    status='live',
+                    lots=[
+                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                    ]
+                )
+                brief_json = api_stubs.brief(status="live", clarification_questions=[
+                    {"question": "Why is my question a question?",
+                     "answer": "Because",
+                     "publishedAt": "2016-01-01T00:00:00.000000Z"}
+                ])
+                brief_json['briefs']['publishedAt'] = "2016-04-02T20:10:00.00000Z"
+                brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+                data_api_client.get_brief.return_value = brief_json
 
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
-            )
+                res = self.client.get(
+                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions"  # noqa
+                )
 
-            assert res.status_code == 200
-            page_html = res.get_data(as_text=True)
-            assert "Supplier questions" in page_html
-            assert "Why is my question a question?" in page_html
-            assert "Because" in page_html
-            assert "Answer a supplier question" in page_html
-            assert "No questions or answers have been published" not in page_html
+                assert res.status_code == 200
+                page_html = res.get_data(as_text=True)
+                assert "Supplier questions" in page_html
+                assert "Why is my question a question?" in page_html
+                assert "Because" in page_html
+                assert "Answer a supplier question" in page_html
+                assert "No questions or answers have been published" not in page_html
 
     def test_404_if_framework_does_not_allow_brief(self, data_api_client):
         with self.app.app_context():
@@ -1642,76 +1731,81 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
 @mock.patch("app.buyers.views.buyers.data_api_client")
 class TestAddBriefClarificationQuestion(BaseApplicationTest):
-    def test_show_brief_clarification_question_form(self, data_api_client):
+    def test_show_brief_clarification_question_form_for_live_and_expired_framework(self, data_api_client):
+        framework_statuses = ['live', 'expired']
         self.login_as_buyer()
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug="digital-outcomes-and-specialists",
-            status="live",
-            lots=[
-                api_stubs.lot(slug="digital-specialists", allows_brief=True)
-            ])
-        brief_json = api_stubs.brief(status="live")
-        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
-        data_api_client.get_brief.return_value = brief_json
+        for framework_status in framework_statuses:
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug="digital-outcomes-and-specialists",
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug="digital-specialists", allows_brief=True)
+                ])
+            brief_json = api_stubs.brief(status="live")
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+            data_api_client.get_brief.return_value = brief_json
 
-        res = self.client.get(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/supplier-questions/answer-question")
+            res = self.client.get(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
+                "/digital-specialists/1234/supplier-questions/answer-question")
 
-        assert res.status_code == 200
+            assert res.status_code == 200
 
-    def test_add_brief_clarification_question(self, data_api_client):
+    def test_add_brief_clarification_question_for_live_and_expired_framework(self, data_api_client):
+        framework_statuses = ['live', 'expired']
         self.login_as_buyer()
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug="digital-outcomes-and-specialists",
-            status="live",
-            lots=[
-                api_stubs.lot(slug="digital-specialists", allows_brief=True)
-            ])
-        brief_json = api_stubs.brief(status="live")
-        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
-        data_api_client.get_brief.return_value = brief_json
+        for framework_status in framework_statuses:
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug="digital-outcomes-and-specialists",
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug="digital-specialists", allows_brief=True)
+                ])
+            brief_json = api_stubs.brief(status="live")
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+            data_api_client.get_brief.return_value = brief_json
 
-        res = self.client.post(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/supplier-questions/answer-question",
-            data={
-                "question": "Why?",
-                "answer": "Because",
-            })
+            res = self.client.post(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
+                "/digital-specialists/1234/supplier-questions/answer-question",
+                data={
+                    "question": "Why?",
+                    "answer": "Because",
+                })
 
-        assert res.status_code == 302
-        data_api_client.add_brief_clarification_question.assert_called_with(
-            "1234", "Why?", "Because", "buyer@email.com")
+            assert res.status_code == 302
+            data_api_client.add_brief_clarification_question.assert_called_with(
+                "1234", "Why?", "Because", "buyer@email.com")
 
-        # test that the redirect ends up on the right page
-        assert res.headers['Location'].endswith(
-            '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions'  # noqa
-        ) is True
+            # test that the redirect ends up on the right page
+            assert res.headers['Location'].endswith(
+                '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/supplier-questions'  # noqa
+            ) is True
 
-    def test_404_if_framework_is_not_live(self, data_api_client):
-        self.login_as_buyer()
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug='digital-outcomes-and-specialists',
-            status='pending',
-            lots=[
-                api_stubs.lot(slug='digital-specialists', allows_brief=True),
-            ]
-        )
-        brief_json = api_stubs.brief()
-        brief_json['briefs']["clarificationQuestionsAreClosed"] = False
-        data_api_client.get_brief.return_value = brief_json
+    def test_404_if_framework_is_not_live_or_expired(self, data_api_client):
+        for framework_status in ['coming', 'open', 'pending', 'standstill']:
+            self.login_as_buyer()
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            brief_json = api_stubs.brief()
+            brief_json['briefs']["clarificationQuestionsAreClosed"] = False
+            data_api_client.get_brief.return_value = brief_json
 
-        res = self.client.post(
-            "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-            "/digital-specialists/1234/supplier-questions/answer-question",
-            data={
-                "question": "Why?",
-                "answer": "Because",
-            })
+            res = self.client.post(
+                "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
+                "/digital-specialists/1234/supplier-questions/answer-question",
+                data={
+                    "question": "Why?",
+                    "answer": "Because",
+                })
 
-        assert res.status_code == 404
-        assert not data_api_client.add_brief_clarification_question.called
+            assert res.status_code == 404
+            assert not data_api_client.add_brief_clarification_question.called
 
     def test_404_if_framework_does_not_allow_brief(self, data_api_client):
         self.login_as_buyer()
@@ -2123,28 +2217,52 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
         super(TestDownloadBriefResponsesView, self).teardown_method(method)
 
     def test_end_to_end(self):
-        self.data_api_client.find_brief_responses.return_value = {
-            'briefResponses': self.responses
-        }
-        self.data_api_client.get_framework.return_value = api_stubs.framework(
-            slug='digital-outcomes-and-specialists',
-            status='live',
-            lots=[
-                api_stubs.lot(slug='digital-specialists', allows_brief=True),
-            ]
-        )
-        self.data_api_client.get_brief.return_value = {'briefs': self.brief}
-
-        with mock.patch.object(buyers, 'data_api_client', self.data_api_client):
-            self.login_as_buyer()
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists"
-                "/requirements/digital-specialists/1234/responses/download"
+        for framework_status in ['live', 'expired']:
+            self.data_api_client.find_brief_responses.return_value = {
+                'briefResponses': self.responses
+            }
+            self.data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
             )
+            self.data_api_client.get_brief.return_value = {'briefs': self.brief}
 
-        assert res.status_code == 200
-        assert res.mimetype == 'application/vnd.oasis.opendocument.spreadsheet'
-        assert len(res.data) > 100
+            with mock.patch.object(buyers, 'data_api_client', self.data_api_client):
+                self.login_as_buyer()
+                res = self.client.get(
+                    "/buyers/frameworks/digital-outcomes-and-specialists"
+                    "/requirements/digital-specialists/1234/responses/download"
+                )
+
+            assert res.status_code == 200
+            assert res.mimetype == 'application/vnd.oasis.opendocument.spreadsheet'
+            assert len(res.data) > 100
+
+    def test_404_if_framework_is_not_live_or_expired(self):
+        for framework_status in ['coming', 'open', 'pending', 'standstill']:
+            self.data_api_client.find_brief_responses.return_value = {
+                'briefResponses': self.responses
+            }
+            self.data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            self.data_api_client.get_brief.return_value = {'briefs': self.brief}
+
+            with mock.patch.object(buyers, 'data_api_client', self.data_api_client):
+                self.login_as_buyer()
+                res = self.client.get(
+                    "/buyers/frameworks/digital-outcomes-and-specialists"
+                    "/requirements/digital-specialists/1234/responses/download"
+                )
+
+            assert res.status_code == 404
 
     def test_get_responses(self):
         brief = mock.Mock()
@@ -2538,26 +2656,27 @@ class TestDownloadBriefResponsesCsv(BaseApplicationTest):
         }
 
     def test_csv_includes_all_eligible_responses_and_no_ineligible_responses(self, data_api_client):
-        data_api_client.find_brief_responses.return_value = self.brief_responses
-        data_api_client.get_framework.return_value = api_stubs.framework(
-            slug='digital-outcomes-and-specialists',
-            status='live',
-            lots=[
-                api_stubs.lot(slug='digital-specialists', allows_brief=True),
-            ]
-        )
-        data_api_client.get_brief.return_value = self.brief
+        for framework_status in ['live', 'expired']:
+            data_api_client.find_brief_responses.return_value = self.brief_responses
+            data_api_client.get_framework.return_value = api_stubs.framework(
+                slug='digital-outcomes-and-specialists',
+                status=framework_status,
+                lots=[
+                    api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                ]
+            )
+            data_api_client.get_brief.return_value = self.brief
 
-        self.login_as_buyer()
-        res = self.client.get(self.url)
-        page = res.get_data(as_text=True)
-        lines = page.splitlines()
-        # There are only the two eligible responses included
-        assert len(lines) == 3
-        assert lines[0] == "Supplier,Date the specialist can start work,Day rate,Nice1,Nice2,Nice3,Email address"
-        # The response with two nice-to-haves is sorted to above the one with only one
-        assert lines[1] == "Kev's Pies,A week Friday,£3.50,False,True,True,test2@email.com"
-        assert lines[2] == "Kev's Butties,Next Tuesday,£1.49,True,False,False,test1@email.com"
+            self.login_as_buyer()
+            res = self.client.get(self.url)
+            page = res.get_data(as_text=True)
+            lines = page.splitlines()
+            # There are only the two eligible responses included
+            assert len(lines) == 3
+            assert lines[0] == "Supplier,Date the specialist can start work,Day rate,Nice1,Nice2,Nice3,Email address"
+            # The response with two nice-to-haves is sorted to above the one with only one
+            assert lines[1] == "Kev's Pies,A week Friday,£3.50,False,True,True,test2@email.com"
+            assert lines[2] == "Kev's Butties,Next Tuesday,£1.49,True,False,False,test1@email.com"
 
     def test_download_brief_responses_for_brief_without_nice_to_haves(self, data_api_client):
         data_api_client.get_framework.return_value = api_stubs.framework(
@@ -2634,43 +2753,79 @@ class TestDownloadBriefResponsesCsv(BaseApplicationTest):
         res = self.client.get(self.url)
         assert res.status_code == 404
 
-
-@mock.patch('app.buyers.views.buyers.data_api_client')
-class TestViewQuestionAndAnswerDates(BaseApplicationTest):
-    def test_show_question_and_answer_dates_for_published_brief(self, data_api_client):
-        with self.app.app_context():
-            self.login_as_buyer()
+    def test_404_if_framework_is_not_live_or_expired(self, data_api_client):
+        for framework_status in ['coming', 'open', 'pending', 'standstill']:
             data_api_client.get_framework.return_value = api_stubs.framework(
                 slug='digital-outcomes-and-specialists',
-                status='live',
+                status=framework_status,
                 lots=[
                     api_stubs.lot(slug='digital-specialists', allows_brief=True),
                 ]
             )
-            brief_json = api_stubs.brief(status="live")
-            brief_json['briefs']['requirementsLength'] = '2 weeks'
-            brief_json['briefs']['publishedAt'] = u"2016-04-02T20:10:00.00000Z"
-            brief_json['briefs']['clarificationQuestionsClosedAt'] = u"2016-04-12T23:59:00.00000Z"
-            brief_json['briefs']['clarificationQuestionsPublishedBy'] = u"2016-04-14T23:59:00.00000Z"
-            brief_json['briefs']['applicationsClosedAt'] = u"2016-04-16T23:59:00.00000Z"
-            brief_json['briefs']['specialistRole'] = 'communicationsManager'
-            brief_json['briefs']["clarificationQuestionsAreClosed"] = True
-            data_api_client.get_brief.return_value = brief_json
+            data_api_client.get_brief.return_value = api_stubs.brief(status='closed')
 
-            res = self.client.get(
-                "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/timeline"
-            )
+            self.login_as_buyer()
+            res = self.client.get(self.url)
+            assert res.status_code == 404
 
-            assert res.status_code == 200
-            page_html = res.get_data(as_text=True)
-            document = html.fromstring(page_html)
 
-            assert (document.xpath('//h1')[0]).text_content().strip() == "Question and answer dates"
-            assert all(
-                date in
-                [e.text_content() for e in document.xpath('//main[@id="content"]//th/span')]
-                for date in ['2 April', '8 April', '15 April', '16 April']
-            )
+@mock.patch('app.buyers.views.buyers.data_api_client')
+class TestViewQuestionAndAnswerDates(BaseApplicationTest):
+    def test_show_question_and_answer_dates_for_published_brief(self, data_api_client):
+        for framework_status in ['live', 'expired']:
+            with self.app.app_context():
+                self.login_as_buyer()
+                data_api_client.get_framework.return_value = api_stubs.framework(
+                    slug='digital-outcomes-and-specialists',
+                    status=framework_status,
+                    lots=[
+                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                    ]
+                )
+                brief_json = api_stubs.brief(status="live")
+                brief_json['briefs']['requirementsLength'] = '2 weeks'
+                brief_json['briefs']['publishedAt'] = u"2016-04-02T20:10:00.00000Z"
+                brief_json['briefs']['clarificationQuestionsClosedAt'] = u"2016-04-12T23:59:00.00000Z"
+                brief_json['briefs']['clarificationQuestionsPublishedBy'] = u"2016-04-14T23:59:00.00000Z"
+                brief_json['briefs']['applicationsClosedAt'] = u"2016-04-16T23:59:00.00000Z"
+                brief_json['briefs']['specialistRole'] = 'communicationsManager'
+                brief_json['briefs']["clarificationQuestionsAreClosed"] = True
+                data_api_client.get_brief.return_value = brief_json
+
+                res = self.client.get(
+                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/timeline"
+                )
+
+                assert res.status_code == 200
+                page_html = res.get_data(as_text=True)
+                document = html.fromstring(page_html)
+
+                assert (document.xpath('//h1')[0]).text_content().strip() == "Question and answer dates"
+                assert all(
+                    date in
+                    [e.text_content() for e in document.xpath('//main[@id="content"]//th/span')]
+                    for date in ['2 April', '8 April', '15 April', '16 April']
+                )
+
+    def test_404_if_framework_is_not_live_or_expired(self, data_api_client):
+        for framework_status in ['coming', 'open', 'pending', 'standstill']:
+            with self.app.app_context():
+                self.login_as_buyer()
+                data_api_client.get_framework.return_value = api_stubs.framework(
+                    slug='digital-outcomes-and-specialists',
+                    status=framework_status,
+                    lots=[
+                        api_stubs.lot(slug='digital-specialists', allows_brief=True),
+                    ]
+                )
+                brief_json = api_stubs.brief(status="live")
+                data_api_client.get_brief.return_value = brief_json
+
+                res = self.client.get(
+                    "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/timeline"
+                )
+
+                assert res.status_code == 404
 
     def test_do_not_show_question_and_answer_dates_for_draft_brief(self, data_api_client):
         with self.app.app_context():


### PR DESCRIPTION
Part of this story: [https://www.pivotaltracker.com/story/show/139283847](https://www.pivotaltracker.com/story/show/139283847)

When DOS1 expires and DOS2 comes live, there are some key areas for the DOS1 framework that it is important still work. Expiring the framework broke some of them. The ones identified that this PR fixes are listed below.

- Viewing a briefs overview
- Viewing the brief responses page
- Downloading an ods/csv of the responses.
- Viewing a live briefs timeline
- Viewing supplier questions
- Adding/answering supplier questions

They were all failing due to a helper called `get_framework_and_lot` which took in the required framework status as a parameter, and was restricted to only one status. That helper has been updated to be able to take multiple statuses. Previously we were only allowing the above actions for a `live` framework. We now allow them for `live` and `expired` frameworks. We do NOT allow things like creating/publishing/editing briefs for `expired` frameworks however.

There is a thought that we may not even need to check the framework status for some of these things. For example, viewing a briefs overview is restricted to briefs on a framework that is `live` or `expired`. Why? A brief cannot be created unless the framework is live, so to explicitly disallow the viewing of a brief that is on a framework thats status is `coming`, `open`, `pending`, or  `standstill` seems overkill. No harm, but why bother?
