### PR TITLE
Bump frontend toolkit to version 22

### DIFF
--- a/app/assets/javascripts/_selection-buttons.js
+++ b/app/assets/javascripts/_selection-buttons.js
@@ -6,6 +6,10 @@
 
     new GOVUK.SelectionButtons('.selection-button input');
 
+    if (!GOVUK.ShowHideContent) return;
+
+    new GOVUK.ShowHideContent().init();
+
   };
 
   GOVUK.GDM = GDM;

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= include ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 //= include _analytics.js'
 //= include _onready.js'
 //= include _selection-buttons.js

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -19,8 +19,9 @@ $path: "/static/images/";
 @import "toolkit/shared_placeholders/_temporary-messages.scss";
 @import "toolkit/shared_placeholders/_placeholders.scss";
 @import "toolkit/shared_placeholders/_dm-typography.scss";
+@import "toolkit/shared_placeholders/_mixins.scss";
 
-// Digtial Marketplace Front-end toolkit styles
+// Digital Marketplace Front-end toolkit styles
 @import "toolkit/_breadcrumb.scss";
 @import "toolkit/_browse-list.scss";
 @import "toolkit/_buttons.scss";


### PR DESCRIPTION
This is consistent with what the supplier frontend is using.

Shouldn't have any practical effect, other than that the person who updates the toolkit next will have less work to do.