### PR TITLE
Remove hard-coding to G-Cloud 6 of content (filters, service page).

### DIFF
--- a/app/main/helpers/framework_helpers.py
+++ b/app/main/helpers/framework_helpers.py
@@ -1,0 +1,9 @@
+def get_latest_live_framework(all_frameworks, framework_type):
+    try:
+        latest = max(
+            (f for f in all_frameworks if f['status'] == 'live' and f['framework'] == framework_type),
+            key=lambda f: f['id'],
+        )
+        return latest
+    except ValueError:  # max of empty iterable
+        return None

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -68,6 +68,11 @@ def get_service_by_id(service_id):
 
         service_data = service['services']
         framework_slug = service_data['frameworkSlug']
+
+        # Some frameworks don't actually have framework content of their own (e.g. G-Cloud 4 and 5) - they
+        # use content from some other framework (for those examples, G-Cloud 6 content works fine). In those
+        # cases, we need to override the framework slug that we got from the service data, and load that
+        # content instead.
         override_framework_slug = current_app.config.get('DM_FRAMEWORK_CONTENT_MAP', {}).get(framework_slug)
         if override_framework_slug:
             framework_slug = override_framework_slug

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -68,7 +68,7 @@ def get_service_by_id(service_id):
 
         service_data = service['services']
         framework_slug = service_data['frameworkSlug']
-        override_framework_slug = current_app.config.get('DM_FRAMEWORK_CONTENT_MAP').get(framework_slug)
+        override_framework_slug = current_app.config.get('DM_FRAMEWORK_CONTENT_MAP', {}).get(framework_slug)
         if override_framework_slug:
             framework_slug = override_framework_slug
 

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -21,6 +21,7 @@ from ..helpers.search_helpers import (
     get_lot_from_request, build_search_query,
     clean_request_args
 )
+from ..helpers import framework_helpers
 
 from ..exceptions import AuthException
 from app import search_api_client, data_api_client, content_loader
@@ -66,9 +67,14 @@ def get_service_by_id(service_id):
             abort(404, "Service ID '{}' can not be found".format(service_id))
 
         service_data = service['services']
+        framework_slug = service_data['frameworkSlug']
+        override_framework_slug = current_app.config.get('DM_FRAMEWORK_CONTENT_MAP').get(framework_slug)
+        if override_framework_slug:
+            framework_slug = override_framework_slug
+
         service_view_data = Service(
             service_data,
-            content_loader.get_builder('g-cloud-6', 'display_service').filter(
+            content_loader.get_builder(framework_slug, 'display_service').filter(
                 service_data
             )
         )
@@ -114,10 +120,14 @@ def get_service_by_id(service_id):
 
 @main.route('/g-cloud/search')
 def search_services():
+    # if there are multiple live g-cloud frameworks, we must assume the same filters work on them all
+    all_frameworks = data_api_client.find_frameworks().get('frameworks')
+    framework = framework_helpers.get_latest_live_framework(all_frameworks, 'g-cloud')
+
     # the bulk of the possible filter parameters are defined through the content loader. they're all boolean and the
     # search api uses the same "question" labels as the content for its attributes, so we can really use those labels
     # verbatim. It also means we can use their human-readable names as defined in the content
-    content_manifest = content_loader.get_manifest('g-cloud-6', 'search_filters')
+    content_manifest = content_loader.get_manifest(framework['slug'], 'search_filters')
     # filters - a seq of dicts describing each parameter group
     filters = filters_for_lot(
         get_lot_from_request(request),

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -12,6 +12,7 @@ from dmcontent.content_loader import ContentNotFoundError
 
 from ...main import main
 from ..helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference, parse_link
+from ..helpers.framework_helpers import get_latest_live_framework
 
 from ..forms.brief_forms import BriefSearchForm
 
@@ -47,27 +48,13 @@ def index():
             "framework {} status {}".format(framework.get('slug'), framework.get('status')))
         abort(500)
 
-    live_dos_frameworks = list(
-        filter(
-            lambda framework: framework['framework'] == 'digital-outcomes-and-specialists'
-            and framework['status'] == 'live',
-            frameworks,
-        )
-    )
-
     # Capture the slug for the most recent live framework. There will only be multiple if currently transitioning
     # between frameworks and more than one has a `live` status.
-    dos_slug = None
-    if live_dos_frameworks:
-        dos_slug = sorted(
-            live_dos_frameworks,
-            reverse=True,
-            key=lambda framework: framework['id'],
-        )[0]['slug']
+    dos_framework = get_latest_live_framework(frameworks, 'digital-outcomes-and-specialists')
 
     return render_template(
         'index.html',
-        dos_slug=dos_slug,
+        dos_slug=dos_framework['slug'] if dos_framework else None,
         frameworks={framework['slug']: framework for framework in frameworks},
         temporary_message=temporary_message
     )

--- a/config.py
+++ b/config.py
@@ -71,6 +71,11 @@ class Config(object):
     DM_APP_NAME = 'buyer-frontend'
     DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
 
+    DM_FRAMEWORK_CONTENT_MAP = {
+        'g-cloud-4': 'g-cloud-6',
+        'g-cloud-5': 'g-cloud-6',
+    }
+
     @staticmethod
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))

