### PR TITLE
Remove search box from /g-cloud

### DIFF
--- a/app/main/helpers/framework_helpers.py
+++ b/app/main/helpers/framework_helpers.py
@@ -11,3 +11,11 @@ def get_latest_live_framework(all_frameworks, framework_type):
 
 def get_lots_by_slug(framework_data):
     return {lot['slug']: lot for lot in framework_data['lots']}
+
+
+def is_g9_live(all_frameworks):
+    """
+    :return: True iff G8 is no longer the latest live G-Cloud framework.
+    """
+    framework = get_latest_live_framework(all_frameworks, 'g-cloud')
+    return framework['slug'] != 'g-cloud-8'

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from flask import abort, render_template, request, redirect, current_app, url_for
-import flask_featureflags as feature
 
 from dmutils.formats import dateformat
 from dmapiclient import HTTPError
@@ -30,11 +29,12 @@ from app import search_api_client, data_api_client, content_loader
 
 @main.route('/g-cloud')
 def index_g_cloud():
-    show_search_box = not feature.is_active('GCLOUD9')
-
     # if there are multiple live g-cloud frameworks, assume they all have the same lots
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
     framework = framework_helpers.get_latest_live_framework(all_frameworks, 'g-cloud')
+
+    # TODO remove me after G-Cloud 9 goes live
+    show_search_box = not framework_helpers.is_g9_live(all_frameworks)
 
     lot_browse_list_items = list()
     for lot in framework['lots']:
@@ -167,7 +167,7 @@ def search_services():
     framework = framework_helpers.get_latest_live_framework(all_frameworks, 'g-cloud')
 
     # TODO remove me after G-Cloud 9 goes live
-    is_g9_live = framework['slug'] != 'g-cloud-8'
+    is_g9_live = framework_helpers.is_g9_live(all_frameworks)
 
     current_lot_slug = get_lot_from_request(request)
     lots_by_slug = framework_helpers.get_lots_by_slug(framework)

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from flask import abort, render_template, request, redirect, current_app
+import flask_featureflags as feature
 
 from dmutils.formats import get_label_for_lot_param, dateformat
 from dmapiclient import HTTPError
@@ -29,7 +30,10 @@ from app import search_api_client, data_api_client, content_loader
 
 @main.route('/g-cloud')
 def index_g_cloud():
-    return render_template('index-g-cloud.html')
+    show_search_box = not feature.is_active('GCLOUD9')
+
+    return render_template('index-g-cloud.html',
+                           show_search_box=show_search_box)
 
 
 @main.route('/g-cloud/framework')

--- a/app/templates/index-g-cloud.html
+++ b/app/templates/index-g-cloud.html
@@ -27,14 +27,16 @@
       Cloud technology and support
     </h1>
   </header>
