### PR TITLE
Update content on DM homepage for G-Cloud 9

### DIFF
--- a/app/main/helpers/framework_helpers.py
+++ b/app/main/helpers/framework_helpers.py
@@ -18,4 +18,4 @@ def is_g9_live(all_frameworks):
     :return: True iff G8 is no longer the latest live G-Cloud framework.
     """
     framework = get_latest_live_framework(all_frameworks, 'g-cloud')
-    return framework['slug'] != 'g-cloud-8'
+    return (framework['slug'] != 'g-cloud-8') if framework else False

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -12,7 +12,7 @@ from dmcontent.content_loader import ContentNotFoundError
 
 from ...main import main
 from ..helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference, parse_link
-from ..helpers.framework_helpers import get_latest_live_framework
+from ..helpers.framework_helpers import get_latest_live_framework, is_g9_live
 
 from ..forms.brief_forms import BriefSearchForm
 
@@ -51,12 +51,14 @@ def index():
     # Capture the slug for the most recent live framework. There will only be multiple if currently transitioning
     # between frameworks and more than one has a `live` status.
     dos_framework = get_latest_live_framework(frameworks, 'digital-outcomes-and-specialists')
+    show_new_g9_content = is_g9_live(frameworks)
 
     return render_template(
         'index.html',
         dos_slug=dos_framework['slug'] if dos_framework else None,
         frameworks={framework['slug']: framework for framework in frameworks},
-        temporary_message=temporary_message
+        temporary_message=temporary_message,
+        show_new_g9_content=show_new_g9_content,
     )
 
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,9 +22,9 @@
 {% endif %}
   <div class="column-two-thirds">
     <h2>Find technology or people for digital projects in the public sector</h2>
+      {% set items = [] %}
       {% if dos_slug %}
-        {% with
-          items = [
+        {% set items = [
             {
               "link": url_for("dos.info_page_for_starting_a_brief", framework_slug=dos_slug, lot_slug='digital-specialists'),
               "title": "Find an individual specialist",
@@ -44,39 +44,27 @@
               "link": url_for("dos.studios_start_page", framework_slug=dos_slug),
               "title": "Find a user research lab",
               "body": "eg a room to conduct research sessions",
-            },
-            {
-              "link": "/g-cloud",
-              "title": "Find cloud technology and support",
-              "body": "eg web hosting or IT health checks",
-            },
-            {
-              "link": "/crown-hosting",
-              "title": "Buy physical datacentre space",
-              "body": "eg for services that can’t be migrated to the cloud",
-            },
+            }
           ]
         %}
-          {% include "toolkit/browse-list.html" %}
-        {% endwith %}
-      {% else %}
-        {% with
-          items = [
-            {
-              "link": "/g-cloud",
-              "title": "Find cloud technology and support",
-              "body": "eg web hosting or IT health checks",
-            },
-            {
-              "link": "/crown-hosting",
-              "title": "Buy physical datacentre space",
-              "body": "eg for services that can’t be migrated to the cloud",
-            },
-          ]
-        %}
-          {% include "toolkit/browse-list.html" %}
-        {% endwith %}
       {% endif %}
+
+      {% set items = items + [
+        {
+          "link": "/g-cloud",
+          "title": "Find cloud hosting, software and support" if show_new_g9_content else "Find cloud technology and support",
+          "body": "eg content delivery networks or accounting software" if show_new_g9_content else "eg web hosting or IT health checks",
+        },
+        {
+          "link": "/crown-hosting",
+          "title": "Buy physical datacentre space",
+          "body": "eg access to mission-critical datacentres" if show_new_g9_content else "eg for services that can’t be migrated to the cloud",
+        }]
+      %}
+
+      {% with items = items %}
+        {% include "toolkit/browse-list.html" %}
+      {% endwith %}
   </div>
 
   <div class="supplier-messages column-one-third">


### PR DESCRIPTION
## Summary
Updates the content on the homepage when G-Cloud 9 is live to use new terminology (eg cloud hosting, software and support). Removes some redundancy from the template listing content twice.

It would be nice to pull this content from the frameworks repo, but crown-hosting is a separate framework altogether (Crown Hosting Data Centres Framework). Putting it in g-cloud would be wrong, and creating an entire new framework directory just for these messages feels just as bad. I'm not adverse to putting the specific g-cloud text in the frameworks repo, but think it's easier left as-is until we tackle this more properly across the board.

## Ticket
https://trello.com/c/qF5KbUwX/377-update-content-on-homepage-for-g-cloud-9