### PR TITLE
Don't break if no content for service framework

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from dmcontent.errors import ContentNotFoundError
 from flask import abort, render_template, request, redirect, current_app, url_for
 
 from dmutils.formats import dateformat
@@ -113,13 +114,17 @@ def get_service_by_id(service_id):
             framework_slug = override_framework_slug
 
         framework = data_api_client.get_framework(framework_slug)['frameworks']
-        service_view_data = Service(
-            service_data,
-            content_loader.get_builder(framework_slug, 'display_service').filter(
-                service_data
-            ),
-            framework_helpers.get_lots_by_slug(framework)
-        )
+        try:
+            service_view_data = Service(
+                service_data,
+                content_loader.get_builder(framework_slug, 'display_service').filter(
+                    service_data
+                ),
+                framework_helpers.get_lots_by_slug(framework)
+            )
+        except ContentNotFoundError as e:
+            # This will happen for service IDs from a DOS-style framework that doesn't display service pages
+            abort(404)
 
         try:
             # get supplier data and add contact info to service object

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -114,17 +114,16 @@ def get_service_by_id(service_id):
             framework_slug = override_framework_slug
 
         framework = data_api_client.get_framework(framework_slug)['frameworks']
-        try:
-            service_view_data = Service(
-                service_data,
-                content_loader.get_builder(framework_slug, 'display_service').filter(
-                    service_data
-                ),
-                framework_helpers.get_lots_by_slug(framework)
-            )
-        except ContentNotFoundError as e:
-            # This will happen for service IDs from a DOS-style framework that doesn't display service pages
+        if framework['framework'] != 'g-cloud':
             abort(404)
+
+        service_view_data = Service(
+            service_data,
+            content_loader.get_builder(framework_slug, 'display_service').filter(
+                service_data
+            ),
+            framework_helpers.get_lots_by_slug(framework)
+        )
 
         try:
             # get supplier data and add contact info to service object

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -305,6 +305,22 @@ class TestServicePage(BaseApplicationTest):
 
         assert res.status_code == 404
 
+    def test_service_on_framework_without_a_display_service_manifest_causes_404(self):
+        self.service = self._get_g6_service_fixture_data()
+        self.service['services']['frameworkSlug'] = 'digital-outcomes-and-specialists'
+        data_api_client.get_service.return_value = self.service
+        data_api_client.get_framework.return_value = self._get_framework_fixture_data(
+            'digital-outcomes-and-specialists'
+        )
+
+        service_id = self.service['services']['id']
+        # This is the "Display service" page, generally for G-Cloud services, but in this case it now has a valid
+        # digital-outcomes-and-specialists service ID.  There is no "display_service" manifest, which will make the
+        # content loader raise a ContentNotFoundError
+        res = self.client.get('/g-cloud/services/{}'.format(service_id))
+
+        assert res.status_code == 404
+
     def test_certifications_section_not_displayed_if_service_has_none(self):
         self.service = self._get_g6_service_fixture_data()
         self.service['services']['vendorCertifications'] = []

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -305,7 +305,7 @@ class TestServicePage(BaseApplicationTest):
 
         assert res.status_code == 404
 
-    def test_service_on_framework_without_a_display_service_manifest_causes_404(self):
+    def test_service_not_a_g_cloud_service_causes_404(self):
         self.service = self._get_g6_service_fixture_data()
         self.service['services']['frameworkSlug'] = 'digital-outcomes-and-specialists'
         data_api_client.get_service.return_value = self.service
@@ -315,8 +315,7 @@ class TestServicePage(BaseApplicationTest):
 
         service_id = self.service['services']['id']
         # This is the "Display service" page, generally for G-Cloud services, but in this case it now has a valid
-        # digital-outcomes-and-specialists service ID.  There is no "display_service" manifest, which will make the
-        # content loader raise a ContentNotFoundError
+        # digital-outcomes-and-specialists service ID.
         res = self.client.get('/g-cloud/services/{}'.format(service_id))
 
         assert res.status_code == 404


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/144457253

We've seen some 500s in production for someone trying to look at DOS services "service pages".  We should 404 requests for service IDs on frameworks that don't have a display_service manifest.