### PR TITLE
Pull in G9 support categories

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.2.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v8.0.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v8.1.0"
   }
 }


### PR DESCRIPTION
## Summary
Pulls in frameworks 8.1.0, which will allow G9 support categories to be displayed on the search page.

## Caveats
The support categories will not function until the search mapping is updated (https://github.com/alphagov/digitalmarketplace-search-api/pull/80) and the services are re-indexed.