### PR TITLE
Log IP on status page

### DIFF
--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -143,7 +143,7 @@
             </tr>
             <tr>
                 <td>AWSELB</td>
-                <td>Ensures you connect to the same web server when using the service.</td>
+                <td>Ensures you connect to the same web server when using the service</td>
                 <td>When you close your browser</td>
             </tr>
             </tbody>


### PR DESCRIPTION
As part of moving to PaaS infrastructure, we want to make sure we can
log the clients IP address.

This checks for the presence of the `X-Forwarded-For` header and logs
the final ip address if found. If not it checks the flask request object
for the `remote_address` attribute and logs that. If that still isn't
present it logs `untrackable`.

I've also added the remote address to the json object returned by the
status route. Could be useful.