-  <div class="grid-row">
-    <form action="{{ url_for('.search_services') }}" method="get" class="search-box column-two-thirds">
-        <input type="text" class="text-box" name="q" maxlength="200">
-        <button type="submit" class="button-save">
-          Show services
-        </button>
-    </form>
-  </div>
+  {% if show_search_box %}
+    <div class="grid-row">
+      <form action="{{ url_for('.search_services') }}" method="get" class="search-box column-two-thirds">
+          <input type="text" class="text-box" name="q" maxlength="200">
+          <button type="submit" class="button-save">
+            Show services
+          </button>
+      </form>
+    </div>
+  {% endif %}
   <div class="grid-row">
     <div class="column-two-thirds">
       {% with

--- a/config.py
+++ b/config.py
@@ -64,7 +64,6 @@ class Config(object):
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = False
-    FEATURE_FLAGS_GCLOUD9 = False
 
     # LOGGING
     DM_LOG_LEVEL = 'DEBUG'
@@ -107,7 +106,6 @@ class Test(Config):
     SECRET_KEY = "KEY"
 
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
-    FEATURE_FLAGS_GCLOUD9 = enabled_since('2016-03-27')
 
 
 class Development(Config):
@@ -125,7 +123,6 @@ class Development(Config):
     SHARED_EMAIL_KEY = "very_secret"
 
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
-    FEATURE_FLAGS_GCLOUD9 = enabled_since('2016-03-27')
 
 
 class Live(Config):
@@ -137,7 +134,6 @@ class Live(Config):
 
 class Preview(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-06')
-    FEATURE_FLAGS_GCLOUD9 = enabled_since('2016-03-27')
 
 
 class Staging(Live):

--- a/config.py
+++ b/config.py
@@ -64,6 +64,7 @@ class Config(object):
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = False
+    FEATURE_FLAGS_GCLOUD9 = False
 
     # LOGGING
     DM_LOG_LEVEL = 'DEBUG'
@@ -106,6 +107,7 @@ class Test(Config):
     SECRET_KEY = "KEY"
 
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
+    FEATURE_FLAGS_GCLOUD9 = enabled_since('2016-03-27')
 
 
 class Development(Config):
@@ -123,6 +125,7 @@ class Development(Config):
     SHARED_EMAIL_KEY = "very_secret"
 
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
+    FEATURE_FLAGS_GCLOUD9 = enabled_since('2016-03-27')
 
 
 class Live(Config):
@@ -134,6 +137,7 @@ class Live(Config):
 
 class Preview(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-06')
+    FEATURE_FLAGS_GCLOUD9 = enabled_since('2016-03-27')
 
 
 class Staging(Live):

--- a/tests/main/views/test_g_cloud.py
+++ b/tests/main/views/test_g_cloud.py
@@ -2,6 +2,8 @@ import mock
 import pytest
 from ...helpers import BaseApplicationTest
 
+from app import data_api_client
+
 
 class TestGCloudIndexResults(BaseApplicationTest):
     def setup_method(self, method):
@@ -14,15 +16,16 @@ class TestGCloudIndexResults(BaseApplicationTest):
     def teardown_method(self, method):
         self._search_api_client.stop()
 
-    @pytest.mark.parametrize('feature_flag_gcloud9, search_box_visible', ((True, False), (False, True)))
-    def test_renders_correct_search_links(self, feature_flag_gcloud9, search_box_visible):
-        self.app.config['FEATURE_FLAGS_GCLOUD9'] = feature_flag_gcloud9
+    @pytest.mark.parametrize('g_cloud_9_status, search_box_visible', (('live', False), ('open', True)))
+    def test_renders_correct_search_links(self, g_cloud_9_status, search_box_visible):
+        framework = next(
+            (f for f in data_api_client.find_frameworks.return_value['frameworks'] if f['slug'] == 'g-cloud-9')
+        )
+        old_status, framework['status'] = framework['status'], g_cloud_9_status
         self._search_api_client.search_services.return_value = self.search_results
 
         res = self.client.get('/g-cloud')
         assert res.status_code == 200
         assert ('form action="/g-cloud/search' in res.get_data(as_text=True)) == search_box_visible
-        assert '/g-cloud/search?lot=saas' in res.get_data(as_text=True)
-        assert '/g-cloud/search?lot=scs' in res.get_data(as_text=True)
-        assert '/g-cloud/search?lot=paas' in res.get_data(as_text=True)
-        assert '/g-cloud/search?lot=iaas' in res.get_data(as_text=True)
+
+        framework['status'] = old_status

--- a/tests/main/views/test_g_cloud.py
+++ b/tests/main/views/test_g_cloud.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 from ...helpers import BaseApplicationTest
 
 
@@ -6,22 +7,21 @@ class TestGCloudIndexResults(BaseApplicationTest):
     def setup_method(self, method):
         super(TestGCloudIndexResults, self).setup_method(method)
 
-        self._search_api_client = mock.patch(
-            'app.main.views.g_cloud.search_api_client'
-        ).start()
+        self._search_api_client = mock.patch('app.main.views.g_cloud.search_api_client').start()
 
         self.search_results = self._get_search_results_fixture_data()
 
     def teardown_method(self, method):
         self._search_api_client.stop()
 
-    def test_renders_correct_search_links(self):
-        self._search_api_client.search_services.return_value = \
-            self.search_results
+    @pytest.mark.parametrize('feature_flag_gcloud9, search_box_visible', ((True, False), (False, True)))
+    def test_renders_correct_search_links(self, feature_flag_gcloud9, search_box_visible):
+        self.app.config['FEATURE_FLAGS_GCLOUD9'] = feature_flag_gcloud9
+        self._search_api_client.search_services.return_value = self.search_results
 
         res = self.client.get('/g-cloud')
         assert res.status_code == 200
-        assert 'form action="/g-cloud/search' in res.get_data(as_text=True)
+        assert ('form action="/g-cloud/search' in res.get_data(as_text=True)) == search_box_visible
         assert '/g-cloud/search?lot=saas' in res.get_data(as_text=True)
         assert '/g-cloud/search?lot=scs' in res.get_data(as_text=True)
         assert '/g-cloud/search?lot=paas' in res.get_data(as_text=True)


### PR DESCRIPTION
## Ticket
https://trello.com/c/fEWlJym1/344-remove-search-on-g-cloud-page

## Summary
The lot will be the most important filter for users to select once G-Cloud 9 goes live. This PR removes the search box on the initial /g-cloud page so that users must choose which lot they are searching before further filtering/browsing services.

## Changes
* Adds a generic 'gcloud9' feature flag, as we expect to be deploying a number of changes that should only go active with G-Cloud 9.
* Enable the feature flag for local development and preview.
* Remove the search box from /g-cloud (gated by said feature flag). 

## Old
<img width="1005" alt="screen shot 2017-03-27 at 08 39 03" src="https://cloud.githubusercontent.com/assets/2920760/24345614/e5a23a10-12c8-11e7-88ea-d8c424fe4a4e.png">


## New
<img width="1007" alt="screen shot 2017-03-27 at 08 38 36" src="https://cloud.githubusercontent.com/assets/2920760/24345619/e7b84326-12c8-11e7-9a99-c842d23a67f0.png">
