### PR TITLE
"All categories' link

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -228,5 +228,4 @@ def search_services():
         summary=search_summary.markup(),
         title='Search results',
         total=search_results_obj.total,
-        show_all_categories=not is_g9_live,
     )

--- a/app/templates/search/_services_filters.html
+++ b/app/templates/search/_services_filters.html
@@ -2,15 +2,13 @@
   <h2>Choose a category</h2>
   {% from 'macros/_filters.html' import checkbox, lot_filters %}
   <ul>
-  {% if show_all_categories %}
     <li>
-          {% if current_lot %}
-          <a href="{{ url_for('.search_services', q=search_keywords) }}">All categories</a>
-          {% else %}
-          All categories
-          {% endif %}
+      {% if current_lot %}
+        <a href="{{ url_for('.search_services', q=search_keywords) }}">All categories</a>
+      {% else %}
+        All categories
+      {% endif %}
     </li>
-  {% endif %}
   {% for lot in lots %}
     <li>
       {% if lot.link %}<a href="{{ lot.link }}">{% endif %}{% if lot.selected %}<strong>{% endif %}


### PR DESCRIPTION
"All categories' link (i.e. no lot selection) link returns for G9.
 - there will be no filters apart from the keywords box until we re-implement the way we fetch the cross-lot filters.

https://trello.com/c/H1AC43Si/399-allow-buyers-to-search-across-all-lots-on-the-search-results-page