### PR TITLE
Support for G9 services

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v20.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v6.4.4"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v6.4.10"
   }
 }


### PR DESCRIPTION
## Summary
Adds compatibility support for G9 services, which have some slightly different question keys.

## Changes
* Load the `display_service` G9 manifest
* Pull 'serviceDescription' from G9 into framework['serviceSummary']; the key has changed for some reason. Maybe it would be better to normalise this part and bring it back to serviceSummary...
* Add a check for 'minimumContractPeriod' key and include the caveat only if present.
* Add a check for 'freeVersionTrialOption', which combines previous keys freeOptional and trialOption.

## Dependency
https://github.com/alphagov/digitalmarketplace-frameworks/pull/410
* Requires version 6.4.10 of the frameworks repo, which adds a G9 display_service manifest.