### PR TITLE
Bump Dockerfile version dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:1.0.1
+FROM digitalmarketplace/base-frontend:1.0.2


### PR DESCRIPTION
## Summary
Bump Dockerfile version, which will prevent breaking on very long URLs.