### PR TITLE
Remove plain text logs in live

### DIFF
--- a/config.py
+++ b/config.py
@@ -67,6 +67,7 @@ class Config(object):
 
     # LOGGING
     DM_LOG_LEVEL = 'DEBUG'
+    DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
     DM_APP_NAME = 'buyer-frontend'
     DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
@@ -93,6 +94,7 @@ class Config(object):
 
 class Test(Config):
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
     DM_LOG_LEVEL = 'CRITICAL'
     WTF_CSRF_ENABLED = False
 
@@ -110,6 +112,7 @@ class Test(Config):
 
 class Development(Config):
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
     SESSION_COOKIE_SECURE = False
     DM_SEARCH_PAGE_SIZE = 5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ unicodecsv==0.14.1
 werkzeug==0.10.4
 odfpy==1.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.1.0#egg=digitalmarketplace-utils==25.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalmarketplace-utils==25.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.8.0#egg=digitalmarketplace-apiclient==8.8.0
 


### PR DESCRIPTION
Trello card: https://trello.com/c/o3Jkp3rK

25.2.0 of utils will create json logs by default, unless the
DM_PLAIN_TEXT_LOGS config variable is set to True in the config.

This config variable is set in dev and test so that logs are more
legible/useful.

The other thing 25.2.0 does is log to stdout instead of file by default,
unless the DM_LOG_PATH config variable is set. In the PaaS
environment, we'll need to log to stdout so will overwrite this
variable. Logging to stdout is also more useful in dev and test.