### PR TITLE
Show service description for g-cloud-9

### DIFF
--- a/app/templates/_service_summary_features_and_benefits.html
+++ b/app/templates/_service_summary_features_and_benefits.html
@@ -1,4 +1,4 @@
-<p class="service-summary-lede">{{ service.serviceSummary }}</p>
+<p class="service-summary-lede">{{ service.serviceSummary or service.serviceDescription }}</p> ## G-Cloud 9 uses serviceDescription, not serviceSummary.
 {% if service.features %}
 <h2 class="service-summary-heading">Features</h2>
 <ul class="service-summary-features-and-benefits">

--- a/app/templates/search/_services_results.html
+++ b/app/templates/search/_services_results.html
@@ -9,7 +9,7 @@
     </p>
 
     <p class="search-result-excerpt">
-        {{ service.serviceSummary }}
+        {{ service.serviceSummary or service.serviceDescription }} ## G-Cloud 9 uses serviceDescription, not serviceSummary.
     </p>
     <ul aria-label="tags" class="search-result-metadata">
         <li class="search-result-metadata-item">


### PR DESCRIPTION
## Summary
G-Cloud 9 uses a `serviceDescription` question in place of previous G-Cloud serviceSummary keys. Our Elasticsearch version doesn't have access to copy_to or field renaming processors to easily handle this on the search-side, and implementing our own transformation is non-trivial compared to this method.

We should really consolidate this to a single key, but open for discussion around how to do this (whether we should revert to serviceSummary or go with the new serviceDescription field name), and when we do it.