### PR TITLE
Move keyword box above filters

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -46,10 +46,6 @@ em.search-result-highlighted-text {
   .option-select-label {
     display: block;
   }
-
-  .filter-field-text {
-    padding: 5px;
-  }
 }
 
 .search-result-important-metadata {

--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -49,14 +49,6 @@ em.search-result-highlighted-text {
 
   .filter-field-text {
     padding: 5px;
-
-    input {
-      @include core-16;
-      @include box-sizing(border-box);
-      width: 100%;
-      padding: 5px;
-      border: 1px solid $border-colour;
-    }
   }
 }
 

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -36,13 +36,14 @@ $path: "/static/images/";
 @import "toolkit/_secondary-action-link.scss";
 @import "toolkit/_service-id.scss";
 @import "toolkit/_temporary-message.scss";
+@import "toolkit/forms/_dates.scss";
 @import "toolkit/forms/_hint.scss";
+@import "toolkit/forms/_keyword-search.scss";
 @import "toolkit/forms/_option-select.scss";
 @import "toolkit/forms/_questions.scss";
 @import "toolkit/forms/_selection-buttons.scss";
 @import "toolkit/forms/_summary.scss";
 @import "toolkit/forms/_textboxes.scss";
-@import "toolkit/forms/_dates.scss";
 @import "toolkit/forms/_validation.scss";
 @import "toolkit/search/_search-result.scss";
 

--- a/app/templates/search/_services_filters.html
+++ b/app/templates/search/_services_filters.html
@@ -1,3 +1,12 @@
+<div class="govuk-option-select filter-field-text">
+  <div class="container-head">
+    <label class="option-select-label" for="keywords">
+      Keywords
+    </label>
+  </div>
+  <input type="text" name="q" id="keywords" value="{{ search_keywords }}" maxlength="200">
+</div>
+
 <div class="lot-filters">
   <h2>Choose a category</h2>
   {% from 'macros/_filters.html' import checkbox, lot_filters %}
@@ -23,14 +32,7 @@
   {% endfor %}
   </ul>
 </div>
-<div class="govuk-option-select filter-field-text">
-  <div class="container-head">
-    <label class="option-select-label" for="keywords">
-      Keywords
-    </label>
-  </div>
-  <input type="text" name="q" id="keywords" value="{{ search_keywords }}" maxlength="200">
-</div>
+
 
 {% if current_lot %}
 <input type="hidden" name="lot" value="{{ current_lot.slug }}" />

--- a/app/templates/search/_services_filters.html
+++ b/app/templates/search/_services_filters.html
@@ -1,11 +1,12 @@
-<div class="govuk-option-select filter-field-text">
-  <div class="container-head">
-    <label class="option-select-label" for="keywords">
-      Keywords
-    </label>
-  </div>
-  <input type="text" name="q" id="keywords" value="{{ search_keywords }}" maxlength="200">
-</div>
+{%
+  with
+  id = "keywords",
+  name = "q",
+  label = "Keywords",
+  value = search_keywords
+%}
+  {% include "toolkit/forms/keyword-search.html" %}
+{% endwith %}
 
 <div class="lot-filters">
   <h2>Choose a category</h2>

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.2.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.3.0"
   }


### PR DESCRIPTION
For this story: https://trello.com/c/dtI7Ozur/414-keyword-search-bar-location

We're not currently using the toolkit keyword search box in the buyer frontend.  This pulls in the updated keyword search box from the toolkit (so depends on this PR being merged first): 
 - [x] https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/343
 
And moves it above the category list and filters.

## BEFORE
![screen shot 2017-05-12 at 14 38 36](https://cloud.githubusercontent.com/assets/6525554/26000422/cfffde16-3720-11e7-8348-24bd021659fc.png)

## AFTER
![screen shot 2017-05-12 at 14 38 16](https://cloud.githubusercontent.com/assets/6525554/26000429/d44e9796-3720-11e7-8206-16dae87b2533.png)
