### PR TITLE
copy-my-requirements

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -114,6 +114,12 @@ def create_new_brief(framework_slug, lot_slug):
                 brief_id=brief['id']))
 
 
+# COPY BRIEF
+@buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/copy', methods=['POST'])
+def copy_brief(framework_slug, lot_slug, brief_id):
+    return 'foooo', 200
+
+
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>', methods=['GET'])
 def view_brief_overview(framework_slug, lot_slug, brief_id):
     framework, lot = get_framework_and_lot(

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 from __future__ import unicode_literals
-import unicodecsv
 import inflection
 import sys
 

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -113,10 +113,27 @@ def create_new_brief(framework_slug, lot_slug):
                 brief_id=brief['id']))
 
 
-# COPY BRIEF
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/copy', methods=['POST'])
 def copy_brief(framework_slug, lot_slug, brief_id):
-    return 'foooo', 200
+    # if is_brief_correct(brief_id):
+
+    new_brief = data_api_client.copy_brief(brief_id, current_user.email_address)['briefs']
+
+    # Get first question for 'edit_brief'
+    content = content_loader.get_manifest(framework_slug, 'edit_brief').filter(
+        {'lot': lot_slug}
+    )
+    section = content.get_section(content.get_next_editable_section_id())
+
+    # Redirect to first question with new (copy of) brief
+    return redirect(url_for(
+        '.edit_brief_question',
+        framework_slug=framework_slug,
+        lot_slug=lot_slug,
+        brief_id=new_brief['id'],
+        section_slug=section.slug,
+        question_id=section.questions[0].id
+    ))
 
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>', methods=['GET'])

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -115,7 +115,9 @@ def create_new_brief(framework_slug, lot_slug):
 
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/copy', methods=['POST'])
 def copy_brief(framework_slug, lot_slug, brief_id):
-    # if is_brief_correct(brief_id):
+    brief = data_api_client.get_brief(brief_id)["briefs"]
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
+        abort(404)
 
     new_brief = data_api_client.copy_brief(brief_id, current_user.email_address)['briefs']
 

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -130,9 +130,9 @@ def copy_brief(framework_slug, lot_slug, brief_id):
     # Redirect to first question with new (copy of) brief
     return redirect(url_for(
         '.edit_brief_question',
-        framework_slug=framework_slug,
-        lot_slug=lot_slug,
-        brief_id=new_brief['id'],
+        framework_slug=new_brief["frameworkSlug"],
+        lot_slug=new_brief["lotSlug"],
+        brief_id=new_brief["id"],
         section_slug=section.slug,
         question_id=section.questions[0].id
     ))

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -65,7 +65,7 @@
 ) %}
 
     {% call summary.row() %}
-        {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id), wide=False) }}
+        {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         
         {{ summary.text(item.createdAt|dateformat) }}
         

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -78,9 +78,7 @@
         {% else %}
             {{ summary.text() }}
         {% endif %}
-
-        {{ summary.button(text="Copy requirement", action="#") }}
-        
+        {{ summary.button(text="Copy requirement", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}
 
@@ -90,9 +88,10 @@
     caption="Published requirements caption",
     empty_message="You don’t have any published requirements",
     field_headings=[
-    "Name",
-    "Published",
-    "Closing",
+        "Name",
+        "Published",
+        "Closing",
+        summary.hidden_field_heading("Copy requirements")
     ],
     field_headings_visible=True
 ) %}
@@ -101,6 +100,7 @@
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.publishedAt|dateformat) }}
         {{ summary.text(item.applicationsClosedAt|dateformat) }}
+        {{ summary.button(text="Copy requirement", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}
         
@@ -110,9 +110,10 @@
     caption="Closed requirements caption",
     empty_message="You don’t have any requirements that are closed",
     field_headings=[
-    "Name",
-    "Closed",
-    "Responses",
+        "Name",
+        "Closed",
+        "Responses",
+        summary.hidden_field_heading("Copy requirements")
     ],
     field_headings_visible=True
 ) %}
