### PR TITLE
Crown hosting content updates from ccs

### DIFF
--- a/app/templates/content/index-crown-hosting.html
+++ b/app/templates/content/index-crown-hosting.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Physical datacentre space for legacy systems - Digital Marketplace{% endblock %}
+{% block page_title %}Physical datacentre space - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -12,7 +12,7 @@
       },
       {
           "link": url_for('.index_crown_hosting'),
-          "label": "Physical datacentre space for legacy systems"
+          "label": "Physical datacentre space"
       }
     ]
   %}
@@ -26,7 +26,7 @@
       <div class="column-two-thirds">
         <header class="page-heading">
           <h1>
-            Physical datacentre space for legacy systems
+            Physical datacentre space
           </h1>
         </header>
       </div>
@@ -36,8 +36,8 @@
           government departments, arm’s length bodies and the wider public sector.
         </p>
         <p class="service-summary-lede">
-          Contact <a href="mailto:crownhosting@cabinetoffice.gov.uk">crownhosting@cabinetoffice.gov.uk</a>
-          to discuss datacentre hosting for your legacy systems.
+          Email <a href="mailto:crownhosting@cabinetoffice.gov.uk">crownhosting@cabinetoffice.gov.uk</a>
+          to talk about your datacentre hosting needs.
         </p>
         <h2 class='summary-item-heading'>
           Features
@@ -47,7 +47,7 @@
         </p>
         <ul class='service-summary-features-and-benefits'>
           <li>
-            mission-critical datacentres for legacy systems
+            mission-critical datacentres 
           </li>
           <li>
             a secure environment for transition to the cloud
@@ -91,7 +91,7 @@
             robust performance service-level agreements, including power uptime
           </li>
           <li>
-            strong step-in rights for government to ensure continuity of service if required
+            strong step-in rights for government to ensure continuity of service if needed
           </li>
         </ul>
       </div>
@@ -100,10 +100,10 @@
           Crown Hosting contact
         </h2>
         <p>
-          <strong>Office of the Chief Technology Officer</strong>
+          <strong>Crown Commercial Service</strong>
         </p>
         <p>
-          <a href="mailto:crownhosting@cabinetoffice.gov.uk">crownhosting@cabinetoffice.gov.uk</a>
+          <a href="mailto:crownhosting@crowncommercial.gov.uk">crownhosting@crowncommercial.gov.uk</a>
         </p>
       </div>
       <div class="column-two-thirds">

--- a/app/templates/content/index-crown-hosting.html
+++ b/app/templates/content/index-crown-hosting.html
@@ -108,7 +108,7 @@
       </div>
       <div class="column-two-thirds">
         <p class="service-summary-lede">
-          Find out more about the <a href="/crown-hosting/framework">Crown Hosting Data Centres framework</a>.
+          Read more about the <a href="/crown-hosting/framework">Crown Hosting Data Centres framework</a>.
         </p>
       </div>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -52,7 +52,7 @@
             },
             {
               "link": "/crown-hosting",
-              "title": "Buy physical datacentre space for legacy systems",
+              "title": "Buy physical datacentre space",
               "body": "eg for services that can’t be migrated to the cloud",
             },
           ]
@@ -69,7 +69,7 @@
             },
             {
               "link": "/crown-hosting",
-              "title": "Buy physical datacentre space for legacy systems",
+              "title": "Buy physical datacentre space",
               "body": "eg for services that can’t be migrated to the cloud",
             },
           ]

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -76,7 +76,7 @@ class TestHomepageBrowseList(BaseApplicationTest):
 
             link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
             assert link_texts[0] == "Find an individual specialist"
-            assert link_texts[-1] == "Buy physical datacentre space for legacy systems"
+            assert link_texts[-1] == "Buy physical datacentre space"
             assert "Find specialists to work on digital projects" not in link_texts
 
     def test_links_are_for_existing_dos_framework_when_a_new_dos_framework_in_standstill_exists(self, data_api_client):
@@ -172,7 +172,7 @@ class TestHomepageBrowseList(BaseApplicationTest):
 
             link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
             assert link_texts[0] == "Find cloud technology and support"
-            assert link_texts[1] == "Buy physical datacentre space for legacy systems"
+            assert link_texts[1] == "Buy physical datacentre space"
             assert len(link_texts) == 2
 
 


### PR DESCRIPTION
Removing references to 'legacy systems' and 'services that aren't ready to migrate to the cloud'. Also tidying up a few style things.