### PR TITLE
Pull in frameworks 8.4.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.4.3"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.4.5"
   }
 }


### PR DESCRIPTION
## Summary
When searching cloud-software, the `backups` filter appears. This question wasn't asked of suppliers and frameworks 8.4.5 will ensure it doesn't show up.

8.4.5 also includes @karlchillmaid's changes to the order of sections on the service display.