--- a/config.py
+++ b/config.py
@@ -71,6 +71,11 @@ class Config(object):
     DM_APP_NAME = 'buyer-frontend'
     DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
 
+    #: For some frameworks (represented by the keys in this map), we store no framework content. But
+    #: they work just like some other framework (represented by the values in the map) for which we do
+    #: have content available. The map uses slugs to identify the framework pairs, so that we can still
+    #: find the framework data we need (and so that we can avoid trying to load up framework data that
+    #: isn't actually available).
     DM_FRAMEWORK_CONTENT_MAP = {
         'g-cloud-4': 'g-cloud-6',
         'g-cloud-5': 'g-cloud-6',

--- a/config.py
+++ b/config.py
@@ -91,9 +91,9 @@ class Test(Config):
     DM_LOG_LEVEL = 'CRITICAL'
     WTF_CSRF_ENABLED = False
 
-    DM_DATA_API_URL = "http://localhost:5000"
+    DM_DATA_API_URL = "http://wrong.completely.invalid:5000"
     DM_DATA_API_AUTH_TOKEN = "myToken"
-    DM_SEARCH_API_URL = "http://localhost:5001"
+    DM_SEARCH_API_URL = "http://wrong.completely.invalid:5001"
     DM_SEARCH_API_AUTH_TOKEN = "myToken"
 
     DM_MANDRILL_API_KEY = 'MANDRILL'

--- a/tests/fixtures/frameworks.json
+++ b/tests/fixtures/frameworks.json
@@ -1,0 +1,431 @@
+{
+  "frameworks": [
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 4,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 7",
+      "slug": "g-cloud-7",
+      "status": "live",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 1,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 6",
+      "slug": "g-cloud-6",
+      "status": "expired",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": true,
+      "application_close_date": "2016-06-01T17:00:00.000000Z",
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {
+        "frameworkAgreementVersion": "v1.0",
+        "variations": {
+          "1": {
+            "countersignedAt": "2016-10-05T11:00:00.000000Z",
+            "countersignerName": "Dan Saxby",
+            "countersignerRole": "Category Director",
+            "createdAt": "2016-08-19T15:31:00.000000Z"
+          }
+        }
+      },
+      "frameworkAgreementVersion": "v1.0",
+      "id": 6,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 8",
+      "slug": "g-cloud-8",
+      "status": "live",
+      "variations": {
+        "1": {
+          "countersignedAt": "2016-10-05T11:00:00.000000Z",
+          "countersignerName": "Dan Saxby",
+          "countersignerRole": "Category Director",
+          "createdAt": "2016-08-19T15:31:00.000000Z"
+        }
+      }
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 3,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 5",
+      "slug": "g-cloud-5",
+      "status": "expired",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 2,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 1,
+          "name": "Software as a Service",
+          "oneServiceLimit": false,
+          "slug": "saas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 2,
+          "name": "Platform as a Service",
+          "oneServiceLimit": false,
+          "slug": "paas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 3,
+          "name": "Infrastructure as a Service",
+          "oneServiceLimit": false,
+          "slug": "iaas",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 4,
+          "name": "Specialist Cloud Services",
+          "oneServiceLimit": false,
+          "slug": "scs",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 4",
+      "slug": "g-cloud-4",
+      "status": "expired",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": true,
+      "application_close_date": "2017-01-16T17:00:00.000000Z",
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "digital-outcomes-and-specialists",
+      "frameworkAgreementDetails": {
+        "frameworkAgreementVersion": "v1.0",
+        "variations": {}
+      },
+      "frameworkAgreementVersion": "v1.0",
+      "id": 7,
+      "lots": [
+        {
+          "allowsBrief": true,
+          "id": 5,
+          "name": "Digital outcomes",
+          "oneServiceLimit": true,
+          "slug": "digital-outcomes",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": true,
+          "id": 6,
+          "name": "Digital specialists",
+          "oneServiceLimit": true,
+          "slug": "digital-specialists",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 7,
+          "name": "User research studios",
+          "oneServiceLimit": false,
+          "slug": "user-research-studios",
+          "unitPlural": "labs",
+          "unitSingular": "lab"
+        },
+        {
+          "allowsBrief": true,
+          "id": 8,
+          "name": "User research participants",
+          "oneServiceLimit": true,
+          "slug": "user-research-participants",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "Digital Outcomes and Specialists 2",
+      "slug": "digital-outcomes-and-specialists-2",
+      "status": "live",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": true,
+      "application_close_date": "2016-01-01T15:00:00.000000Z",
+      "clarificationQuestionsOpen": false,
+      "countersignerName": null,
+      "framework": "digital-outcomes-and-specialists",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 5,
+      "lots": [
+        {
+          "allowsBrief": true,
+          "id": 5,
+          "name": "Digital outcomes",
+          "oneServiceLimit": true,
+          "slug": "digital-outcomes",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": true,
+          "id": 6,
+          "name": "Digital specialists",
+          "oneServiceLimit": true,
+          "slug": "digital-specialists",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 7,
+          "name": "User research studios",
+          "oneServiceLimit": false,
+          "slug": "user-research-studios",
+          "unitPlural": "labs",
+          "unitSingular": "lab"
+        },
+        {
+          "allowsBrief": true,
+          "id": 8,
+          "name": "User research participants",
+          "oneServiceLimit": true,
+          "slug": "user-research-participants",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "Digital Outcomes and Specialists",
+      "slug": "digital-outcomes-and-specialists",
+      "status": "live",
+      "variations": {}
+    },
+    {
+      "allow_declaration_reuse": false,
+      "application_close_date": null,
+      "clarificationQuestionsOpen": true,
+      "countersignerName": null,
+      "framework": "g-cloud",
+      "frameworkAgreementDetails": {},
+      "frameworkAgreementVersion": null,
+      "id": 8,
+      "lots": [
+        {
+          "allowsBrief": false,
+          "id": 9,
+          "name": "Cloud hosting",
+          "oneServiceLimit": false,
+          "slug": "cloud-hosting",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 10,
+          "name": "Cloud software",
+          "oneServiceLimit": false,
+          "slug": "cloud-software",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        },
+        {
+          "allowsBrief": false,
+          "id": 11,
+          "name": "Cloud support",
+          "oneServiceLimit": false,
+          "slug": "cloud-support",
+          "unitPlural": "services",
+          "unitSingular": "service"
+        }
+      ],
+      "name": "G-Cloud 9",
+      "slug": "g-cloud-9",
+      "status": "open",
+      "variations": {}
+    }
+  ]
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import os
 import json
 import re
+import mock
 
 from app import create_app, data_api_client
 from datetime import datetime, timedelta
@@ -14,6 +15,12 @@ from dmutils.formats import DATETIME_FORMAT
 
 class BaseApplicationTest(object):
     def setup_method(self, method):
+        # We need to mock the API client in create_app, however we can't use patch the constructor,
+        # as the DataAPIClient instance has already been created; nor can we temporarily replace app.data_api_client
+        # with a mock, because then the shared instance won't have been configured (done in create_app). Instead,
+        # just mock the one function that would make an API call in this case.
+        data_api_client.find_frameworks = mock.Mock()
+        data_api_client.find_frameworks.return_value = BaseApplicationTest._get_fixture_data('frameworks.json')
         self.app = create_app('test')
         self.client = self.app.test_client()
         self.get_user_patch = None

--- a/tests/main/presenters/test_search_summary.py
+++ b/tests/main/presenters/test_search_summary.py
@@ -11,10 +11,17 @@ from app.main.presenters.search_summary import SearchSummary, \
 from app import content_loader
 
 
-filter_groups = filters_for_lot(
-    "saas",
-    content_loader.get_builder('g-cloud-6', 'search_filters')
-)
+filter_groups = None
+
+
+def setup_module(module):
+    # for now the tests here are g-cloud-6 (==7/8) specific
+    content_loader.load_manifest('g-cloud-6', 'services', 'search_filters')
+
+    module.filter_groups = filters_for_lot(
+        "saas",
+        content_loader.get_builder('g-cloud-6', 'search_filters')
+    )
 
 
 def _get_fixture_data():


### PR DESCRIPTION
A one-line fix that became a bit more than that...
 - work in preparation for G-Cloud 9 category filtering / go-live;
 - G-Cloud 4 and 5 services are to continue to use G-Cloud 6
   content and manifests (new config controls this);
 - refactor code to get 'latest' iteration of a framework that
   already existed for DOS frameworks;
 - tests are largely unaltered, we probably want to write new
   ones relating to G-Cloud 9 at some point.

https://trello.com/c/x6ANlaCf/339-filtering-based-on-category