### PR TITLE
Remove hardcoded G-Cloud descriptions

### DIFF
--- a/app/main/helpers/framework_helpers.py
+++ b/app/main/helpers/framework_helpers.py
@@ -1,3 +1,6 @@
+from ... import content_loader
+
+
 def get_latest_live_framework(all_frameworks, framework_type):
     try:
         latest = max(
@@ -19,3 +22,14 @@ def is_g9_live(all_frameworks):
     """
     framework = get_latest_live_framework(all_frameworks, 'g-cloud')
     return (framework['slug'] != 'g-cloud-8') if framework else False
+
+
+def get_framework_description(data_api_client, framework_family):
+    frameworks = data_api_client.find_frameworks().get('frameworks')
+    framework = get_latest_live_framework(frameworks, framework_family)
+    if framework is None:
+        return ''
+
+    content_loader.load_messages(framework['slug'], ['descriptions'])
+
+    return content_loader.get_message(framework['slug'], 'descriptions', 'framework')

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -141,7 +141,9 @@ def get_service_by_id(service_id):
             'service.html',
             service=service_view_data,
             service_unavailability_information=service_unavailability_information,
-            lot=service_view_data.lot), status_code
+            lot=service_view_data.lot,
+            gcloud_framework_description=framework_helpers.get_framework_description(data_api_client, 'g-cloud'),
+        ), status_code
     except AuthException:
         abort(500, "Application error")
     except HTTPError as e:
@@ -219,4 +221,5 @@ def search_services():
         summary=search_summary.markup(),
         title='Search results',
         total=search_results_obj.total,
+        gcloud_framework_description=framework_helpers.get_framework_description(data_api_client, 'g-cloud'),
     )

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -12,7 +12,7 @@ from dmcontent.content_loader import ContentNotFoundError
 
 from ...main import main
 from ..helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference, parse_link
-from ..helpers.framework_helpers import get_latest_live_framework, is_g9_live
+from ..helpers.framework_helpers import get_latest_live_framework, is_g9_live, get_framework_description
 
 from ..forms.brief_forms import BriefSearchForm
 
@@ -59,6 +59,7 @@ def index():
         frameworks={framework['slug']: framework for framework in frameworks},
         temporary_message=temporary_message,
         show_new_g9_content=show_new_g9_content,
+        gcloud_framework_description=get_framework_description(data_api_client, 'g-cloud'),
     )
 
 

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -5,6 +5,7 @@ from flask import render_template, request, abort
 from app import data_api_client
 from dmapiclient import APIError
 from ..helpers.shared_helpers import parse_link
+from ..helpers.framework_helpers import get_framework_description
 import re
 
 try:
@@ -50,7 +51,8 @@ def suppliers_list_by_prefix():
                                count=len(suppliers),
                                prev_link=parse_link(links, 'prev'),
                                next_link=parse_link(links, 'next'),
-                               prefix=template_prefix
+                               prefix=template_prefix,
+                               gcloud_framework_description=get_framework_description(data_api_client, 'g-cloud'),
                                )
     except APIError as e:
         if e.status_code == 404:
@@ -61,18 +63,17 @@ def suppliers_list_by_prefix():
 
 @main.route('/g-cloud/supplier/<supplier_id>')
 def suppliers_details(supplier_id):
-    supplier = data_api_client.get_supplier(
-        supplier_id=supplier_id)["suppliers"]
+    supplier = data_api_client.get_supplier(supplier_id=supplier_id)["suppliers"]
 
     first_character_of_supplier_name = supplier["name"][:1]
     if is_alpha(first_character_of_supplier_name):
-        prefix = process_prefix(
-            prefix=first_character_of_supplier_name, format='template')
+        prefix = process_prefix(prefix=first_character_of_supplier_name, format='template')
     else:
         prefix = u"other"
 
     return render_template(
         'suppliers_details.html',
         supplier=supplier,
-        prefix=prefix
+        prefix=prefix,
+        gcloud_framework_description=get_framework_description(data_api_client, 'g-cloud'),
     )

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -52,7 +52,7 @@
       {% set items = items + [
         {
           "link": "/g-cloud",
-          "title": "Find cloud hosting, software and support" if show_new_g9_content else "Find cloud technology and support",
+          "title": "Find " + gcloud_framework_description,
           "body": "eg content delivery networks or accounting software" if show_new_g9_content else "eg web hosting or IT health checks",
         },
         {

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -17,7 +17,7 @@
         },
         {
             "link": url_for('.index_g_cloud'),
-            "label": "Cloud technology and support"
+            "label": gcloud_framework_description|capitalize
         },
         {
           "label": current_lot.name
@@ -31,7 +31,7 @@
         },
         {
             "link": url_for('.index_g_cloud'),
-            "label": "Cloud technology and support"
+            "label": gcloud_framework_description|capitalize
         }
       ] %}
     {% endif %}

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -13,7 +13,7 @@
       },
       {
           "link": url_for('.index_g_cloud'),
-          "label": "Cloud technology and support"
+          "label": gcloud_framework_description|capitalize
       },
       {
           "link": url_for('.search_services', lot=lot.slug),

--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -12,7 +12,7 @@
       },
       {
           "link": url_for('.index_g_cloud'),
-          "label": "Cloud technology and support"
+          "label": gcloud_framework_description|capitalize
       },
       {
           "link": url_for('.suppliers_list_by_prefix'),

--- a/app/templates/suppliers_list.html
+++ b/app/templates/suppliers_list.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 
 {% block page_title %}
-  Suppliers starting with {{ prefix }} – Cloud technology and support – Digital Marketplace
+  Suppliers starting with {{ prefix }} – {{ gcloud_framework_description|capitalize }} – Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -14,7 +14,7 @@
       },
       {
           "link": url_for('.index_g_cloud'),
-          "label": "Cloud technology and support"
+          "label": gcloud_framework_description|capitalize
       }
     ]
   %}

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -62,6 +62,13 @@ class TestHomepageBrowseList(BaseApplicationTest):
         "id": 7
     }
 
+    mock_live_g_cloud_9_framework = {
+        "framework": "g-cloud",
+        "slug": "g-cloud-9",
+        "status": "live",
+        "id": 8
+    }
+
     def test_dos_links_are_shown(self, data_api_client):
         with self.app.app_context():
             data_api_client.find_frameworks.return_value = {
@@ -158,11 +165,13 @@ class TestHomepageBrowseList(BaseApplicationTest):
             mock_expired_dos_1_framework.update({"status": "expired"})
             mock_expired_dos_2_framework = self.mock_live_dos_2_framework.copy()
             mock_expired_dos_2_framework.update({"status": "expired"})
+            mock_g_cloud_9_framework = self.mock_live_g_cloud_9_framework.copy()
 
             data_api_client.find_frameworks.return_value = {
                 "frameworks": [
                     mock_expired_dos_1_framework,
                     mock_expired_dos_2_framework,
+                    mock_g_cloud_9_framework,
                 ]
             }
 
@@ -172,7 +181,7 @@ class TestHomepageBrowseList(BaseApplicationTest):
             assert res.status_code == 200
 
             link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
-            assert link_texts[0] == "Find cloud technology and support"
+            assert link_texts[0] == "Find cloud hosting, software and support"
             assert link_texts[1] == "Buy physical datacentre space"
             assert len(link_texts) == 2
 
@@ -862,9 +871,7 @@ class TestGCloudHomepageLinks(BaseApplicationTest):
     def test_g_cloud_homepage_content_is_correct(self, data_api_client, framework_slug, gcloud_content):
         with self.app.app_context():
             data_api_client.find_frameworks.return_value = {
-                "frameworks": [
-                    self.mock_live_g_cloud_framework
-                ]
+                "frameworks": [self.mock_live_g_cloud_framework.copy()]
             }
             data_api_client.find_frameworks.return_value['frameworks'][0].update({'slug': framework_slug})
 


### PR DESCRIPTION
## Summary
Lots of templates/etc had hardcoded references to 'Cloud technology and support', which was the standard description for G-Cloud 8 and earlier. We are now changing that to 'Cloud hosting, software and support' and are aware this may change again in the future. Therefore, we want to remove hardcoded references to this and have the sentence fragment as a framework-mutable string.

## Implementation Details
* New descriptions.yml file in messages for each framework, containing a 'description' key which stores the framework's description fragment.
* New get_framework_description helper to retrieve this fragment, given a framework slug.
* Update templates to use this per-framework value.

## Ticket
https://trello.com/c/pYYRBhNu/336-content-on-g-cloud-page