### PR TITLE
Show withdrawn briefs on buyer dash

### DIFF
--- a/app/buyers/helpers/buyers_helpers.py
+++ b/app/buyers/helpers/buyers_helpers.py
@@ -17,12 +17,12 @@ def get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_sta
     return framework, lot
 
 
-def is_brief_correct(brief, framework_slug, lot_slug, current_user_id):
+def is_brief_correct(brief, framework_slug, lot_slug, current_user_id, allow_withdrawn=False):
     return (
         brief['frameworkSlug'] == framework_slug
         and brief['lotSlug'] == lot_slug
         and is_brief_associated_with_user(brief, current_user_id)
-        and not brief_is_withdrawn(brief)
+        and (True if allow_withdrawn else not brief_is_withdrawn(brief))
     )
 
 

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -119,7 +119,7 @@ def create_new_brief(framework_slug, lot_slug):
 @buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/copy', methods=['POST'])
 def copy_brief(framework_slug, lot_slug, brief_id):
     brief = data_api_client.get_brief(brief_id)["briefs"]
-    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id):
+    if not is_brief_correct(brief, framework_slug, lot_slug, current_user.id, allow_withdrawn=True):
         abort(404)
 
     new_brief = data_api_client.copy_brief(brief_id, current_user.email_address)['briefs']

--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -33,10 +33,13 @@ from collections import Counter
 @buyers.route('')
 def buyer_dashboard():
     user_briefs = data_api_client.find_briefs(current_user.id).get('briefs', [])
-    draft_briefs = add_unanswered_counts_to_briefs([brief for brief in user_briefs if brief['status'] == 'draft'],
-                                                   content_loader)
+
+    draft_briefs = add_unanswered_counts_to_briefs(
+        [brief for brief in user_briefs if brief['status'] == 'draft'],
+        content_loader
+    )
     live_briefs = [brief for brief in user_briefs if brief['status'] == 'live']
