### PR TITLE
Throw when the search summary manifest omits a filter value

### DIFF
--- a/app/main/presenters/search_summary.py
+++ b/app/main/presenters/search_summary.py
@@ -266,4 +266,8 @@ class SummaryFragment(object):
                     filter_string = self.rules.add_filter_preposition(
                         filter_id=filter, filter_string=filter_string)
                     processed_filters.append(filter_string)
+                else:
+                    raise Exception(
+                        "Filter with id '{}' not found in filterRules.".format(filter)
+                    )
         return processed_filters


### PR DESCRIPTION
Seems harsh to throw, but later on, the code crashed anyway, but with a totally confusing and bizarre stack trace / error. This way, we can know why it broke.

https://trello.com/c/3XUKd0tX/345-add-filters-to-search-results-page