### PR TITLE
Update /g-cloud lots descriptions

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -97,3 +97,8 @@ $path: "/static/images/";
   display: inline-block;
   word-break: break-all;
 }
+
+.framework-lots ul li ul {
+  list-style: disc;
+  margin: 0px 0px 0px 20px;
+}

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -34,38 +34,25 @@ def index_g_cloud():
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
     framework = framework_helpers.get_latest_live_framework(all_frameworks, 'g-cloud')
 
+    content_loader.load_messages(framework['slug'], ['advice', 'descriptions'])
+    gcloud_page_title = content_loader.get_message(framework['slug'], 'descriptions', 'framework')
+    gcloud_lot_messages = content_loader.get_message(framework['slug'], 'advice', 'lots')
+    gcloud_lot_messages = {x['slug']: x for x in gcloud_lot_messages}
+
     lot_browse_list_items = list()
     for lot in framework['lots']:
         lot_item = {
             "link": url_for('.search_services', lot=lot['slug']),
-            "title": lot['name']
+            "title": lot['name'],
+            "body": gcloud_lot_messages[lot['slug']]['body'],
+            "subtext": gcloud_lot_messages[lot['slug']].get('advice'),
         }
-
-        # TODO proper lot body/subtext for G9 - G7/G8 content moved here temporarily from template
-
-        if lot['slug'] == 'saas':
-            lot_item.update({
-                "body": "Find applications or services that are run over the internet or in the cloud",
-                "subtext": "eg accounting tools or email",
-            })
-        elif lot['slug'] == 'paas':
-            lot_item.update({
-                "body": "Find platforms that provide a basis for building other services and applications",
-            })
-        elif lot['slug'] == 'iaas':
-            lot_item.update({
-                "body": "Find networks, hosting facilities and servers on which platforms and software depend",
-                "subtext": "eg hosting or content delivery",
-            })
-        elif lot['slug'] == 'scs':
-            lot_item.update({
-                "body": "Find help with cloud management and deployment",
-                "subtext": "eg IT health checks or data migrations",
-            })
 
         lot_browse_list_items.append(lot_item)
 
-    return render_template('index-g-cloud.html', lots=lot_browse_list_items)
+    return render_template('index-g-cloud.html',
+                           title=gcloud_page_title,
+                           lots=lot_browse_list_items)
 
 
 @main.route('/g-cloud/framework')

--- a/app/templates/index-g-cloud.html
+++ b/app/templates/index-g-cloud.html
@@ -11,7 +11,7 @@
           "label": "Digital Marketplace"
       },
       {
-          "label": "Cloud technology and support"
+          "label": title|capitalize
       }
     ]
   %}
@@ -24,7 +24,7 @@
 <div class="index-page">
   <header class="page-heading">
     <h1>
-      Cloud technology and support
+      {{ title|capitalize }}
     </h1>
   </header>
   <div class="grid-row">
@@ -36,7 +36,7 @@
     </form>
   </div>
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-two-thirds framework-lots">
       {% with items = lots %}
         {% include "toolkit/browse-list.html" %}
       {% endwith %}

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.2.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v8.2.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.3.0"
   }
 }


### PR DESCRIPTION
## Summary
* Pull in newer frameworks version (8.2.0) which contains lot descriptions/advice to display on the /g-cloud page.
* Removes some hard-coded lots+content.
* Adds a CSS tag on the /g-cloud page to allow targetting the lot descriptions with bullet list styles.

## Dependencies
* ~~https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/487~~
* https://github.com/alphagov/digitalmarketplace-frameworks/pull/424