### PR TITLE
Don't override margin styles in homepage sidebar

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -73,7 +73,6 @@
   .supplier-messages {
 
     p {
-      margin: 0;
 
       &.hint {
         color: $grey-1;


### PR DESCRIPTION
Styles in the app for `supplier-messages` were overriding the styles of things from the frontend toolkit.

Ralph doesn't like this.

Spot the difference in the temporary message:
## BEFORE
![screen shot 2017-02-16 at 11 31 50](https://cloud.githubusercontent.com/assets/6525554/23019735/c1172a6c-f43b-11e6-8e32-2a1514657674.png)


## AFTER
![screen shot 2017-02-16 at 11 32 38](https://cloud.githubusercontent.com/assets/6525554/23019734/becfe4d8-f43b-11e6-98e5-421ecd56d197.png)

