### PR TITLE
391-show-that-a-brief-is-withdrawn

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -77,7 +77,7 @@ def terms_and_conditions():
 def get_brief_by_id(framework_framework, brief_id):
     briefs = data_api_client.get_brief(brief_id)
     brief = briefs.get('briefs')
-    if brief['status'] not in ['live', 'closed'] or brief['frameworkFramework'] != framework_framework:
+    if brief['status'] not in ['live', 'closed', 'withdrawn'] or brief['frameworkFramework'] != framework_framework:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
 
     if getattr(current_user, "supplier_id", None) is None:

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -1,6 +1,6 @@
 {% import "toolkit/summary-table.html" as summary %}
 
-{% if (not brief.clarificationQuestionsAreClosed) and brief.questionAndAnswerSessionDetails %}
+{% if brief.status == 'live' and not brief.clarificationQuestionsAreClosed and brief.questionAndAnswerSessionDetails %}
   {{ summary.heading("Question and answer session", id="question-and-answer-session") }}
   <a href="/suppliers/opportunities/{{ brief.id }}/question-and-answer-session">
     {% if current_user.is_authenticated() and current_user.role == 'supplier' %}

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -42,8 +42,8 @@
     {%
       with
       type = "temporary-message",
-      heading = "This opportunity was withdrawn on {}".format(brief.withdrawnAt|dateformat),
-      message = "You can't apply for this opportunity now. The buyer may publish an updated version on the Digital Marketplace."
+      heading = "This opportunity was withdrawn on " + "{}".format(brief.withdrawnAt|dateformat)|nbsp,
+      message = "You can't apply for this opportunity now. The buyer may publish an " + "updated version"|nbsp + " on the " + "Digital Marketplace."|nbsp
     %}
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -43,7 +43,7 @@
       with
       type = "temporary-message",
       heading = "This opportunity was withdrawn on {}".format(brief.withdrawnAt|dateformat),
-      message = "The buyer may publish an updated version of this opportunity on the Digital Marketplace."
+      message = "You can't apply for this opportunity now. The buyer may publish an updated version on the Digital Marketplace."
     %}
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -36,6 +36,19 @@
     {% endwith %}
   </div>
 </div>
+{% elif brief.status == 'withdrawn' %}
+<div class="grid-row">
+  <div class="column-one-whole">
+    {%
+      with
+      type = "temporary-message",
+      heading = "This opportunity was withdrawn on {}".format(brief.withdrawnAt|dateformat),
+      message = "The buyer may publish an updated version of this opportunity on the Digital Marketplace."
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  </div>
+</div>
 {% endif %}
 
 <div class="grid-row">

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -445,31 +445,6 @@ class TestBriefPage(BaseBriefPageTest):
         assert contract_length_key[0] == 'Expected contract length'
         assert contract_length_value[0] == '4 weeks'
 
-    def test_dos_brief_has_question_and_answer_session_details_link(self):
-        brief_id = self.brief['briefs']['id']
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-
-        document = html.fromstring(res.get_data(as_text=True))
-        qa_session_link_text = document.xpath(
-            '//a[@href="/suppliers/opportunities/{}/question-and-answer-session"]/text()'.format(brief_id)
-        )[0].strip()
-
-        assert qa_session_link_text == "Log in to view question and answer session details"
-
-    def test_dos_brief_question_and_answer_session_details_hidden_when_questions_closed(self):
-        self.brief['briefs']['clarificationQuestionsAreClosed'] = True
-        brief_id = self.brief['briefs']['id']
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-
-        assert "/question-and-answer-session" not in res.get_data(as_text=True)
-
-    def test_dos_brief_question_and_answer_session_details_hidden_when_empty(self):
-        del self.brief['briefs']['questionAndAnswerSessionDetails']
-        brief_id = self.brief['briefs']['id']
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-
-        assert "/question-and-answer-session" not in res.get_data(as_text=True)
-
     def test_dos_brief_has_questions_and_answers(self):
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
@@ -483,26 +458,10 @@ class TestBriefPage(BaseBriefPageTest):
         number = clarification_questions[0].xpath('td[1]/span/span/text()')[0].strip()
         question = clarification_questions[0].xpath('td[1]/span/text()')[0].strip()
         answer = clarification_questions[0].xpath('td[2]/span/text()')[0].strip()
-        qa_link_text = document.xpath('//a[@href="/suppliers/opportunities/{}/ask-a-question"]/text()'
-                                      .format(brief_id))[0].strip()
 
         assert number == "1."
         assert question == "Why?"
         assert answer == "Because"
-        assert qa_link_text == "Log in to ask a question"
-
-    def test_dos_brief_has_different_link_text_for_logged_in_supplier(self):
-        self.login_as_supplier()
-        brief_id = self.brief['briefs']['id']
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
-        assert res.status_code == 200
-
-        document = html.fromstring(res.get_data(as_text=True))
-
-        qa_link_text = document.xpath('//a[@href="/suppliers/opportunities/{}/ask-a-question"]/text()'
-                                      .format(brief_id))[0]
-
-        assert qa_link_text.strip() == "Ask a question"
 
     def test_can_apply_to_live_brief(self):
         brief_id = self.brief['briefs']['id']
@@ -669,7 +628,7 @@ class TestBriefPageQandASectionViewQandASessionDetails(BaseBriefPageTest):
             {'clarificationQuestionsAreClosed': True}
         ]
     )
-    def test_brief_q_and_a_session_fails(self, brief_data):
+    def test_brief_q_and_a_session_link_not_shown(self, brief_data):
         """
         On viewing briefs with data like the above the page should load but we should not get the link.
         """
