### PR TITLE
Add AWSELB cookie info to cookie page

### DIFF
--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -132,7 +132,7 @@
         <h3>Routing cookies</h3>
 
         <p>
-            If we’re doing some work on the site, you may have limited access to the Digital Marketplace for a short time. We’ll save a cookie so that you consistently see the same version of the site.
+            We store routing cookies on your computer to ensure you consistently see the same version of the site.
         </p>
         <table class="content-table">
             <tbody>
@@ -143,7 +143,7 @@
             </tr>
             <tr>
                 <td>AWSELB</td>
-                <td>Ensures a consistent experience when Digital Marketplace switches to maintenance mode</td>
+                <td>Ensures you connect to the same web server when using the service.</td>
                 <td>When you close your browser</td>
             </tr>
             </tbody>


### PR DESCRIPTION
We've enabled sticky sessions for the nginx ELB on the PaaS environment
to make sure that users get a consistent experience when we move to
maintenance mode.

If, for example, we're moving form live to maintenance mode, during the
transition the new maintenance nginx instances will be added to the
autoscaling group with the old ones. This means for a short period of
time a user could initially hit a `live` instance and get the html for
the page, but then when the browser makes further requests for css/js
it could get a 503.

Weirdness.

Enabling sticky sessions means that if they hit a `live` nginx instance,
further requests for all css/js will also hit that instance. Similarly,
as soon as they hit a `maintenance` instance they will only see the
maintenance page, even on a refresh of the page.

<img width="672" alt="screen shot 2017-04-27 at 13 56 13" src="https://cloud.githubusercontent.com/assets/13836290/25484298/511b9796-2b51-11e7-962d-a0e173a7e347.png">