### PR TITLE
Always show search box on G-Cloud home page.

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -33,9 +33,6 @@ def index_g_cloud():
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
     framework = framework_helpers.get_latest_live_framework(all_frameworks, 'g-cloud')
 
-    # TODO remove me after G-Cloud 9 goes live
-    show_search_box = not framework_helpers.is_g9_live(all_frameworks)
-
     lot_browse_list_items = list()
     for lot in framework['lots']:
         lot_item = {
@@ -67,7 +64,7 @@ def index_g_cloud():
 
         lot_browse_list_items.append(lot_item)
 
-    return render_template('index-g-cloud.html', lots=lot_browse_list_items, show_search_box=show_search_box)
+    return render_template('index-g-cloud.html', lots=lot_browse_list_items)
 
 
 @main.route('/g-cloud/framework')

--- a/app/templates/index-g-cloud.html
+++ b/app/templates/index-g-cloud.html
@@ -27,16 +27,14 @@
       Cloud technology and support
     </h1>
   </header>
-  {% if show_search_box %}
-    <div class="grid-row">
-      <form action="{{ url_for('.search_services') }}" method="get" class="search-box column-two-thirds">
-          <input type="text" class="text-box" name="q" maxlength="200">
-          <button type="submit" class="button-save">
-            Show services
-          </button>
-      </form>
-    </div>
-  {% endif %}
+  <div class="grid-row">
+    <form action="{{ url_for('.search_services') }}" method="get" class="search-box column-two-thirds">
+      <input type="text" class="text-box" name="q" maxlength="200">
+      <button type="submit" class="button-save">
+        Show services
+      </button>
+    </form>
+  </div>
   <div class="grid-row">
     <div class="column-two-thirds">
       {% with items = lots %}

--- a/tests/main/views/test_g_cloud.py
+++ b/tests/main/views/test_g_cloud.py
@@ -16,16 +16,10 @@ class TestGCloudIndexResults(BaseApplicationTest):
     def teardown_method(self, method):
         self._search_api_client.stop()
 
-    @pytest.mark.parametrize('g_cloud_9_status, search_box_visible', (('live', False), ('open', True)))
-    def test_renders_correct_search_links(self, g_cloud_9_status, search_box_visible):
-        framework = next(
-            (f for f in data_api_client.find_frameworks.return_value['frameworks'] if f['slug'] == 'g-cloud-9')
-        )
-        old_status, framework['status'] = framework['status'], g_cloud_9_status
+    def test_renders_correct_search_links(self):
         self._search_api_client.search_services.return_value = self.search_results
 
         res = self.client.get('/g-cloud')
         assert res.status_code == 200
-        assert ('form action="/g-cloud/search' in res.get_data(as_text=True)) == search_box_visible
-
-        framework['status'] = old_status
+        assert 'form action="/g-cloud/search' in res.get_data(as_text=True)
+        assert '/g-cloud/search?lot=' in res.get_data(as_text=True)  # at least one link into a specific lot


### PR DESCRIPTION
A straight revert wasn't quite the thing, in the end.

https://trello.com/c/fEWlJym1/344-add-un-remove-search-on-g-cloud-page