@@ -121,6 +122,7 @@
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.applicationsClosedAt|dateformat) }}
         {{ summary.link("View responses", url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        {{ summary.button(text="Copy requirement", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}
 {% endblock %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -56,15 +56,16 @@
     caption="Unpublished requirements caption",
     empty_message="You don’t have any unpublished requirements",
     field_headings=[
-    "Name",
-    "Created",
-    "Unanswered questions",
+        "Name",
+        "Created",
+        "Unanswered questions",
+        summary.hidden_field_heading("Copy requirements")
     ],
     field_headings_visible=True
 ) %}
 
     {% call summary.row() %}
-        {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id), wide=False) }}
         
         {{ summary.text(item.createdAt|dateformat) }}
         
@@ -77,6 +78,8 @@
         {% else %}
             {{ summary.text() }}
         {% endif %}
+
+        {{ summary.button(text="Copy requirement", action="#") }}
         
     {% endcall %}
 {% endcall %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -56,7 +56,7 @@
     caption="Unpublished requirements caption",
     empty_message="You don’t have any unpublished requirements",
     field_headings=[
-    "Brief name",
+    "Name",
     "Created",
     "Unanswered questions",
     ],
@@ -87,7 +87,7 @@
     caption="Published requirements caption",
     empty_message="You don’t have any published requirements",
     field_headings=[
-    "Brief name",
+    "Name",
     "Published",
     "Closing",
     ],
@@ -107,7 +107,7 @@
     caption="Closed requirements caption",
     empty_message="You don’t have any requirements that are closed",
     field_headings=[
-    "Brief name",
+    "Name",
     "Closed",
     "Responses",
     ],

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -59,7 +59,7 @@
         "Name",
         "Created",
         "Unanswered questions",
-        summary.hidden_field_heading("Copy requirements")
+        summary.hidden_field_heading("Make a copy")
     ],
     field_headings_visible=True
 ) %}
@@ -78,7 +78,7 @@
         {% else %}
             {{ summary.text() }}
         {% endif %}
-        {{ summary.button(text="Copy requirement", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}
 
@@ -91,7 +91,7 @@
         "Name",
         "Published",
         "Closing",
-        summary.hidden_field_heading("Copy requirements")
+        summary.hidden_field_heading("Make a copy")
     ],
     field_headings_visible=True
 ) %}
@@ -100,7 +100,7 @@
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.publishedAt|dateformat) }}
         {{ summary.text(item.applicationsClosedAt|dateformat) }}
-        {{ summary.button(text="Copy requirement", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}
         
@@ -113,7 +113,7 @@
         "Name",
         "Closed",
         "Responses",
-        summary.hidden_field_heading("Copy requirements")
+        summary.hidden_field_heading("Make a copy")
     ],
     field_headings_visible=True
 ) %}
