### PR TITLE
add column with framework name to buyer dashboard

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -30,6 +30,10 @@ from io import BytesIO
 
 from collections import Counter
 
+from typogrify.filters import widont
+from typogrify.templatetags.jinja_filters import make_safe
+
+buyers.add_app_template_filter(make_safe(widont))
 
 @buyers.route('')
 def buyer_dashboard():

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -35,6 +35,7 @@ from typogrify.templatetags.jinja_filters import make_safe
 
 buyers.add_app_template_filter(make_safe(widont))
 
+
 @buyers.route('')
 def buyer_dashboard():
     user_briefs = data_api_client.find_briefs(current_user.id).get('briefs', [])

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -88,6 +88,7 @@
     empty_message="You don’t have any published requirements",
     field_headings=[
     "Brief name",
+    "Framework",
     "Published",
     "Closing",
     ],
@@ -96,11 +97,12 @@
 
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
-        {{ summary.text(item.publishedAt|dateformat) }}
+        {{ summary.text(item.frameworkName|widont) }}
+        {{ summary.text(item.publishedAt|dateformat|widont) }}
         {{ summary.text(item.applicationsClosedAt|dateformat) }}
     {% endcall %}
 {% endcall %}
-        
+
 {{ summary.heading("Closed requirements", id="closed_requirements") }}
 {% call(item) summary.list_table(
     closed_briefs,
@@ -108,6 +110,7 @@
     empty_message="You don’t have any requirements that are closed",
     field_headings=[
     "Brief name",
+    "Framework",
     "Closed",
     "Responses",
     ],
@@ -116,7 +119,8 @@
 
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
-        {{ summary.text(item.applicationsClosedAt|dateformat) }}
+        {{ summary.text(item.frameworkName|widont) }}
+        {{ summary.text(item.applicationsClosedAt|dateformat|widont) }}
         {{ summary.link("View responses", url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -65,9 +65,9 @@
 
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
-        
-        {{ summary.text(item.createdAt|dateformat) }}
-        
+
+        {{ summary.text(item.createdAt|dateformat|widont) }}
+
         {% if item.unanswered_required > 0 and item.unanswered_optional > 0 %}
             {{ summary.text("{} required<br>{} optional".format(item.unanswered_required, item.unanswered_optional)|safe) }}
         {% elif item.unanswered_required > 0 %}
@@ -99,7 +99,7 @@
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.frameworkName|widont) }}
         {{ summary.text(item.publishedAt|dateformat|widont) }}
-        {{ summary.text(item.applicationsClosedAt|dateformat) }}
+        {{ summary.text(item.applicationsClosedAt|dateformat|widont) }}
     {% endcall %}
 {% endcall %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ inflection==0.2.1
 unicodecsv==0.14.1
 werkzeug==0.10.4
 odfpy==1.3.3
+typogrify==2.0.7
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.0.4#egg=digitalmarketplace-utils==24.0.4
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -32,12 +32,22 @@ class TestBuyerDashboard(BaseApplicationTest):
                     {"status": "draft",
                      "title": "A draft brief",
                      "createdAt": "2016-02-02T00:00:00.000000Z",
-                     "frameworkSlug": "digital-outcomes-and-specialists"},
+                     "frameworkSlug": "digital-outcomes-and-specialists",
+                     "frameworkName": "Digital Outcomes and Specialists"},
                     {"status": "live",
                      "title": "A live brief",
                      "createdAt": "2016-02-01T00:00:00.000000Z",
                      "publishedAt": "2016-02-04T12:00:00.000000Z",
-                     "frameworkSlug": "digital-outcomes-and-specialists"},
+                     "applicationsClosedAt": "2016-02-15T12:00:00.000000Z",
+                     "frameworkSlug": "digital-outcomes-and-specialists",
+                     "frameworkName": "Digital Outcomes and Specialists"},
+                    {"status": "closed",
+                     "title": "A closed brief",
+                     "createdAt": "2016-02-01T00:00:00.000000Z",
+                     "publishedAt": "2016-02-04T12:00:00.000000Z",
+                     "applicationsClosedAt": "2016-02-15T12:00:00.000000Z",
+                     "frameworkSlug": "digital-outcomes-and-specialists",
+                     "frameworkName": "Digital Outcomes and Specialists"},
                 ]
             }
 
@@ -49,11 +59,17 @@ class TestBuyerDashboard(BaseApplicationTest):
             tables = document.xpath('//table')
             draft_row = [cell.text_content().strip() for cell in tables[0].xpath('.//tbody/tr/td')]
             assert draft_row[0] == "A draft brief"
-            assert draft_row[1] == "Tuesday 2 February 2016"
+            assert draft_row[1] == "Tuesday 2 February\u00a02016"
 
             live_row = [cell.text_content().strip() for cell in tables[1].xpath('.//tbody/tr/td')]
             assert live_row[0] == "A live brief"
-            assert live_row[1] == "Thursday 4 February 2016"
+            assert live_row[1] == "Digital Outcomes and\u00a0Specialists"
+            assert live_row[2] == "Thursday 4 February\u00a02016"
+
+            closed_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr/td')]
+            assert closed_row[0] == "A closed brief"
+            assert closed_row[1] == "Digital Outcomes and\u00a0Specialists"
+            assert closed_row[2] == "Monday 15 February\u00a02016"
 
 
 @mock.patch('app.buyers.views.buyers.data_api_client')


### PR DESCRIPTION
adds a column with the framework name, and prevents widows in the date and framework columns