-    closed_briefs = [brief for brief in user_briefs if brief['status'] == 'closed']
+    closed_briefs = [brief for brief in user_briefs if brief['status'] in ['closed', 'withdrawn']]
 
     return render_template(
         'buyers/dashboard.html',

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -38,7 +38,7 @@
                 {% endfor %}
             {% endif %}
         {% endwith %}
-        
+
         <div class="column-two-thirds">
             {% with
                 context = current_user.email_address,
@@ -66,9 +66,9 @@
 
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
-        
+
         {{ summary.text(item.createdAt|dateformat) }}
-        
+
         {% if item.unanswered_required > 0 and item.unanswered_optional > 0 %}
             {{ summary.text("{} required<br>{} optional".format(item.unanswered_required, item.unanswered_optional)|safe) }}
         {% elif item.unanswered_required > 0 %}
@@ -103,7 +103,7 @@
         {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}
-        
+
 {{ summary.heading("Closed requirements", id="closed_requirements") }}
 {% call(item) summary.list_table(
     closed_briefs,
@@ -120,7 +120,11 @@
 
     {% call summary.row() %}
         {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
-        {{ summary.text(item.applicationsClosedAt|dateformat) }}
+        {% if item.status == "closed" %}
+          {{ summary.text(item.applicationsClosedAt|dateformat) }}
+        {% elif item.status == "withdrawn" %}
+          {{ summary.text("Withdrawn") }}
+        {% endif %}
         {{ summary.link("View responses", url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -122,11 +122,12 @@
         {% if item.status == "closed" %}
           {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
           {{ summary.text(item.applicationsClosedAt|dateformat) }}
+          {{ summary.link("View responses", url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {% elif item.status == "withdrawn" %}
           {{ summary.service_link(item.title, url_for("main.get_brief_by_id", framework_framework=item.frameworkSlug, brief_id=item.id)) }}
           {{ summary.text("Withdrawn") }}
+          {{ summary.text() }}
         {% endif %}
-        {{ summary.link("View responses", url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {{ summary.button(text="Make a copy", action=url_for(".copy_brief", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
     {% endcall %}
 {% endcall %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -124,7 +124,7 @@
           {{ summary.text(item.applicationsClosedAt|dateformat) }}
           {{ summary.link("View responses", url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {% elif item.status == "withdrawn" %}
-          {{ summary.service_link(item.title, url_for("main.get_brief_by_id", framework_framework=item.frameworkSlug, brief_id=item.id)) }}
+          {{ summary.service_link(item.title, url_for("main.get_brief_by_id", framework_framework=item.frameworkFramework, brief_id=item.id)) }}
           {{ summary.text("Withdrawn") }}
           {{ summary.text() }}
         {% endif %}

--- a/app/templates/buyers/dashboard.html
+++ b/app/templates/buyers/dashboard.html
@@ -119,10 +119,11 @@
 ) %}
 
     {% call summary.row() %}
-        {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
         {% if item.status == "closed" %}
+          {{ summary.service_link(item.title, url_for(".view_brief_overview", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}
           {{ summary.text(item.applicationsClosedAt|dateformat) }}
         {% elif item.status == "withdrawn" %}
+          {{ summary.service_link(item.title, url_for("main.get_brief_by_id", framework_framework=item.frameworkSlug, brief_id=item.id)) }}
           {{ summary.text("Withdrawn") }}
         {% endif %}
         {{ summary.link("View responses", url_for(".view_brief_responses", framework_slug=item.frameworkSlug, lot_slug=item.lot, brief_id=item.id)) }}

--- a/tests/buyers/helpers/test_buyers_helpers.py
+++ b/tests/buyers/helpers/test_buyers_helpers.py
@@ -101,6 +101,13 @@ class TestBuyersHelpers(object):
             'digital-specialists',
             123
         ) is False
+        assert helpers.buyers_helpers.is_brief_correct(
+            api_stubs.brief(user_id=123, status='withdrawn')['briefs'],
+            'digital-outcomes-and-specialists',
+            'digital-specialists',
+            123,
+            allow_withdrawn=True
+        ) is True
 
     def test_is_brief_associated_with_user(self):
         brief = api_stubs.brief(user_id=123)['briefs']

--- a/tests/buyers/helpers/test_buyers_helpers.py
+++ b/tests/buyers/helpers/test_buyers_helpers.py
@@ -76,38 +76,19 @@ class TestBuyersHelpers(object):
                 must_allow_brief=True,
             )
 
-    def test_is_brief_correct(self):
+    @pytest.mark.parametrize(
+        ['framework', 'lot', 'user', 'result'],
+        [
+            ('digital-outcomes-and-specialists', 'digital-specialists', 123, True),
+            ('not-digital-outcomes-and-specialists', 'digital-specialists', 123, False),
+            ('digital-outcomes-and-specialists', 'not-digital-specialists', 123, False),
+            ('digital-outcomes-and-specialists', 'digital-specialists', 124, False),
+        ]
+    )
+    def test_is_brief_correct(self, framework, lot, user, result):
         brief = api_stubs.brief(user_id=123, status='live')['briefs']
 
-        assert helpers.buyers_helpers.is_brief_correct(
-            brief, 'digital-outcomes-and-specialists', 'digital-specialists', 123
-        ) is True
-
-        assert helpers.buyers_helpers.is_brief_correct(
-            brief, 'not-digital-outcomes-and-specialists', 'digital-specialists', 123
-        ) is False
-
-        assert helpers.buyers_helpers.is_brief_correct(
-            brief, 'digital-outcomes-and-specialists', 'not-digital-specialists', 123
-        ) is False
-
-        assert helpers.buyers_helpers.is_brief_correct(
-            brief, 'digital-outcomes-and-specialists', 'not-digital-specialists', 124
-        ) is False
-
-        assert helpers.buyers_helpers.is_brief_correct(
-            api_stubs.brief(user_id=123, status='withdrawn')['briefs'],
-            'digital-outcomes-and-specialists',
-            'digital-specialists',
-            123
-        ) is False
-        assert helpers.buyers_helpers.is_brief_correct(
-            api_stubs.brief(user_id=123, status='withdrawn')['briefs'],
-            'digital-outcomes-and-specialists',
-            'digital-specialists',
-            123,
-            allow_withdrawn=True
-        ) is True
+        assert helpers.buyers_helpers.is_brief_correct(brief, framework, lot, user) is result
 
     @pytest.mark.parametrize(
         ['status', 'allow_withdrawn', 'result'],

--- a/tests/buyers/helpers/test_buyers_helpers.py
+++ b/tests/buyers/helpers/test_buyers_helpers.py
@@ -109,6 +109,21 @@ class TestBuyersHelpers(object):
             allow_withdrawn=True
         ) is True
 
+    @pytest.mark.parametrize(
+        ['status', 'allow_withdrawn', 'result'],
+        [
+            ('withdrawn', True, True),
+            ('withdrawn', False, False),
+            ('live', True, True),
+            ('live', False, True),
+        ]
+    )
+    def test_if_brief_correct_allow_withdrawn(self, status, allow_withdrawn, result):
+        brief = api_stubs.brief(user_id=123, status=status)['briefs']
+        assert helpers.buyers_helpers.is_brief_correct(
+            brief, 'digital-outcomes-and-specialists', 'digital-specialists', 123, allow_withdrawn=allow_withdrawn
+        ) is result
+
     def test_is_brief_associated_with_user(self):
         brief = api_stubs.brief(user_id=123)['briefs']
         assert helpers.buyers_helpers.is_brief_associated_with_user(brief, 123) is True

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -48,6 +48,7 @@ class TestBuyerDashboard(BaseApplicationTest):
                         "applicationsClosedAt": "2016-02-18T12:00:00.000000Z",
                         "frameworkSlug": "digital-outcomes-and-specialists"
                     }, {
+                        "id": 23,
                         "status": "withdrawn",
                         "title": "A withdrawn brief",
                         "createdAt": "2016-02-01T00:00:00.000000Z",
@@ -78,6 +79,8 @@ class TestBuyerDashboard(BaseApplicationTest):
 
             withdrawn_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr')[1].xpath('.//td')]
             assert withdrawn_row[0] == "A withdrawn brief"
+            public_link = '/digital-outcomes-and-specialists/opportunities/23'
+            assert tables[2].xpath('.//tbody/tr')[1].xpath('.//td')[0].xpath('.//a/@href')[0] == public_link
             assert withdrawn_row[1] == "Withdrawn"
 
 

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -29,15 +29,32 @@ class TestBuyerDashboard(BaseApplicationTest):
             self.login_as_buyer()
             data_api_client.find_briefs.return_value = {
                 "briefs": [
-                    {"status": "draft",
-                     "title": "A draft brief",
-                     "createdAt": "2016-02-02T00:00:00.000000Z",
-                     "frameworkSlug": "digital-outcomes-and-specialists"},
-                    {"status": "live",
-                     "title": "A live brief",
-                     "createdAt": "2016-02-01T00:00:00.000000Z",
-                     "publishedAt": "2016-02-04T12:00:00.000000Z",
-                     "frameworkSlug": "digital-outcomes-and-specialists"},
+                    {
+                        "status": "draft",
+                        "title": "A draft brief",
+                        "createdAt": "2016-02-02T00:00:00.000000Z",
+                        "frameworkSlug": "digital-outcomes-and-specialists"
+                    }, {
+                        "status": "live",
+                        "title": "A live brief",
+                        "createdAt": "2016-02-01T00:00:00.000000Z",
+                        "publishedAt": "2016-02-04T12:00:00.000000Z",
+                        "frameworkSlug": "digital-outcomes-and-specialists"
+                    }, {
+                        "status": "closed",
+                        "title": "A closed brief",
+                        "createdAt": "2016-02-01T00:00:00.000000Z",
+                        "publishedAt": "2016-02-04T12:00:00.000000Z",
+                        "applicationsClosedAt": "2016-02-18T12:00:00.000000Z",
+                        "frameworkSlug": "digital-outcomes-and-specialists"
+                    }, {
+                        "status": "withdrawn",
+                        "title": "A withdrawn brief",
+                        "createdAt": "2016-02-01T00:00:00.000000Z",
+                        "publishedAt": "2016-02-04T12:00:00.000000Z",
+                        "withdrawnAt": "2016-02-05T12:00:00.000000Z",
+                        "frameworkSlug": "digital-outcomes-and-specialists"
+                    }
                 ]
             }
 
@@ -54,6 +71,14 @@ class TestBuyerDashboard(BaseApplicationTest):
             live_row = [cell.text_content().strip() for cell in tables[1].xpath('.//tbody/tr/td')]
             assert live_row[0] == "A live brief"
             assert live_row[1] == "Thursday 4 February 2016"
+
+            closed_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr/td')]
+            assert closed_row[0] == "A closed brief"
+            assert closed_row[1] == "Thursday 18 February 2016"
+
+            withdrawn_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr')[1].xpath('.//td')]
+            assert withdrawn_row[0] == "A withdrawn brief"
+            assert withdrawn_row[1] == "Withdrawn"
 
 
 @mock.patch('app.buyers.views.buyers.data_api_client')

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -30,23 +30,29 @@ class TestBuyerDashboard(BaseApplicationTest):
             data_api_client.find_briefs.return_value = {
                 "briefs": [
                     {
+                        "id": 20,
                         "status": "draft",
                         "title": "A draft brief",
                         "createdAt": "2016-02-02T00:00:00.000000Z",
-                        "frameworkSlug": "digital-outcomes-and-specialists"
+                        "frameworkSlug": "digital-outcomes-and-specialists",
+                        "lot": "digital-specialists"
                     }, {
+                        "id": 21,
                         "status": "live",
                         "title": "A live brief",
                         "createdAt": "2016-02-01T00:00:00.000000Z",
                         "publishedAt": "2016-02-04T12:00:00.000000Z",
-                        "frameworkSlug": "digital-outcomes-and-specialists"
+                        "frameworkSlug": "digital-outcomes-and-specialists",
+                        "lot": "digital-specialists"
                     }, {
+                        "id": 22,
                         "status": "closed",
                         "title": "A closed brief",
                         "createdAt": "2016-02-01T00:00:00.000000Z",
                         "publishedAt": "2016-02-04T12:00:00.000000Z",
                         "applicationsClosedAt": "2016-02-18T12:00:00.000000Z",
-                        "frameworkSlug": "digital-outcomes-and-specialists"
+                        "frameworkSlug": "digital-outcomes-and-specialists",
+                        "lot": "digital-specialists"
                     }, {
                         "id": 23,
                         "status": "withdrawn",
@@ -67,14 +73,20 @@ class TestBuyerDashboard(BaseApplicationTest):
             tables = document.xpath('//table')
             draft_row = [cell.text_content().strip() for cell in tables[0].xpath('.//tbody/tr/td')]
             assert draft_row[0] == "A draft brief"
+            req_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/20'
+            assert tables[0].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == req_link
             assert draft_row[1] == "Tuesday 2 February 2016"
 
             live_row = [cell.text_content().strip() for cell in tables[1].xpath('.//tbody/tr/td')]
             assert live_row[0] == "A live brief"
+            req_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/21'
+            assert tables[1].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == req_link
             assert live_row[1] == "Thursday 4 February 2016"
 
             closed_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr/td')]
             assert closed_row[0] == "A closed brief"
+            req_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/22'
+            assert tables[2].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == req_link
             assert closed_row[1] == "Thursday 18 February 2016"
 
             withdrawn_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr')[1].xpath('.//td')]

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -114,6 +114,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert closed_row[0] == "A closed brief"
         assert tables[2].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert closed_row[1] == "Thursday 18 February 2016"
+        assert closed_row[2] == "View responses"
 
     def test_withdrawn_briefs_section(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock
@@ -129,6 +130,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert withdrawn_row[0] == "A withdrawn brief"
         assert tables[2].xpath('.//tbody/tr')[1].xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert withdrawn_row[1] == "Withdrawn"
+        assert "View responses" not in withdrawn_row[2]
 
 
 @mock.patch('app.buyers.views.buyers.data_api_client')

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -26,7 +26,8 @@ po = functools.partial(mock.patch.object, autospec=True)
 def find_briefs_mock():
     base_brief_values = {
         "createdAt": "2016-02-01T00:00:00.000000Z",
-        "frameworkSlug": "digital-outcomes-and-specialists",
+        "frameworkSlug": "digital-outcomes-and-specialists-2",
+        "frameworkFramework": "digital-outcomes-and-specialists",
         "lot": "digital-specialists"
     }
 
@@ -79,7 +80,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert res.status_code == 200
 
         draft_row = [cell.text_content().strip() for cell in tables[0].xpath('.//tbody/tr/td')]
-        expected_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/20'
+        expected_link = '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/20'
 
         assert draft_row[0] == "A draft brief"
         assert tables[0].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
@@ -94,7 +95,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert res.status_code == 200
 
         live_row = [cell.text_content().strip() for cell in tables[1].xpath('.//tbody/tr/td')]
-        expected_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/21'
+        expected_link = '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/21'
 
         assert live_row[0] == "A live brief"
         assert tables[1].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
@@ -109,7 +110,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert res.status_code == 200
 
         closed_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr/td')]
-        expected_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/22'
+        expected_link = '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/digital-specialists/22'
 
         assert closed_row[0] == "A closed brief"
         assert tables[2].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
@@ -374,7 +375,7 @@ class TestCopyBrief(BaseApplicationTest):
         assert res.status_code == 404
 
     def test_copy_brief_and_redirect_to_copied_brief_edit_title_page(self):
-        new_brief = self.brief
+        new_brief = self.brief.copy()
         new_brief["briefs"]["id"] = 1235
         self.data_api_client.copy_brief.return_value = new_brief
 

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -18,6 +18,10 @@ import sys
 
 from werkzeug.exceptions import NotFound
 
+
+po = functools.partial(mock.patch.object, autospec=True)
+
+
 @pytest.fixture()
 def find_briefs_mock():
     base_brief_values = {
@@ -58,6 +62,7 @@ def find_briefs_mock():
 
     return find_briefs_response
 
+
 @mock.patch('app.buyers.views.buyers.data_api_client')
 class TestBuyerDashboard(BaseApplicationTest):
 
@@ -69,63 +74,60 @@ class TestBuyerDashboard(BaseApplicationTest):
         data_api_client.find_briefs.return_value = find_briefs_mock
 
         res = self.client.get("/buyers")
-        document = html.fromstring(res.get_data(as_text=True))
+        tables = html.fromstring(res.get_data(as_text=True)).xpath('//table')
 
         assert res.status_code == 200
 
-        tables = document.xpath('//table')
         draft_row = [cell.text_content().strip() for cell in tables[0].xpath('.//tbody/tr/td')]
+        expected_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/20'
+
         assert draft_row[0] == "A draft brief"
-        req_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/20'
-        assert tables[0].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == req_link
+        assert tables[0].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert draft_row[1] == "Monday 1 February 2016"
 
     def test_live_briefs_section(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock
 
         res = self.client.get("/buyers")
-        document = html.fromstring(res.get_data(as_text=True))
+        tables = html.fromstring(res.get_data(as_text=True)).xpath('//table')
 
         assert res.status_code == 200
 
-        tables = document.xpath('//table')
-
         live_row = [cell.text_content().strip() for cell in tables[1].xpath('.//tbody/tr/td')]
+        expected_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/21'
+
         assert live_row[0] == "A live brief"
-        req_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/21'
-        assert tables[1].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == req_link
+        assert tables[1].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert live_row[1] == "Thursday 4 February 2016"
 
     def test_closed_briefs_section(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock
 
         res = self.client.get("/buyers")
-        document = html.fromstring(res.get_data(as_text=True))
+        tables = html.fromstring(res.get_data(as_text=True)).xpath('//table')
 
         assert res.status_code == 200
 
-        tables = document.xpath('//table')
-
         closed_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr/td')]
+        expected_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/22'
+
         assert closed_row[0] == "A closed brief"
-        req_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/22'
-        assert tables[2].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == req_link
+        assert tables[2].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert closed_row[1] == "Thursday 18 February 2016"
 
     def test_withdrawn_briefs_section(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock
 
         res = self.client.get("/buyers")
-        document = html.fromstring(res.get_data(as_text=True))
+        tables = html.fromstring(res.get_data(as_text=True)).xpath('//table')
 
         assert res.status_code == 200
 
-        tables = document.xpath('//table')
-
         withdrawn_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr')[1].xpath('.//td')]
+        expected_link = '/digital-outcomes-and-specialists/opportunities/23'
+
         assert withdrawn_row[0] == "A withdrawn brief"
-        public_link = '/digital-outcomes-and-specialists/opportunities/23'
-        assert tables[2].xpath('.//tbody/tr')[1].xpath('.//td')[0].xpath('.//a/@href')[0] == public_link
+        assert tables[2].xpath('.//tbody/tr')[1].xpath('.//td')[0].xpath('.//a/@href')[0] == expected_link
         assert withdrawn_row[1] == "Withdrawn"
 
 

--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -65,7 +65,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         super(TestBuyerDashboard, self).setup_method(method)
         self.login_as_buyer()
 
-    def test_buyer_dashboard(self, data_api_client, find_briefs_mock):
+    def test_draft_briefs_section(self, data_api_client, find_briefs_mock):
         data_api_client.find_briefs.return_value = find_briefs_mock
 
         res = self.client.get("/buyers")
@@ -80,17 +80,47 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert tables[0].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == req_link
         assert draft_row[1] == "Monday 1 February 2016"
 
+    def test_live_briefs_section(self, data_api_client, find_briefs_mock):
+        data_api_client.find_briefs.return_value = find_briefs_mock
+
+        res = self.client.get("/buyers")
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+
+        tables = document.xpath('//table')
+
         live_row = [cell.text_content().strip() for cell in tables[1].xpath('.//tbody/tr/td')]
         assert live_row[0] == "A live brief"
         req_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/21'
         assert tables[1].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == req_link
         assert live_row[1] == "Thursday 4 February 2016"
 
+    def test_closed_briefs_section(self, data_api_client, find_briefs_mock):
+        data_api_client.find_briefs.return_value = find_briefs_mock
+
+        res = self.client.get("/buyers")
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+
+        tables = document.xpath('//table')
+
         closed_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr/td')]
         assert closed_row[0] == "A closed brief"
         req_link = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/22'
         assert tables[2].xpath('.//tbody/tr')[0].xpath('.//td')[0].xpath('.//a/@href')[0] == req_link
         assert closed_row[1] == "Thursday 18 February 2016"
+
+    def test_withdrawn_briefs_section(self, data_api_client, find_briefs_mock):
+        data_api_client.find_briefs.return_value = find_briefs_mock
+
+        res = self.client.get("/buyers")
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert res.status_code == 200
+
+        tables = document.xpath('//table')
 
         withdrawn_row = [cell.text_content().strip() for cell in tables[2].xpath('.//tbody/tr')[1].xpath('.//td')]
         assert withdrawn_row[0] == "A withdrawn brief"


### PR DESCRIPTION
### Context
When a brief is withdrawn. Buyers may need to republish the brief. 

### User need
As a buyer, I need to create a copy of my withdrawn brief so that I can republish with limited time and effort.

### Acceptance criteria
Given that a brief has been withdrawn, when I go to my accounts, Then I should see the opportunity and I should be able to create a copy


<img width="688" alt="screen shot 2017-05-18 at 16 59 44" src="https://cloud.githubusercontent.com/assets/3469840/26211850/717c0430-3beb-11e7-9937-63fa13ce37fc.png">
