### PR TITLE
Don't break for non-numeric `page` URL param

### DIFF
--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -15,9 +15,9 @@ def get_keywords_from_request(request):
 
 
 def get_page_from_request(request):
-    if 'page' in request.args:
+    try:
         return int(request.args['page'])
-    else:
+    except (KeyError, ValueError, TypeError):
         return None
 
 


### PR DESCRIPTION
We've seen some 500s in production for someone trying `page=test` in the URL.  This should fix that.