### PR TITLE
404 brief responses page if brief is not closed

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -296,6 +296,9 @@ def view_brief_responses(framework_slug, lot_slug, brief_id):
     if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
         abort(404)
 
+    if brief['status'] != "closed":
+        abort(404)
+
     brief_responses = data_api_client.find_brief_responses(brief_id)['briefResponses']
 
     brief_responses_require_evidence = (

--- a/app/templates/buyers/brief_responses.html
+++ b/app/templates/buyers/brief_responses.html
@@ -67,27 +67,19 @@
               {% include "toolkit/instruction-list.html" %}
           {% endwith %}
 
-          {% if brief.get("status") == "closed" %}
-              {%
-              with
-              items = [
-                  {
-                      "title": "Download supplier responses to this requirement",
-                      "link": url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-                      "file_type": "ODS",
-                      "download": "True"
-                  }
-              ]
-              %}
-                  {% include "toolkit/documents.html" %}
-              {% endwith %}
-          {% else %}
-          <div class="dmspeak">
-            <p>
-                The file will be available here once applications have closed.
-            </p>
-          </div>
-          {% endif %}
+          {%
+          with
+          items = [
+              {
+                  "title": "Download supplier responses to this requirement",
+                  "link": url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  "file_type": "ODS",
+                  "download": "True"
+              }
+          ]
+          %}
+              {% include "toolkit/documents.html" %}
+          {% endwith %}
 
         {% else %}
           <div class="dmspeak">
@@ -101,27 +93,19 @@
             </p>
           </div>
 
-          {% if brief.get("status") == "closed" %}
-              {%
-              with
-              items = [
-                  {
-                      "title": "Download supplier responses to \u2018" + brief.get('title', brief['lotName']) + "\u2019",
-                      "link": url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
-                      "file_type": "CSV",
-                      "download": "True"
-                  }
-              ]
-              %}
-                  {% include "toolkit/documents.html" %}
-              {% endwith %}
-          {% else %}
-          <div class="dmspeak">
-            <p>
-                The file will be available here once applications have closed.
-            </p>
-          </div>
-          {% endif %}
+          {%
+          with
+          items = [
+              {
+                  "title": "Download supplier responses to \u2018" + brief.get('title', brief['lotName']) + "\u2019",
+                  "link": url_for('buyers.download_brief_responses', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id),
+                  "file_type": "CSV",
+                  "download": "True"
+              }
+          ]
+          %}
+              {% include "toolkit/documents.html" %}
+          {% endwith %}
 
         {% endif %}
       {% else %}


### PR DESCRIPTION
For this pivotal story - https://www.pivotaltracker.com/story/show/138995271

Previously we were somewhat supporting this page for live briefs even though we didn't link to the page. We have removed this functionality because there were bugs on the page for live briefs and we had no evidence that it is worth the maintenance cost as the page is effectively hidden unless a user 'hacks' the url.