@@ -122,7 +122,7 @@
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.text(item.applicationsClosedAt|dateformat) }}
         {{ summary.link("View responses", url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
-        {{ summary.button(text="Copy requirement", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
+        {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ odfpy==1.3.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@25.1.0#egg=digitalmarketplace-utils==25.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.4.0#egg=digitalmarketplace-apiclient==8.4.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.8.0#egg=digitalmarketplace-apiclient==8.8.0
 
 # For Cloud Foundry
 cffi==1.5.2

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -283,7 +283,6 @@ class TestCopyBrief(BaseApplicationTest):
             framework_slug="digital-outcomes-and-specialists-2",
             framework_name="Digital Outcomes and Specialists 2"
         )
-
         self.data_api_client.get_brief.return_value = self.brief
 
     def teardown_method(self, method):
@@ -307,6 +306,22 @@ class TestCopyBrief(BaseApplicationTest):
         )
 
         self.data_api_client.copy_brief.assert_called_once_with('1234', 'buyer@email.com')
+
+        assert res.location == (
+            "http://localhost/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/"
+            "1235/edit/title/title"
+        )
+
+    def test_copy_brief_for_expired_framework_redirects_to_edit_page_for_new_framework(self):
+        self.data_api_client.get_brief.return_value = api_stubs.brief()  # dos1 brief
+
+        new_brief = self.brief  # dos2 brief
+        new_brief["briefs"]["id"] = 1235
+        self.data_api_client.copy_brief.return_value = new_brief
+
+        res = self.client.post(
+            '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/copy'
+        )
 
         assert res.location == (
             "http://localhost/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/"

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -271,6 +271,28 @@ class TestCreateNewBrief(BaseApplicationTest):
         )
 
 
+class TestCopyBrief(BaseApplicationTest):
+
+    def setup_method(self, method):
+        super(TestCopyBrief, self).setup_method(method)
+        self.login_as_buyer()
+        self.data_api_client_patch = mock.patch('app.buyers.views.buyers.data_api_client')
+        self.data_api_client = self.data_api_client_patch.start()
+
+        self.data_api_client.get_brief.return_value = api_stubs.brief()
+
+    def teardown_method(self, method):
+        self.data_api_client_patch.stop()
+        super(TestCopyBrief, self).teardown_method(method)
+
+    def test_get_not_allowed(self):
+        res = self.client.get(
+            '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/copy'
+        )
+
+        assert res.status_code == 404
+
+
 class TestEveryDamnPage(BaseApplicationTest):
     def _load_page(self, url, status_code, method='get', data=None, framework_status='live', brief_status='draft'):
         data = {} if data is None else data

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -306,7 +306,7 @@ class TestCopyBrief(BaseApplicationTest):
             '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/1234/copy'
         )
 
-        self.data_api_client.copy_brief.assert_called_once_with('1234', 123)
+        self.data_api_client.copy_brief.assert_called_once_with('1234', 'buyer@email.com')
 
         assert res.location == (
             "http://localhost/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/"

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -279,7 +279,10 @@ class TestCopyBrief(BaseApplicationTest):
         self.data_api_client_patch = mock.patch('app.buyers.views.buyers.data_api_client')
         self.data_api_client = self.data_api_client_patch.start()
 
-        self.data_api_client.get_brief.return_value = api_stubs.brief()
+        self.data_api_client.get_brief.return_value = api_stubs.brief(
+            framework_slug="digital-outcomes-and-specialists-2",
+            framework_name="Digital Outcomes and Specialists 2"
+        )
 
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
@@ -287,7 +290,7 @@ class TestCopyBrief(BaseApplicationTest):
 
     def test_get_not_allowed(self):
         res = self.client.get(
-            '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/copy'
+            '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/1234/copy'
         )
 
         assert res.status_code == 404

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -276,7 +276,7 @@ class TestCopyBrief(BaseApplicationTest):
     def setup_method(self, method):
         super(TestCopyBrief, self).setup_method(method)
         self.login_as_buyer()
-        self.data_api_client_patch = mock.patch('app.buyers.views.buyers.data_api_client', autospec=False)
+        self.data_api_client_patch = mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
 
         self.brief = api_stubs.brief(
@@ -298,15 +298,15 @@ class TestCopyBrief(BaseApplicationTest):
         assert res.status_code == 404
 
     def test_copy_brief_and_redirect_to_copied_brief_edit_title_page(self):
-        copied_brief = self.brief
-        copied_brief["briefs"]["id"] = 1235
-        self.data_api_client.copy_brief.return_value = copied_brief
+        new_brief = self.brief
+        new_brief["briefs"]["id"] = 1235
+        self.data_api_client.copy_brief.return_value = new_brief
 
         res = self.client.post(
             '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/1234/copy'
         )
 
-        self.data_api_client.copy_brief.assert_called_once_with(1234)
+        self.data_api_client.copy_brief.assert_called_once_with('1234', 123)
 
         assert res.location == (
             "http://localhost/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/"

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -313,6 +313,18 @@ class TestCopyBrief(BaseApplicationTest):
             "1235/edit/title/title"
         )
 
+    @mock.patch("app.buyers.views.buyers.is_brief_correct", autospec=True)
+    def test_404_if_brief_is_not_correct(self, is_brief_correct):
+        is_brief_correct.return_value = False
+
+        res = self.client.post(
+            '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/1234/copy'
+        )
+
+        assert res.status_code == 404
+        is_brief_correct.assert_called_once_with(
+            self.brief["briefs"], "digital-outcomes-and-specialists-2", "digital-specialists", 123)
+
 
 class TestEveryDamnPage(BaseApplicationTest):
     def _load_page(self, url, status_code, method='get', data=None, framework_status='live', brief_status='draft'):


### PR DESCRIPTION
* Create view that:
   1. Does a preliminary check that the brief belongs to the `current_user` (`is_brief_correct`)
   2. Triggers the `copy_brief` on the api client.
   3. Redirects to the first page of the brief form.
* Edit template:
  * Change field name headings as per request from @laurenceberry 
  * Add new buttons (to trigger `POST` to above view) to summary form
* Pull in new `apiclient` version
* Tests
