### PR TITLE
Service page labels

### DIFF
--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -24,8 +24,8 @@ class Service(object):
         if key[0] in service_data:
             setattr(self, key[1], service_data[key[0]])
 
-    def __init__(self, service_data, service_questions, lots_by_slug):
-        self.service_questions = service_questions
+    def __init__(self, service_data, builder, lots_by_slug):
+        self.summary_manifest = builder.summary(service_data)
         # required attributes directly mapped to service_data values
         self.title = service_data['serviceName']
         self.serviceSummary = service_data['serviceSummary']\
@@ -40,36 +40,10 @@ class Service(object):
             ('serviceBenefits', 'benefits')
         ]:
             self._add_as_attribute_if_key_exists(key, service_data)
-        self.attributes = self._get_service_attributes(service_data)
         self.meta = self._get_service_meta(service_data)
-
-    def _get_service_attributes(self, service_data):
-        sections = map(
-            lambda section: {
-                'name': section['name'],
-                'rows': self._get_rows(section, service_data)
-            },
-            self.service_questions
-        )
-        return list(filter(
-            lambda section: len(list(section['rows'])) > 0,
-            list(sections)
-        ))
 
     def _get_service_meta(self, service_data):
         return Meta(service_data)
-
-    def _get_rows(self, section, service_data):
-        return list(filter(
-            not_empty, map(
-                lambda question: Attribute(
-                    value=service_data.get(question['id'], None),
-                    question_type=question['type'],
-                    label=question['question']
-                ),
-                section['questions']
-            )
-        ))
 
 
 class Meta(object):
@@ -227,15 +201,3 @@ class Meta(object):
             return values['if_exists']
         else:
             return values['if_absent']
-
-
-def lowercase_first_character_unless_part_of_acronym(string):
-    if not string:
-        return ''
-    if string[1:2] == string[1:2].upper():
-        return string
-    return string[:1].lower() + string[1:]
-
-
-def not_empty(item):
-    return item.value is not ''

--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -24,8 +24,8 @@ class Service(object):
         if key[0] in service_data:
             setattr(self, key[1], service_data[key[0]])
 
-    def __init__(self, service_data, builder, lots_by_slug):
-        self.summary_manifest = builder.summary(service_data)
+    def __init__(self, service_data, manifest, lots_by_slug):
+        self.summary_manifest = manifest.summary(service_data)
         # required attributes directly mapped to service_data values
         self.title = service_data['serviceName']
         self.serviceSummary = service_data['serviceSummary']\

--- a/app/templates/_service_attributes.html
+++ b/app/templates/_service_attributes.html
@@ -1,17 +1,21 @@
 {% import "toolkit/summary-table.html" as summary %}
-{% for attributeGrouping in service.attributes %}
-  {{ summary.heading(attributeGrouping.name) }}
-  {% call(item) summary.list_table(
-    attributeGrouping.rows,
-    caption=attributeGrouping.name,
-    field_headings=[
-      "Name", "Content",
-    ],
-    field_headings_visible = False
-  ) %}
-    {% call summary.row() %}
-      {{ summary.field_name(item.label) }}
-      {{ summary[item.type](item.value, item.assurance) }}
+
+{% for section in service.summary_manifest %}
+  {% if not section.is_empty %}
+    {{ summary.heading(section.name, id=section.slug) }}
+
+    {% call(question) summary.list_table(
+      section.questions,
+      caption=section.name,
+      field_headings_visible=False
+    ) %}
+      {% if not question.is_empty %}
+        {% call summary.row() %}
+          {{ summary.field_name(question.label) }}
+          {{ summary[question.type](question.value, question.assurance) }}
+
+        {% endcall %}
+      {% endif %}
     {% endcall %}
