### PR TITLE
Increase service-meta font sizes

### DIFF
--- a/app/assets/scss/_service-page.scss
+++ b/app/assets/scss/_service-page.scss
@@ -1,4 +1,5 @@
 // styles specific to service pages
+@import "shared_placeholders/_visuallyhidden.scss";
 
 %sub-heading {
   @include core-24;
@@ -61,7 +62,7 @@
   }
 
   .contact-details-organisation {
-    display: none;
+    @extend %visuallyhidden;
   }
 
   .framework-name {

--- a/app/assets/scss/_service-page.scss
+++ b/app/assets/scss/_service-page.scss
@@ -98,6 +98,6 @@
 }
 
 .sidebar-heading {
-  @include bold-16;
+  @include bold-19;
   margin-bottom: 5px;
 }

--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -48,7 +48,8 @@
       </div>
     {% endif %}
 
-    <aside role="complementary" class="column-one-third" aria-label="Supplier contact">
+    <aside id="meta" role="complementary" class="column-one-third" aria-label="Supplier contact">
+      <h2 class="sidebar-heading">Contact</h2>
       {%
         with
         organisation_type = "supplier",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v19.5.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.17.3/jinja_govuk_template-0.17.3.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.15.3"
   }


### PR DESCRIPTION
This is, I think, the intended effect of @Wynndow's [pull request in the frontend-toolkit](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/303).

@ralph-hawkins says we want the headers to be the same size as the text for the service meta-info, but bumping the font-size of the organisation won't have a visible effect on the service page.

This pull request:

- bumps the service meta headers
- uses the `.visuallyhidden` styles for the organsation name instead of `display: none;`
- adds an `id` and an `h2` to the A-Z supplier listing template to give the service pages and the supplier pages matching markup.

## service meta headers

| old | new |
|-----|-------------|
| ![screen shot 2017-02-16 at 11 51 57](https://cloud.githubusercontent.com/assets/2454380/23020447/148402f8-f43f-11e6-81a5-3937ee4905c9.png) | ![screen shot 2017-02-16 at 11 47 02](https://cloud.githubusercontent.com/assets/2454380/23020446/1483971e-f43f-11e6-9039-60c61236fb4e.png) |

## supplier A-Z page

The contact information now says "Contact" instead of listing the supplier name (which is already the title of this page).

| old | new |
|-----|-------------|
| ![screen shot 2017-02-16 at 11 44 13](https://cloud.githubusercontent.com/assets/2454380/23020434/08625556-f43f-11e6-8ccd-00885d6deb29.png) | ![screen shot 2017-02-16 at 11 45 07](https://cloud.githubusercontent.com/assets/2454380/23020435/08660318-f43f-11e6-8189-587ca377243a.png) |

## wraith diffs

ran off some diffs of some pages yo

### supplier page

![1024_phantomjs_diff](https://cloud.githubusercontent.com/assets/2454380/23032142/70615fa4-f46b-11e6-911c-2a95c7e62da2.png)

### service page

![1024_phantomjs_diff](https://cloud.githubusercontent.com/assets/2454380/23032155/7936626e-f46b-11e6-8daf-30a622d34ab4.png)
