### PR TITLE
Display framework on opportunites page

### DIFF
--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -17,6 +17,9 @@
         <li class="search-result-metadata-item">
             {{ brief.lotName }}
         </li>
+        <li class="search-result-metadata-item">
+            {{ brief.frameworkName }}
+        </li>
     </ul>
 
     <ul class="search-result-metadata">

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -31,7 +31,7 @@
     {
       "startDate":"29th March",
       "links":{
-        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists",
+        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists-2",
         "self":"http://localhost:5000/briefs/4"
       },
       "evaluationType":[
@@ -73,9 +73,9 @@
         }
       ],
       "title":"Another requirement",
-      "frameworkSlug":"digital-outcomes-and-specialists",
+      "frameworkSlug":"digital-outcomes-and-specialists-2",
       "additionalTerms":"You'll never work in this town again.",
-      "frameworkName":"Digital Outcomes and Specialists",
+      "frameworkName":"Digital Outcomes and Specialists 2",
       "publishedAt":"2016-03-07T16:02:51.591567Z"
     }
   ],

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -720,6 +720,11 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         ss_elem = document.xpath("//p[@class='search-summary']")[0]
         assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "2 opportunities"
 
+        dos1_framework_label = document.xpath("//div[@class='search-result']/ul[2]/li[2]/text()")[0].strip()
+        dos2_framework_label = document.xpath("//div[@class='search-result']/ul[2]/li[2]/text()")[1].strip()
+        assert dos1_framework_label == "Digital Outcomes and Specialists"
+        assert dos2_framework_label == "Digital Outcomes and Specialists 2"
+
     def test_catalogue_of_briefs_page_filtered(self):
         original_url = "/digital-outcomes-and-specialists/opportunities?page=2&status=live&lot=lot-one&lot=lot-three"
         res = self.client.get(original_url)


### PR DESCRIPTION
For this story on Pivotal: [https://www.pivotaltracker.com/story/show/139281925](https://www.pivotaltracker.com/story/show/139281925)

As a supplier you want to know if an opportunity is on DOS1 or DOS2. This adds a label to each opportunity listing on the briefs catalogue page.

Screenshot below.

![screen shot 2017-02-22 at 15 46 45](https://cloud.githubusercontent.com/assets/13836290/23219148/3447e5c4-f916-11e6-9cc7-1a7bed31a61c.png)
