### PR TITLE
Latest g9 content homepage message

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -357,9 +357,8 @@ class DownloadBriefResponsesView(View):
 
     def get_questions(self, framework_slug, lot_slug, manifest):
         section = 'view-response-to-requirements'
-
         result = self.content_loader.get_manifest(framework_slug, manifest)\
-                                    .filter({'lot': lot_slug})\
+                                    .filter({'lot': lot_slug}, dynamic=False)\
                                     .get_section(section)
 
         return result.questions if result else []
@@ -466,7 +465,7 @@ class DownloadBriefResponsesView(View):
 
         # QUESTIONS
         for question in questions:
-            if question.type in ('boolean_list', 'dynamic_list'):
+            if question._data['type'] in ('boolean_list', 'dynamic_list'):
                 length = len(brief[question.id])
 
                 for i, requirement in enumerate(brief[question.id]):
@@ -488,7 +487,7 @@ class DownloadBriefResponsesView(View):
             sheet.create_column(stylename="co2", defaultcellstylename="ce1")
 
             for question in questions:
-                if question.type == 'dynamic_list':
+                if question._data['type'] == 'dynamic_list':
                     if not brief.get(question.id):
                         continue
 

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v20.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v5.15.4"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v6.4.4"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ werkzeug==0.10.4
 odfpy==1.3.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@24.0.4#egg=digitalmarketplace-utils==24.0.4
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@2.1.0#egg=digitalmarketplace-content-loader==2.1.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@3.5.0#egg=digitalmarketplace-content-loader==3.5.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.4.0#egg=digitalmarketplace-apiclient==8.4.0
 
 # For Cloud Foundry

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -2279,7 +2279,7 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
         self.content_loader.get_manifest\
             .assert_called_once_with(framework_slug, manifest)
 
-        obj.filter.assert_called_once_with({'lot': lot_slug})
+        obj.filter.assert_called_once_with({'lot': lot_slug}, dynamic=False)
 
         content.get_section\
                .assert_called_once_with('view-response-to-requirements')


### PR DESCRIPTION
This pulls in the latest content - net effect is hopefully just that the "G9 open" message changes from GMT to BST.

i.e it will now look like:

![screen shot 2017-03-06 at 13 48 53](https://cloud.githubusercontent.com/assets/6525554/23612533/b516f6e8-0273-11e7-836a-201c2deccb2c.png)

In doing this there was a major version change for both the content and content loader modules.

This created some issues for downloading responses to briefs (the ODS spreadsheet of responses).

I have fixed things so the unit tests pass, but once merged it will definitely need to be checked on Preview that downloading brief responses still works correctly (i.e. that the file is generated and downloads OK, and that the data is as expected).