### PR TITLE
Remove hanging bullets on service page

### DIFF
--- a/app/assets/scss/_service-page.scss
+++ b/app/assets/scss/_service-page.scss
@@ -48,6 +48,7 @@
   li {
     list-style-type: disc;
     margin-bottom: 10px;
+    margin-left: 20px;
   }
 }
 


### PR DESCRIPTION
## Summary
Jeremy doesn't like the hanging bullets on the service page (nor do I), and we've been moving away from them generally, so let's bring them _in line_. (Get it? Hahahaha...)

## Old
<img width="702" alt="screen shot 2017-05-17 at 08 35 58" src="https://cloud.githubusercontent.com/assets/2920760/26143271/34ce00c0-3adc-11e7-8192-9a002742448a.png">

## New
<img width="707" alt="screen shot 2017-05-17 at 08 35 38" src="https://cloud.githubusercontent.com/assets/2920760/26143276/36ec0c80-3adc-11e7-93eb-da2b2a9c9b78.png">