### PR TITLE
Free trial link in meta section of service page

### DIFF
--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -123,6 +123,9 @@ class Meta(object):
         return documents
 
     def get_price_caveats(self, service_data):
+        def make_caveat(text, link=None):
+            return {'text': text, 'link': link} if link else {'text': text}
+
         caveats = []
         main_caveats = [
             {
@@ -143,10 +146,11 @@ class Meta(object):
         ]
 
         if 'minimumContractPeriod' in service_data:
-            caveats.append('Minimum contract period: {}'.format(service_data['minimumContractPeriod']))
+            caveats.append(make_caveat('Minimum contract period: {}'.format(service_data['minimumContractPeriod'])))
 
-        if 'freeVersionTrialOption' in service_data:
-            options = 'Free trial option available'
+        if service_data.get('freeVersionTrialOption') is True:
+            options = make_caveat('Free trial available', service_data.get('freeVersionLink'))
+
         else:
             options = self._if_both_keys_or_either(
                 service_data,
@@ -158,16 +162,19 @@ class Meta(object):
                     'if_neither': False
                 }
             )
+            options = make_caveat(options) if options else options
+
         for item in main_caveats:
             if item['key'] in service_data:
                 if service_data[item['key']]:
-                    caveats.append(item['if_exists'])
+                    caveats.append(make_caveat(item['if_exists']))
                 else:
                     if item['if_absent']:
-                        caveats.append(item['if_absent'])
+                        caveats.append(make_caveat(item['if_absent']))
 
         if options:
             caveats.append(options)
+
         return caveats
 
     def _get_pretty_document_name_without_extension(self, document_url):

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -3,7 +3,18 @@
   <p class="price">{{ service.meta.price }}</p>
   <ul class="price-caveats">
   {% for caveat in service.meta.priceCaveats %}
-    <li>{{ caveat }}</li>
+    <li>
+      {% if caveat['link'] %}
+        {% with text = caveat['text'],
+                link = caveat['link'],
+                target = "_blank"
+        %}
+          {% include "toolkit/external-link.html" %}
+        {% endwith %}
+      {% else %}
+        {{ caveat['text'] }}
+      {% endif %}
+    </li>
   {% endfor %}
   </ul>
   <h2 class="visuallyhidden">Service documents</h2>

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -1,5 +1,6 @@
-import os
 import json
+import os
+import pytest
 from app.main.presenters.service_presenters import (
     Service, Meta,
     chunk_string
@@ -168,62 +169,71 @@ class TestMeta(object):
     def test_vat_status_is_correct(self):
         # if VAT is not included
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Excluding VAT' in price_caveats
+        assert 'Excluding VAT' in [x['text'] for x in price_caveats]
         # if VAT is included
         self.fixture['vatIncluded'] = True
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Including VAT' in price_caveats
+        assert 'Including VAT' in [x['text'] for x in price_caveats]
 
     def test_education_pricing_status_is_correct(self):
         # if Education pricing is included
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Education pricing available' in price_caveats
+        assert 'Education pricing available' in [x['text'] for x in price_caveats]
         # if Education pricing is excluded
         self.fixture['educationPricing'] = False
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Education pricing available' not in price_caveats
+        assert 'Education pricing available' not in [x['text'] for x in price_caveats]
 
     def test_termination_costs_status_is_correct(self):
         # if Termination costs are excluded
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Termination costs apply' not in price_caveats
+        assert 'Termination costs apply' not in [x['text'] for x in price_caveats]
         # if Termination costs are included
         self.fixture['terminationCost'] = True
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Termination costs apply' in price_caveats
+        assert 'Termination costs apply' in [x['text'] for x in price_caveats]
         # if the question wasn't asked
         del self.fixture['terminationCost']
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Termination costs apply' not in price_caveats
+        assert 'Termination costs apply' not in [x['text'] for x in price_caveats]
 
     def test_minimum_contract_status_is_correct(self):
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Minimum contract period: Month' in price_caveats
+        assert 'Minimum contract period: Month' in [x['text'] for x in price_caveats]
 
     def test_options_are_correct_if_both_false(self):
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Trial and free options available' not in price_caveats
-        assert 'Trial option available' not in price_caveats
-        assert 'Free option available' not in price_caveats
+        assert 'Trial and free options available' not in [x['text'] for x in price_caveats]
+        assert 'Trial option available' not in [x['text'] for x in price_caveats]
+        assert 'Free option available' not in [x['text'] for x in price_caveats]
 
     def test_options_are_correct_if_free_is_false_and_trial_true(self):
         self.fixture['trialOption'] = True
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Trial and free options available' not in price_caveats
-        assert 'Free option available' not in price_caveats
-        assert 'Trial option available' in price_caveats
+        assert 'Trial and free options available' not in [x['text'] for x in price_caveats]
+        assert 'Free option available' not in [x['text'] for x in price_caveats]
+        assert 'Trial option available' in [x['text'] for x in price_caveats]
 
     def test_options_are_correct_if_free_is_true_and_trial_false(self):
         self.fixture['freeOption'] = True
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Trial and free options available' not in price_caveats
-        assert 'Trial option available' not in price_caveats
-        assert 'Free option available' in price_caveats
+        assert 'Trial and free options available' not in [x['text'] for x in price_caveats]
+        assert 'Trial option available' not in [x['text'] for x in price_caveats]
+        assert 'Free option available' in [x['text'] for x in price_caveats]
 
     def test_options_are_correct_if_both_are_not_set(self):
         del self.fixture['freeOption']
         del self.fixture['trialOption']
         price_caveats = self.meta.get_price_caveats(self.fixture)
-        assert 'Trial and free options available' not in price_caveats
-        assert 'Trial option available' not in price_caveats
-        assert 'Free option available' not in price_caveats
+        assert 'Trial and free options available' not in [x['text'] for x in price_caveats]
+        assert 'Trial option available' not in [x['text'] for x in price_caveats]
+        assert 'Free option available' not in [x['text'] for x in price_caveats]
+
+    def test_caveats_for_free_trial(self):
+        self.fixture['freeVersionTrialOption'] = True
+        self.fixture['freeVersionLink'] = 'https://www.digitalmarketplace.service.gov.uk'
+        price_caveats = self.meta.get_price_caveats(self.fixture)
+
+        free_trial_caveat = list(filter(lambda x: x['text'] == 'Free trial available', price_caveats))
+        assert len(free_trial_caveat) == 1
+        assert free_trial_caveat[0]['link'] == 'https://www.digitalmarketplace.service.gov.uk'


### PR DESCRIPTION
## Summary
In the Meta section of a service page we currently show whether or not the service offers a free trial. In G-Cloud 9 we want to turn this into a hyperlink if the supplier has provided a link to the free trial. We will also show the hyperlink provided as part of the summary table. Currently we will not turn this text into a hyperlink in the summary table, though we may do so in the future.

## Ticket
https://trello.com/c/Sxd04wcI/416-free-trial-text-becomes-a-link

## Old (from G8)
<img width="279" alt="screen shot 2017-05-17 at 16 10 34" src="https://cloud.githubusercontent.com/assets/2920760/26161314/827ef59c-3b1b-11e7-8a2b-c2fbcdb96e3f.png">

## New (from G9)
<img width="290" alt="screen shot 2017-05-17 at 16 11 26" src="https://cloud.githubusercontent.com/assets/2920760/26161315/84acf1de-3b1b-11e7-81eb-a48c618baba5.png">