### PR TITLE
Only show parent categories when no sub-category is selected.

### DIFF
--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -177,9 +177,10 @@ def _annotate_categories_with_selection(lot, category_filters, request, parent_c
                                        lot=lot['slug'],
                                        **url_args)
 
-    # Remove categories (except the selected one), when any is selected - we
-    # think this may make navigation easier (and it's similar to what Amazon does)
+    # When there's a selection, remove parent categories (i.e. preserve the selection, plus
+    # sub-categories, which is those without children).
     if selected_category_filter is not None:
-        category_filters[:] = (c for c in category_filters if c['selected'])  # in-place filter(!)
+        category_filters[:] = (c for c in category_filters
+                               if c['selected'] or not c.get('children', []))  # in-place filter(!)
 
     return selected_category_filter

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -178,7 +178,8 @@ def _annotate_categories_with_selection(lot, category_filters, request, parent_c
                                        **url_args)
 
     # When there's a selection, remove parent categories (i.e. preserve the selection, plus
-    # sub-categories, which is those without children).
+    # sub-categories, which is those without children). The effect is that siblings of any
+    # selected category or sub-category are shown, if that selection has no children.
     if selected_category_filter is not None:
         category_filters[:] = (c for c in category_filters
                                if c['selected'] or not c.get('children', []))  # in-place filter(!)


### PR DESCRIPTION
Per 'version 4' mockup in ticket - the A/C for that (which I just wrote are:

"We now want to see sibling categories of the currently-selected category, but only at the bottom level (i.e. sub-categories in the case of the SaaS lot, but categories in the other two lots)."

Before:
<img width="322" alt="screen shot 2017-05-09 at 17 34 07" src="https://cloud.githubusercontent.com/assets/190828/25862031/8d396f3c-34de-11e7-917f-0d596e5517b3.png">

After:
<img width="353" alt="screen shot 2017-05-09 at 17 34 00" src="https://cloud.githubusercontent.com/assets/190828/25862050/986097aa-34de-11e7-90ad-b0eaba114db3.png">

https://trello.com/c/Fyi0uec3/415-clicking-back-on-categories-navigation