### PR TITLE
Remove legacy behaviour to link to old supplier flow

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -105,17 +105,11 @@ def get_brief_by_id(framework_framework, brief_id):
         brief
     )
 
-    new_flow_brief = False
-    if feature.is_active('NEW_SUPPLIER_FLOW'):
-        new_flow_brief = (datetime.strptime(current_app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'], "%Y-%m-%d")
-                          <= datetime.strptime(brief['publishedAt'][0:10], "%Y-%m-%d"))
-
     return render_template(
         'brief.html',
         brief=brief,
         brief_responses=brief_responses,
-        content=brief_content,
-        new_flow_brief=new_flow_brief,
+        content=brief_content
     )
 
 

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -70,36 +70,23 @@
     </div>
   </div>
 {% elif brief.status == 'live' %}
-  {% if new_flow_brief %}
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <h2 class="summary-item-heading">Apply for this opportunity</h2>
-        <p class="dmspeak">To apply, you must give evidence for all the essential and nice-to-have skills and experience you have.</p>
-      </div>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h2 class="summary-item-heading">Apply for this opportunity</h2>
+      <p class="dmspeak">To apply, you must give evidence for all the essential and nice-to-have skills and experience you have.</p>
     </div>
-    <div class="grid-row">
-      <div class="column-one-third">
-        {% with
-           url = "/suppliers/opportunities/{}/responses/start".format(brief.id),
-           label = "Apply",
-           advice = True
-        %}
-          {% include "toolkit/link-button.html" %}
-        {% endwith %}
-      </div>
+  </div>
+  <div class="grid-row">
+    <div class="column-one-third">
+      {% with
+         url = "/suppliers/opportunities/{}/responses/start".format(brief.id),
+         label = "Apply",
+         advice = True
+      %}
+        {% include "toolkit/link-button.html" %}
+      {% endwith %}
     </div>
-  {% else %}
-    <div class="grid-row">
-      <div class="column-one-third">
-        {% with
-           url = "/suppliers/opportunities/{}/responses/create".format(brief.id),
-           label = "Start application"
-        %}
-          {% include "toolkit/link-button.html" %}
-        {% endwith %}
-      </div>
-    </div>
-  {% endif %}
+  </div>
 {% endif %}
 
 {% endblock %}

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -343,10 +343,6 @@ class TestBriefPage(BaseApplicationTest):
 
         self.brief = self._get_dos_brief_fixture_data()
         self._data_api_client.get_brief.return_value = self.brief
-        self.application_path = 'start'
-        self.expected_message = "To apply, you must give evidence for all the essential and nice-to-have " \
-            "skills and experience you have."
-        self.expected_button_text = 'Apply'
 
     def teardown_method(self, method):
         self._data_api_client.stop()
@@ -491,11 +487,7 @@ class TestBriefPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/{}"]'.format(
-            brief_id, self.application_path)
-        )
-
-        assert len(apply_links) == 1
+        self._assert_start_application(document, brief_id)
 
     def test_cannot_apply_to_closed_brief(self):
         self.brief['briefs']['status'] = "closed"
@@ -505,10 +497,7 @@ class TestBriefPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/{}"]'.format(
-            brief_id, self.application_path
-            )
-        )
+        apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/start"]'.format(brief_id))
         assert len(apply_links) == 0
         assert '15 December 2016' in document.xpath('//p[@class="banner-message"]')[0].text_content()
 
@@ -523,16 +512,16 @@ class TestBriefPage(BaseApplicationTest):
         message_list = document.xpath("//p[@class='dmspeak']/text()")
         message = message_list[0] if message_list else None
 
-        assert message == self.expected_message
+        assert message == "To apply, you must give evidence for all the essential and nice-to-have " \
+            "skills and experience you have."
         assert len(document.xpath(
             '//a[@href="{0}"][contains(normalize-space(text()), normalize-space("{1}"))]'.format(
-                "/suppliers/opportunities/{}/responses/{}".format(brief_id, self.application_path),
-                self.expected_button_text,
+                "/suppliers/opportunities/{}/responses/start".format(brief_id),
+                'Apply',
             )
         )) == 1
 
-    @staticmethod
-    def _assert_view_application(document, brief_id):
+    def _assert_view_application(self, document, brief_id):
         assert len(document.xpath(
             '//a[@href="{0}"][contains(normalize-space(text()), normalize-space("{1}"))]'.format(
                 "/suppliers/opportunities/{}/responses/result".format(brief_id),
@@ -596,33 +585,6 @@ class TestBriefPage(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         self._assert_view_application(document, brief_id)
-
-
-class TestBriefPageWithLegacyBrief(TestBriefPage):
-    # This set of tests is to check the behavior of the brief page with the new flow active, but with a brief published
-    # before the new flow was activated. It should exhibit the same behaviour as the legacy flow.
-    # This class just overwrites the specific data and re-runs all the same tests in the previous class with it.
-
-    def setup_method(self, method):
-        super(TestBriefPageWithLegacyBrief, self).setup_method(method)
-        self.brief['briefs']['publishedAt'] = "2016-11-01T11:09:28.054129Z"
-        self.application_path = 'create'
-        self.expected_message = None
-        self.expected_button_text = 'Start application'
-
-
-class TestBriefPageWithLegacyFlow(TestBriefPage):
-    # This set of tests is to check the behaviour of the brief page with the new flow not active. This is important as
-    # the production environment will not have the new flow turned on until all the work is in place and ready. These
-    # tests make sure we don't break anything in the mean time.
-    # This class just overwrites the specific data and re-runs all the same tests in the previous class with it.
-
-    def setup_method(self, method):
-        super(TestBriefPageWithLegacyFlow, self).setup_method(method)
-        self.app.config['FEATURE_FLAGS_NEW_SUPPLIER_FLOW'] = False
-        self.application_path = 'create'
-        self.expected_message = None
-        self.expected_button_text = 'Start application'
 
 
 class TestCatalogueOfBriefsPage(BaseApplicationTest):


### PR DESCRIPTION
As all briefs published will be applied to using the old flow we now no longer need to point users to start a brief application using the old flow so we remove this functionality.

Note, tests now no longer need to cover three different cases with very slight differences but only cover the case for the new supplier flow, therefore have had a minor restructure and tidy up.