### PR TITLE
Fix categories with commas

### DIFF
--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -121,6 +121,20 @@ def replace_g5_search_dots(keywords_query):
     )
 
 
+def get_filter_value_from_question_option(option):
+    """
+    Processes `option` into a search term value suitable for the Search API.
+
+    The Search API does not allow commas in filter values, because they are used
+    to separate the terms in an 'OR' search - see `group_request_filters`. They
+    are removed from the field values by the indexer by the Search API itself,
+    see `dm-search-api:app.main.services.conversions.strip_and_lowercase`.
+
+    :return: normalized string value
+    """
+    return (option.get('value') or option.get('label', '')).lower().replace(',', '')
+
+
 def build_search_query(request, lot_filters, content_builder, lots_by_slug):
     """Match request args with known filters.
 

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -6,6 +6,7 @@ from ..helpers.search_helpers import (
     get_filters_from_request,
     get_lot_from_request,
     get_keywords_from_request,
+    get_filter_value_from_question_option,
 )
 
 
@@ -59,13 +60,14 @@ def filters_for_question(question):
 
 def _recursive_add_option_filters(question, options_list, filters_list):
     for option in options_list:
+        value = get_filter_value_from_question_option(option)
         presented_filter = {
             'label': option['label'],
             'name': question['id'],
             'id': '{}-{}'.format(
                 question['id'],
-                option['label'].lower().replace(' ', '-')),
-            'value': option['label'].lower(),
+                value.replace(' ', '-')),
+            'value': value,
         }
         if option.get('options'):
             presented_filter['children'] = []

--- a/tests/fixtures/content/frameworks/g9/questions/data/checkboxTreeExample.yml
+++ b/tests/fixtures/content/frameworks/g9/questions/data/checkboxTreeExample.yml
@@ -16,6 +16,11 @@ options:
         filter_label: 'Option 2.1 filter label'
       - label: 'Option 2.2'
         filter_label: 'Option 2.2 filter label'
+  - label: 'Option 3, with comma'
+    filter_label: 'Option 3 filter label'
+  - label: 'Option 4 has a value'
+    filter_label: 'Option 4 filter label'
+    value: 'option_4_value'
 
 validations:
   -

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -99,6 +99,17 @@ class TestSearchFilters(BaseApplicationTest):
             ],
         }
 
+    def test_filters_with_commas(self):
+        checkboxes_filter_group = filters_for_lot('cloud-software', g9_builder)['categories-example']
+        filter_with_comma = None
+        for some_filter in checkboxes_filter_group['filters']:
+            if some_filter['label'] == 'Option 3, with comma':
+                filter_with_comma = some_filter
+                break
+        assert filter_with_comma is not None
+        assert filter_with_comma['id'] == 'checkboxTreeExample-option-3-with-comma'
+        assert filter_with_comma['value'] == 'option 3 with comma'
+
     def test_get_filter_groups_from_questions_with_boolean_filters(self):
         booleans_filter_group = self._get_filter_group_by_label(
             'saas', 'Booleans example'

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -110,6 +110,17 @@ class TestSearchFilters(BaseApplicationTest):
         assert filter_with_comma['id'] == 'checkboxTreeExample-option-3-with-comma'
         assert filter_with_comma['value'] == 'option 3 with comma'
 
+    def test_filters_with_values(self):
+        checkboxes_filter_group = filters_for_lot('cloud-software', g9_builder)['categories-example']
+        filter_with_value = None
+        for some_filter in checkboxes_filter_group['filters']:
+            if some_filter['label'] == 'Option 4 has a value':
+                filter_with_value = some_filter
+                break
+        assert filter_with_value is not None
+        assert filter_with_value['id'] == 'checkboxTreeExample-option_4_value'
+        assert filter_with_value['value'] == 'option_4_value'
+
     def test_get_filter_groups_from_questions_with_boolean_filters(self):
         booleans_filter_group = self._get_filter_group_by_label(
             'saas', 'Booleans example'

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -17,7 +17,7 @@ from ...helpers import BaseApplicationTest
 content_loader = ContentLoader('tests/fixtures/content')
 content_loader.load_manifest('g6', 'data', 'manifest')
 content_loader.load_manifest('g9', 'data', 'manifest')
-questions_builder = content_loader.get_builder('g6', 'manifest')
+g6_builder = content_loader.get_builder('g6', 'manifest')
 g9_builder = content_loader.get_builder('g9', 'manifest')
 
 
@@ -46,7 +46,7 @@ def _get_fixture_multiple_pages_data():
 class TestSearchFilters(BaseApplicationTest):
 
     def _get_filter_group_by_label(self, lot, label):
-        filter_groups = filters_for_lot(lot, questions_builder)
+        filter_groups = filters_for_lot(lot, g6_builder)
         for filter_group in filter_groups.values():
             if filter_group['label'] == label:
                 return filter_group
@@ -122,7 +122,7 @@ class TestSearchFilters(BaseApplicationTest):
         }
 
     def test_request_filters_are_set(self):
-        search_filters = list(filters_for_lot('saas', questions_builder).values())
+        search_filters = list(filters_for_lot('saas', g6_builder).values())
         request = self._get_request_for_params({
             'q': 'email',
             'booleanExample1': 'true'
@@ -164,7 +164,7 @@ class TestSearchFilters(BaseApplicationTest):
             'lot': 'paas'
         })
 
-        search_filters = list(filters_for_lot('paas', questions_builder).values())
+        search_filters = list(filters_for_lot('paas', g6_builder).values())
         set_filter_states(search_filters, request)
         assert search_filters[0] == {
             'label': 'Booleans example',
@@ -193,7 +193,7 @@ class TestSearchFilters(BaseApplicationTest):
             'booleanExample1': 'true'
         })
 
-        search_filters = list(filters_for_lot('paas', questions_builder).values())
+        search_filters = list(filters_for_lot('paas', g6_builder).values())
         set_filter_states(search_filters, request)
 
         assert search_filters[0] == {
@@ -228,7 +228,7 @@ class TestSearchFilters(BaseApplicationTest):
         assert all_filters == no_lot_filters
 
     def test_instance_has_correct_filter_groups_for_paas(self):
-        search_filters = filters_for_lot('paas', questions_builder).values()
+        search_filters = filters_for_lot('paas', g6_builder).values()
 
         filter_group_labels = [
             group['label'] for group in search_filters
@@ -239,7 +239,7 @@ class TestSearchFilters(BaseApplicationTest):
         assert 'Radios example' in filter_group_labels
 
     def test_instance_has_correct_filter_groups_for_iaas(self):
-        search_filters = filters_for_lot('iaas', questions_builder).values()
+        search_filters = filters_for_lot('iaas', g6_builder).values()
 
         filter_group_labels = [
             group['label'] for group in search_filters


### PR DESCRIPTION
Bug-fix - search/filter where value contains a comma.

https://trello.com/c/Fi4N1ypL/382-categories-with-a-comma-in-name-broken