### PR TITLE
Filter summary grouping fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.4.8"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.4.9"
   }
 }


### PR DESCRIPTION
Simplify and fix the grouping of filters for the search summary.

Fixes:

1) filters that mix booleans and checkbox/radio question types not displaying correctly, because a single set of checkbox/radio options completely overrode any boolean questions (and in fact also any other checkbox/radio options that came from a different question).

2) it was not possible to have multiple filters in the same group with the same value, regardless of each filter's name.