### PR TITLE
140921999-Create-the-ability-to-segment-opportunities-by-lot

### DIFF
--- a/app/assets/javascripts/analytics/_pageViews.js
+++ b/app/assets/javascripts/analytics/_pageViews.js
@@ -7,6 +7,7 @@
 
     'setCustomDimensions': function() {
       var search = GOVUK.GDM.analytics.location.search(),
+          pathname = GOVUK.GDM.analytics.location.pathname(),
           filterGroupDimension = [],
           numberOfOpportunites,
           dimensions,
@@ -16,7 +17,7 @@
           j;
 
       // check that we're on the catalogue page for opportunites
-      if (GOVUK.GDM.analytics.location.pathname() === "/digital-outcomes-and-specialists/opportunities") {
+      if (pathname === "/digital-outcomes-and-specialists/opportunities") {
 
         // if it does, we want to send the current number of opportunites back to GA
         numberOfOpportunites = $('.search-summary-count').text();
@@ -72,6 +73,10 @@
             }
           }
         }
+      }
+      if (/^\/digital-outcomes-and-specialists(.*?)\/opportunities\/(\d+)$/.test(pathname)) {
+        var lot = $('[data-lot]').first().data('lot');
+        GOVUK.analytics.setDimension(26, lot);
       }
     }
   };

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -43,6 +43,7 @@
     <header class="page-heading-smaller">
       <p class="context">{{ brief.organisation }}</p>
       <h1>{{ brief.title }}</h1>
+      <span data-lot="{{ brief.lotSlug }}"></span>
     </header>
   </div>
 </div>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [pep8]
-exclude = ./venv,./bower_components,./node_modules,./app/content
+exclude = ./venv*,./bower_components,./node_modules,./app/content
 max-line-length = 120
 
 [pytest]
-norecursedirs = venv app/content bower_components node_modules
+norecursedirs = venv* app/content bower_components node_modules

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -293,4 +293,32 @@ describe("GOVUK.Analytics", function () {
     });
 
   });
+
+  describe("Opportunity page", function() {
+    var lotData = $('<span data-lot="test-lot"></span>');
+
+    beforeEach(function () {
+      $(document.body).append(lotData);
+    });
+
+    afterEach(function () {
+      lotData.remove();
+    });
+
+    it('should send the lot as a custom dimension for any DOS lot', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/digital-outcomes-and-specialists-3/opportunities/100');
+      window.GOVUK.GDM.analytics.pageViews.init();
+      expect(window.ga.calls.all().map(function (i) {return i.args})).toContain(['set', 'dimension26', 'test-lot']);
+    });
+
+    it('should not send the lot as a custom dimension for any non DOS lot', function() {
+      spyOn(GOVUK.GDM.analytics.location, "pathname")
+        .and
+        .returnValue('/not-digital-outcomes-and-specialists/opportunities/100');
+      window.GOVUK.GDM.analytics.pageViews.init();
+      expect(window.ga.calls.all().map(function (i) {return i.args})).not.toContain(['set', 'dimension26', 'test-lot']);
+    });
+  });
 });

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -370,6 +370,16 @@ class TestBriefPage(BaseApplicationTest):
 
         self._assert_page_title(document)
 
+    def test_dos_brief_has_lot_analytics_string(self):
+        brief = self.brief['briefs']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief['id']))
+        assert res.status_code == 200
+
+        data = res.get_data(as_text=True)
+        analytics_string = '<span data-lot="{lot_slug}"></span>'.format(lot_slug=brief['lotSlug'])
+
+        assert analytics_string in data
+
     def _convert_date_to_display_date_format(self, date_string):
         date_object = datetime.strptime(date_string, DATETIME_FORMAT)
         return date_object.strftime(DISPLAY_DATE_FORMAT)


### PR DESCRIPTION
Create the ability to segment opportunities by lot in GA

* Add slug data to template
* Look for the slug and report it to Google Analytics in JS