-  {% endcall %}
+  {% endif %}
 {% endfor %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ werkzeug==0.10.4
 odfpy==1.3.3
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalmarketplace-utils==25.2.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.2.0#egg=digitalmarketplace-content-loader==4.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.3.0#egg=digitalmarketplace-content-loader==4.3.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.8.0#egg=digitalmarketplace-apiclient==8.8.0
 
 # For Cloud Foundry

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -1,7 +1,7 @@
 import os
 import json
 from app.main.presenters.service_presenters import (
-    Service, Meta, lowercase_first_character_unless_part_of_acronym,
+    Service, Meta,
     chunk_string
 )
 from app import content_loader
@@ -267,15 +267,3 @@ class TestMeta(object):
         assert 'Trial and free options available' not in price_caveats
         assert 'Trial option available' not in price_caveats
         assert 'Free option available' not in price_caveats
-
-
-class TestHelpers(object):
-    def test_normal_string_can_be_lowercased(self):
-        assert lowercase_first_character_unless_part_of_acronym(
-            "Independent validation of assertion"
-        ) == "independent validation of assertion"
-
-    def test_string_starting_with_acronym_can_be_lowercased(self):
-        assert lowercase_first_character_unless_part_of_acronym(
-            "CESG-assured components"
-        ) == "CESG-assured components"

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -77,55 +77,15 @@ class TestService(BaseApplicationTest):
         assert hasattr(self.service, 'benefits')
         assert len(self.service.benefits) == 6
 
-    def test_attributes_are_correctly_set(self):
+    def test_service_properties_available_via_summary_manifest(self):
         service = Service(
             self.fixture,
             content_loader.get_builder('g-cloud-6', 'display_service').filter({'lot': 'iaas'}),
             self._lots_by_slug
         )
-        assert service.attributes[0]['name'] == 'Support'
-        assert len(service.attributes) == 30
-        assert len(list(service.attributes[0]['rows'])) == 5
-
-    def test_the_support_attribute_group_is_not_there_if_no_attributes(self):
-        del self.fixture['openStandardsSupported']
-        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'),
-                          self._lots_by_slug)
-        for group in service.attributes:
-            assert group['name'] != 'Open standards', "Support group should not be found"
-
-    def test_only_attributes_with_a_valid_type_are_added_to_groups(self):
-        invalidValue = (u'Manuals provided', u'CMS training')
-        self.fixture['onboardingGuidance'] = invalidValue
-        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'),
-                          self._lots_by_slug)
-        for group in service.attributes:
-            assert not (group['name'] == 'External interface protection' and 'onboardingGuidance' in group), \
-                "Attribute with tuple value should not be in group"
-
-    def test_attributes_with_assurance_in_the_fields_add_it_correctly(self):
-        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'),
-                          self._lots_by_slug)
-        for group in service.attributes:
-            if group['name'] == 'Data-in-transit protection':
-                for row in group['rows']:
-                    # string with bespoke assurance caveat
-                    if row.label == 'Data protection between services':
-                        assert row.value == [u'No encryption']
-                        assert row.assurance == u'independent validation of assertion'
-                    # string with standard assurance caveat
-                    if row.label == 'Data protection within service':
-                        assert row.value == [u'No encryption']
-
-    def test_attributes_with_assurance_for_a_list_value_has_a_caveat(self):
-        service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'),
-                          self._lots_by_slug)
-        for group in service.attributes:
-            if group['name'] == 'Asset protection and resilience':
-                for row in group['rows']:
-                    # list with bespoke assurance caveat
-                    if row.label == 'Data management location':
-                        assert u'independent validation of assertion' in row.assurance
+        assert service.summary_manifest.sections[0].name == 'Support'
+        assert len(service.summary_manifest.sections) == 30
+        assert len(service.summary_manifest.sections[0].questions) == 5
 
 
 class TestMeta(object):


### PR DESCRIPTION
G-cloud service page to use labels (from the framework data via the content loader), rather than values, where possible.

Also, a refactoring to remove a layer of presentation-oriented classes, that were originally supposed to be shared, but have in fact been superseded by the content loader's summary classes.

https://trello.com/c/SmYXzVyu/374-buyer-service-page-displays-question-values-not-labels