### PR TITLE
Update content on shortlisting page

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -298,19 +298,18 @@ def view_brief_responses(framework_slug, lot_slug, brief_id):
 
     brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
 
-    met = None
+    new_flow_brief = (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
+                      <= datetime.strptime(brief['publishedAt'][0:10], "%Y-%m-%d"))
 
     counter = Counter()
 
     for response in brief_responses:
-        met = response.get('essentialRequirementsMet', None)
-
         counter[all(response['essentialRequirements'])] += 1
 
     return render_template(
         "buyers/brief_responses.html",
         response_counts={"failed": counter[False], "eligible": counter[True]},
-        ods=met is not None,  # will be None for legacy responses
+        new_flow_brief=new_flow_brief,
         brief=brief
     ), 200
 

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -298,8 +298,10 @@ def view_brief_responses(framework_slug, lot_slug, brief_id):
 
     brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
 
-    new_flow_brief = (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
-                      <= datetime.strptime(brief['publishedAt'][0:10], "%Y-%m-%d"))
+    brief_responses_require_evidence = (
+        datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
+        <= datetime.strptime(brief['publishedAt'][0:10], "%Y-%m-%d")
+    )
 
     counter = Counter()
 
@@ -309,7 +311,7 @@ def view_brief_responses(framework_slug, lot_slug, brief_id):
     return render_template(
         "buyers/brief_responses.html",
         response_counts={"failed": counter[False], "eligible": counter[True]},
-        new_flow_brief=new_flow_brief,
+        brief_responses_require_evidence=brief_responses_require_evidence,
         brief=brief
     ), 200
 

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -38,11 +38,12 @@
 <div class="grid-row">
     <div class="column-two-thirds">
       {% if response_counts['eligible'] > 0 %}
-        {% if ods %}
+        {% if new_flow_brief %}
           <div class="dmspeak">
               <p>
                 <span class='visual-emphasis'>{{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "supplier", "suppliers") }}</span>
-                responded to your requirements and {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential skills and experience. Suppliers that didn't meet all your essential requirements have already been told they were unsuccessful.
+                responded to your requirements and {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential skills and experience.
+                Any suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
               </p>
               <p>
                 You said you’d take <span class='visual-emphasis'>{{ brief.numberOfSuppliers }} {{ pluralize(brief.numberOfSuppliers, "supplier", "suppliers") }}</span> through to the evaluation stage. To do this, you need to:
@@ -93,11 +94,8 @@
             <p>
                 <span class='visual-emphasis'>{{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "supplier", "suppliers") }}</span>
                 responded to your requirements and {{ pluralize(response_counts['eligible'], "meets", "meet") }} all your essential skills and experience.
+                Any suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
             </p>
-            <p>
-                Suppliers that did not meet all your essential requirements have already been told they were unsuccessful.
-            </p>
-
             <p>
               Download the list of supplier responses and follow the guidance on <a href="https://www.gov.uk/guidance/how-to-shortlist-digital-outcomes-and-specialists-suppliers">how to shortlist</a>.
             </p>
@@ -131,9 +129,11 @@
           <p>
               No suppliers met your essential skills and experience requirements.
           </p>
-          <p>
-              All the suppliers who applied have already been told they were unsuccessful.
-          </p>
+          {% if not new_flow_brief %}
+            <p>
+                All the suppliers who applied have already been told they were unsuccessful.
+            </p>
+          {% endif %}
         </div>
         <div class='explanation-list'>
             <p class='lead'>

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -38,7 +38,7 @@
 <div class="grid-row">
     <div class="column-two-thirds">
       {% if response_counts['eligible'] > 0 %}
-        {% if new_flow_brief %}
+        {% if brief_responses_require_evidence %}
           <div class="dmspeak">
               <p>
                 <span class='visual-emphasis'>{{ response_counts['eligible'] }} {{ pluralize(response_counts['eligible'], "supplier", "suppliers") }}</span>
@@ -129,7 +129,7 @@
           <p>
               No suppliers met your essential skills and experience requirements.
           </p>
-          {% if not new_flow_brief %}
+          {% if not brief_responses_require_evidence %}
             <p>
                 All the suppliers who applied have already been told they were unsuccessful.
             </p>


### PR DESCRIPTION
For these stories on Pivotal:
[https://www.pivotaltracker.com/story/show/139290411](https://www.pivotaltracker.com/story/show/139290411)
[https://www.pivotaltracker.com/story/show/138994639](https://www.pivotaltracker.com/story/show/138994639)

This PR updates content displayed when a buyer view the shortlist page for a brief. It also changes the way that page decides to render content for a legacy style brief or a new flow style brief. Details below.

When there are no responses to a brief the content displayed needs to be
different depending on if the brief is a legacy brief (no evidence
required for responses), or a new flow brief (evidence required in
responses).

Previously the split between new and old style briefs was being
determined by the `requirementsMet` key of the responses. If there are
no responses however this breaks down and we need another way to
determine what kind of brief we're dealing with.

This can be done by comparing the `publishedAt` date of the brief with
the feature flag set in the config.

This may not be a permanent solution. We may want to remove that flag at
some point in the future. We could possibly hard code the date the new
flow went live in the logic.

Screenshots:

Legacy brief, no responses

![screen shot 2017-02-21 at 15 51 16](https://cloud.githubusercontent.com/assets/13836290/23176908/e2ac6686-f85c-11e6-8492-49099c0e6205.png)

Legacy brief with valid responses

![screen shot 2017-02-21 at 15 41 45](https://cloud.githubusercontent.com/assets/13836290/23176920/edfb7e14-f85c-11e6-8988-dcdb4470a75e.png)

New flow style brief, no responses

![screen shot 2017-02-21 at 16 02 08](https://cloud.githubusercontent.com/assets/13836290/23176935/fb7b465a-f85c-11e6-99ec-01fb41733bbf.png)

New flow style brief, with responses

![screen shot 2017-02-21 at 15 42 28](https://cloud.githubusercontent.com/assets/13836290/23176943/04c0bdda-f85d-11e6-8107-9590eee72c95.png)









