### PR TITLE
Show filters for all lots; remove hard-coded lots

### DIFF
--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -10,21 +10,18 @@ from ..helpers.search_helpers import (
 )
 
 
-def sections_for_lot(lot, builder):
+def sections_for_lot(lot, builder, all_lots=[]):
     if lot is None or lot == 'all':
-        sections = builder.filter(
-            {'lot': 'iaas'}).filter(
-            {'lot': 'paas'}).filter(
-            {'lot': 'saas'}).filter(
-            {'lot': 'scs'}).sections
+        for lot_slug in [x['slug'] for x in all_lots]:
+            builder = builder.filter({'lot': lot_slug})
     else:
-        sections = builder.filter({'lot': lot}).sections
+        builder = builder.filter({'lot': lot})
 
-    return sections
+    return builder.sections
 
 
-def filters_for_lot(lot, builder):
-    sections = sections_for_lot(lot, builder)
+def filters_for_lot(lot, builder, all_lots=[]):
+    sections = sections_for_lot(lot, builder, all_lots=all_lots)
     lot_filters = OrderedDict()
 
     for section in sections:

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -169,7 +169,8 @@ def search_services():
     # filters - an OrderedDictionary of dicts describing each parameter group
     filters = filters_for_lot(
         current_lot_slug,
-        content_manifest
+        content_manifest,
+        all_lots=framework['lots']
     )
 
     search_api_response = search_api_client.search_services(

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -13,7 +13,6 @@ from app.main.presenters.search_presenters import (
 
 from ...helpers import BaseApplicationTest
 
-
 content_loader = ContentLoader('tests/fixtures/content')
 content_loader.load_manifest('g6', 'data', 'manifest')
 content_loader.load_manifest('g9', 'data', 'manifest')
@@ -43,10 +42,24 @@ def _get_fixture_multiple_pages_data():
         return json.load(fixture_file)
 
 
+def _get_framework_lots(framework_slug):
+    test_root = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../..")
+    )
+    fixture_path = os.path.join(
+        test_root, 'fixtures', 'frameworks.json'
+    )
+    with open(fixture_path) as fixture_file:
+        frameworks = json.load(fixture_file)['frameworks']
+        framework = list(filter(lambda x: x['slug'] == framework_slug, frameworks))[0]
+
+        return framework['lots']
+
+
 class TestSearchFilters(BaseApplicationTest):
 
     def _get_filter_group_by_label(self, lot, label):
-        filter_groups = filters_for_lot(lot, g6_builder)
+        filter_groups = filters_for_lot(lot, g6_builder, all_lots=_get_framework_lots('g-cloud-6'))
         for filter_group in filter_groups.values():
             if filter_group['label'] == label:
                 return filter_group


### PR DESCRIPTION
## Summary
Cross-lot filters should appear when searching in all categories.
Removes hard-coded lots.

## Ticket
https://trello.com/c/AcMy4wcL/372-filters-must-appear-when-no-lot-is-selected-all-categories