### PR TITLE
Add AWSELB cookie info to cookie page

### DIFF
--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -128,6 +128,26 @@
             </tr>
             </tbody>
         </table>
+
+        <h3>Routing cookies</h3>
+
+        <p>
+            If we’re doing some work on the site, you may have limited access to the Digital Marketplace for a short time. We’ll save a cookie so that you consistently see the same version of the site.
+        </p>
+        <table class="content-table">
+            <tbody>
+            <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Purpose</th>
+                <th scope="col">Expires&nbsp;&nbsp;&nbsp;</th>
+            </tr>
+            <tr>
+                <td>AWSELB</td>
+                <td>Ensures a consistent experience when Digital Marketplace switches to maintenance mode</td>
+                <td>When you close your browser</td>
+            </tr>
+            </tbody>
+        </table>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Part of this story: [https://www.pivotaltracker.com/story/show/143491505](https://www.pivotaltracker.com/story/show/143491505)

We've enabled sticky sessions for the nginx ELB on the PaaS environment
to make sure that users get a consistent experience when we move to
maintenance mode.

If, for example, we're moving form live to maintenance mode, during the
transition the new maintenance nginx instances will be added to the
autoscaling group with the old ones. This means for a short period of
time a user could initially hit a `live` instance and get the html for
the page, but then when the browser makes further requests for css/js
it could get a 503.

Weirdness.

Enabling sticky sessions means that if they hit a `live` nginx instance,
further requests for all css/js will also hit that instance. Similarly,
as soon as they hit a `maintenance` instance they will only see the
maintenance page, even on a refresh of the page.

<img width="699" alt="screen shot 2017-04-26 at 15 31 51" src="https://cloud.githubusercontent.com/assets/13836290/25439850/86f81d38-2a95-11e7-9c78-4ed2bbcfe56f.png">