@@ -700,7 +659,6 @@ class TestBriefPageQandASectionAskAQuestion(BaseBriefPageTest):
             A user is not logged in
             The brief is live
             Clarification questions are open
-            The brief has Q and A session details
         We should show the:
             link to login and ask a question
         """
@@ -721,7 +679,6 @@ class TestBriefPageQandASectionAskAQuestion(BaseBriefPageTest):
             Supplier user is logged in
             The brief is live
             Clarification questions are open
-            The brief has Q and A session details
         We should show the:
             Link to ask a question
         """
@@ -745,7 +702,7 @@ class TestBriefPageQandASectionAskAQuestion(BaseBriefPageTest):
             {'clarificationQuestionsAreClosed': True}
         ]
     )
-    def test_brief_ask_a_question_fails(self, brief_data):
+    def test_brief_ask_a_question_link_not_shown(self, brief_data):
         """
         On viewing briefs with data like the above the page should load but we should not get either the
         log in to ask a question or ask a question links.

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -612,7 +612,6 @@ class TestBriefPage(BaseBriefPageTest):
 class TestWithdrawnBriefPage(BaseBriefPageTest):
     def setup_method(self, method):
         super(TestWithdrawnBriefPage, self).setup_method(method)
-        self.login_as_supplier()
         self.brief['briefs']['status'] = "withdrawn"
         self.brief['briefs']['withdrawnAt'] = "2016-11-25T10:47:23.126761Z"
         self.brief_id = self.brief['briefs']['id']
@@ -629,7 +628,7 @@ class TestWithdrawnBriefPage(BaseBriefPageTest):
 
         assert len(apply_links) == 0
 
-    def test_apply_button_not_visible_for_withdrawn_briefs(self):
+    def test_deadline_text_not_shown(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(self.brief_id))
         page = res.get_data(as_text=True)
 
@@ -642,7 +641,7 @@ class TestWithdrawnBriefPage(BaseBriefPageTest):
         assert 'This opportunity was withdrawn on' in page
         assert (
             "You can&#39;t apply for this opportunity now. "
-            "The buyer may publish an updated version on the Digital Marketplace."
+            "The buyer may publish an updated&nbsp;version on the Digital&nbsp;Marketplace."
         ) in page
 
     @pytest.mark.parametrize(('status'), ['live', 'closed'])
@@ -658,7 +657,7 @@ class TestWithdrawnBriefPage(BaseBriefPageTest):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(self.brief_id))
         page = res.get_data(as_text=True)
 
-        assert 'This opportunity was withdrawn on Friday 25 November 2016' in page
+        assert 'This opportunity was withdrawn on Friday&nbsp;25&nbsp;November&nbsp;2016' in page
 
 
 class TestCatalogueOfBriefsPage(BaseApplicationTest):

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -614,6 +614,56 @@ class TestBriefPage(BaseApplicationTest):
 
         assert res.status_code == 200
 
+    def test_apply_button_not_visible_for_withdrawn_briefs(self):
+        self.login_as_supplier()
+        self.brief['briefs']['status'] = "withdrawn"
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        document = html.fromstring(res.get_data(as_text=True))
+        apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/start"]'.format(brief_id))
+
+        assert len(apply_links) == 0
+
+    def test_apply_button_not_visible_for_withdrawn_briefs(self):
+        self.login_as_supplier()
+        self.brief['briefs']['status'] = "withdrawn"
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        page = res.get_data(as_text=True)
+
+        assert 'The deadline for asking questions about this opportunity was ' not in page
+
+    def test_withdrawn_banner_shown_on_withdrawn_brief(self):
+        self.login_as_supplier()
+        self.brief['briefs']['status'] = "withdrawn"
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        page = res.get_data(as_text=True)
+
+        assert 'This opportunity was withdrawn on' in page
+        assert 'The buyer may publish an updated version of this opportunity on the Digital Marketplace.' in page
+
+    @pytest.mark.parametrize(('status'), ['live', 'closed'])
+    def test_withdrawn_banner_not_shown_on_live_and_closed_brief(self, status):
+        self.login_as_supplier()
+        self.brief['briefs']['status'] = status
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        page = res.get_data(as_text=True)
+
+        assert 'This opportunity was withdrawn on' not in page
+
+    def test_dateformat_in_withdrawn_banner_displayed_correctly(self):
+        self.login_as_supplier()
+        self.brief['briefs']['status'] = "withdrawn"
+        self.brief['briefs']['withdrawnAt'] = "2016-11-25T10:47:23.126761Z"
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        page = res.get_data(as_text=True)
+
+        assert 'This opportunity was withdrawn on Friday 25 November 2016' in page
+
+
 class TestCatalogueOfBriefsPage(BaseApplicationTest):
     def setup_method(self, method):
         super(TestCatalogueOfBriefsPage, self).setup_method(method)

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -606,6 +606,13 @@ class TestBriefPage(BaseApplicationTest):
 
         self._assert_view_application(document, brief_id)
 
+    def test_dos_brief_visible_when_withdrawn(self):
+        self.login_as_supplier()
+        self.brief['briefs']['status'] = "withdrawn"
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+
+        assert res.status_code == 200
 
 class TestCatalogueOfBriefsPage(BaseApplicationTest):
     def setup_method(self, method):


### PR DESCRIPTION
https://trello.com/c/ah5hRupi/391-show-that-a-brief-is-withdrawn

Allow viewing of withdrawn brief but show a banner informing the user it's withdrawn.
<img width="812" alt="screen shot 2017-05-18 at 11 11 11" src="https://cloud.githubusercontent.com/assets/3469840/26197644/dda9853c-3bba-11e7-9ca1-9f3ba6526eaf.png">

