### PR TITLE
Adjust category filter

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -211,7 +211,7 @@ def search_services():
         category_filter_group = None
 
     lots = framework['lots']
-    annotate_lots_with_categories_selection(lots, category_filter_group, request)
+    current_category_filter = annotate_lots_with_categories_selection(lots, category_filter_group, request)
 
     current_lot = lots_by_slug.get(current_lot_slug)
 
@@ -221,6 +221,7 @@ def search_services():
     return render_template(
         'search/services.html',
         current_lot=current_lot,
+        current_category_filter=current_category_filter,
         filters=filters.values(),
         lots=lots,
         pagination=pagination_config,

--- a/app/templates/search/_services_filters.html
+++ b/app/templates/search/_services_filters.html
@@ -33,7 +33,13 @@
   </div>
   <input type="text" name="q" id="keywords" value="{{ search_keywords }}" maxlength="200">
 </div>
+
 {% if current_lot %}
 <input type="hidden" name="lot" value="{{ current_lot.slug }}" />
 {% endif %}
+
+{% if current_category_filter %}
+<input type="hidden" name="{{ current_category_filter.name }}" value="{{ current_category_filter.value }}" />
+{% endif %}
+
 {% include 'search/_filters.html' %}


### PR DESCRIPTION
A UI change (re which categories are visible once a selection has been made) and a functionality fix (the filters should combine with the category selection as well as the lot selection). Both affect G9 only.

https://trello.com/c/x6ANlaCf/339-filtering-based-on-category

UI change - before:

<img width="1036" alt="screen shot 2017-04-18 at 13 12 59" src="https://cloud.githubusercontent.com/assets/190828/25130131/011ca1c8-2439-11e7-9e90-7fff9972708e.png">

After:

<img width="1047" alt="screen shot 2017-04-18 at 13 13 31" src="https://cloud.githubusercontent.com/assets/190828/25130141/07bf061a-2439-11e7-9488-2bcf43e25e35.png">
