### PR TITLE
filter_label and filter_ignore

### DIFF
--- a/app/main/helpers/search_summary_manifest.yml
+++ b/app/main/helpers/search_summary_manifest.yml
@@ -85,3 +85,22 @@
   filtersPreposition:
   filterRules:
   conjunction: and
+-
+  id: User support
+  labelPreposition: with
+  filtersPreposition:
+  filterRules:
+  conjunction: and
+-
+  id: Government security clearances
+  labelPreposition: where
+  filtersPreposition: the supplier's staff will undergo
+  filterRules:
+  conjunction: and
+-
+  id: Security certification
+  labelPreposition: covering the service includes
+  label:
+  filtersPreposition:
+  filterRules:
+  conjunction: and

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -46,7 +46,7 @@ def filters_for_question(question):
     question_filters = []
     if question['type'] == 'boolean':
         question_filters.append({
-            'label': question['question'],
+            'label': question.get('filter_label') or question.get('name') or question['question'],
             'name': question['id'],
             'id': question['id'],
             'value': 'true',
@@ -60,20 +60,21 @@ def filters_for_question(question):
 
 def _recursive_add_option_filters(question, options_list, filters_list):
     for option in options_list:
-        value = get_filter_value_from_question_option(option)
-        presented_filter = {
-            'label': option['label'],
-            'name': question['id'],
-            'id': '{}-{}'.format(
-                question['id'],
-                value.replace(' ', '-')),
-            'value': value,
-        }
-        if option.get('options'):
-            presented_filter['children'] = []
-            _recursive_add_option_filters(question, option.get('options', []), presented_filter['children'])
+        if not option.get('filter_ignore'):
+            value = get_filter_value_from_question_option(option)
+            presented_filter = {
+                'label': option.get('filter_label') or option['label'],
+                'name': question['id'],
+                'id': '{}-{}'.format(
+                    question['id'],
+                    value.replace(' ', '-')),
+                'value': value,
+            }
+            if option.get('options'):
+                presented_filter['children'] = []
+                _recursive_add_option_filters(question, option.get('options', []), presented_filter['children'])
 
-        filters_list.append(presented_filter)
+            filters_list.append(presented_filter)
 
 
 def set_filter_states(filter_groups, request):

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.2.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v8.1.0"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v8.2.0"
   }
 }

--- a/tests/fixtures/content/frameworks/g9/questions/data/checkboxTreeExample.yml
+++ b/tests/fixtures/content/frameworks/g9/questions/data/checkboxTreeExample.yml
@@ -5,22 +5,19 @@ depends:
 hint: 'Choose all options that apply'
 type: checkbox_tree
 options:
-  -
-    label: 'Option 1'
-    filter_label: 'Option 1 filter label'
-  -
-    label: 'Option 2'
-    filter_label: 'Option 2 filter label'
+  - label: 'Option 1'
+  - label: 'Option 2'
     options:
       - label: 'Option 2.1'
-        filter_label: 'Option 2.1 filter label'
       - label: 'Option 2.2'
-        filter_label: 'Option 2.2 filter label'
   - label: 'Option 3, with comma'
-    filter_label: 'Option 3 filter label'
   - label: 'Option 4 has a value'
-    filter_label: 'Option 4 filter label'
     value: 'option_4_value'
+  - label: 'Option 5'
+    filter_label: 'Option 5 filter label'
+    value: 'option_5_value'
+  - label: 'Option 6'
+    filter_label: 'Option 6 filter label'
 
 validations:
   -

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -121,6 +121,28 @@ class TestSearchFilters(BaseApplicationTest):
         assert filter_with_value['id'] == 'checkboxTreeExample-option_4_value'
         assert filter_with_value['value'] == 'option_4_value'
 
+    def test_filters_with_filter_labels(self):
+        checkboxes_filter_group = filters_for_lot('cloud-software', g9_builder)['categories-example']
+        filter_with_special_label = None
+        for some_filter in checkboxes_filter_group['filters']:
+            if some_filter['value'] == 'option_5_value':
+                filter_with_special_label = some_filter
+                break
+        assert filter_with_special_label is not None
+        assert filter_with_special_label['label'] == 'Option 5 filter label'
+        assert filter_with_special_label['id'] == 'checkboxTreeExample-option_5_value'
+
+    def test_filters_with_filter_label_but_no_value(self):
+        checkboxes_filter_group = filters_for_lot('cloud-software', g9_builder)['categories-example']
+        filter_with_special_label = None
+        for some_filter in checkboxes_filter_group['filters']:
+            if some_filter['label'] == 'Option 6 filter label':
+                filter_with_special_label = some_filter
+                break
+        assert filter_with_special_label is not None
+        assert filter_with_special_label['id'] == 'checkboxTreeExample-option-6'
+        assert filter_with_special_label['value'] == 'option 6'
+
     def test_get_filter_groups_from_questions_with_boolean_filters(self):
         booleans_filter_group = self._get_filter_group_by_label(
             'saas', 'Booleans example'


### PR DESCRIPTION
 - filter_label can apply at question level, for boolean questions, in which case the name field is iused as a fallback (followed by using the question which is existing behaviour);
 - it also applies at option level, for checkbox and radio questions;
 - filter_ignore allows certain options to be skipped entirely.

https://trello.com/c/vZP7vbGP/412-labelling-of-filters