### PR TITLE
Update brief fixture to be on latest framework and latest keys

### DIFF
--- a/tests/fixtures/dos_brief_fixture.json
+++ b/tests/fixtures/dos_brief_fixture.json
@@ -1,8 +1,21 @@
 {
   "briefs": {
     "backgroundInformation": "Testing the new platform.",
+    "budgetRange": "Maximum day rate of up to £700.",
+    "clarificationQuestions": [
+      {"question": "Why?", "answer": "Because", "publishedAt": "2016-12-02T00:00:00.000000Z"}
+    ],
+    "clarificationQuestionsAreClosed": true,
+    "clarificationQuestionsClosedAt": "2016-12-07T11:09:28.054129Z",
+    "clarificationQuestionsPublishedBy": "2017-06-10T23:59:59.000000Z",
+    "contractLength": "Up to 24 months or completion of the services.",
     "contractLength": "4 weeks",
     "createdAt": "2016-11-25T10:47:23.126761Z",
+    "culturalFitCriteria": [
+      "Work well in a team within our organisation.",
+      "Mentor members of the team."
+    ],
+    "culturalWeighting": 10,
     "essentialRequirements": [
       "Can write Capybara tests",
       "Is competent with Linux, Ruby and JavaScript"
@@ -10,9 +23,10 @@
     "evaluationType": [
       "provide a case study or evidence of previous work"
     ],
+    "existingTeam": "Key stakeholders within Border Force",
     "frameworkFramework": "digital-outcomes-and-specialists",
-    "frameworkName": "Digital Outcomes and Specialists",
-    "frameworkSlug": "digital-outcomes-and-specialists",
+    "frameworkName": "Digital Outcomes and Specialists 2",
+    "frameworkSlug": "digital-outcomes-and-specialists-2",
     "frameworkStatus": "live",
     "id": 1,
     "importantDates": "31st of March: Test coverage must be 100%.",
@@ -28,12 +42,19 @@
       "Experience of cross-browser testing",
       "Devops skills and experience"
     ],
+    "numberOfSuppliers": 5,
     "organisation": "ByteMe IT",
+    "priceWeighting": 30,
     "publishedAt": "2016-12-01T11:09:28.054129Z",
     "questionAndAnswerSessionDetails": "session details",
+    "requirementsLength": "2 weeks",
+    "securityClearance": "Security clearance required",
     "specialistRole": "qualityAssurance",
-    "startDate": "01/03/2017",
+    "specialistWork": "Squashing bugs left right and center",
+    "startDate": "2017-3-1",
     "status": "live",
+    "summary": "Be the best QA ever",
+    "technicalWeighting": 60,
     "title": "QA tester for next-gen web project",
     "updatedAt": "2016-12-01T11:08:28.061327Z",
     "users": [
@@ -45,8 +66,7 @@
         "role": "buyer"
       }
     ],
-    "clarificationQuestions": [
-      {"question": "Why?", "answer": "Because", "publishedAt": "2016-12-02T00:00:00.000000Z"}
-    ]
+    "workingArrangements": "9-5",
+    "workplaceAddress": "The big smoke"
   }
 }

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -1,70 +1,49 @@
 {
   "briefs":[
     {
+      "applicationsClosedAt":"2016-03-24T00:00:00.000000Z",
+      "backgroundInformation":"Here is the first requirements summary.",
+      "clarificationQuestions":[],
       "clarificationQuestionsAreClosed":true,
-      "status":"live",
+      "clarificationQuestionsClosedAt":"2016-03-17T00:00:00.000000Z",
+      "clarificationQuestionsPublishedBy": "2016-03-20T00:00:00.000000Z",
+      "createdAt":"2016-03-09T15:23:48.328413Z",
+      "culturalWeighting": 30,
+      "essentialRequirements": [
+        "Proven experience in recruiting niche business users"
+      ],
+      "evaluationType": [
+        "Interview"
+      ],
       "frameworkFramework":"digital-outcomes-and-specialists",
+      "frameworkName":"Digital Outcomes and Specialists",
+      "frameworkSlug":"digital-outcomes-and-specialists",
+      "frameworkStatus":"live",
+      "id":17,
       "links":{
         "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists",
         "self":"http://localhost:5000/briefs/17"
       },
-      "clarificationQuestionsClosedAt":"2016-03-17T00:00:00.000000Z",
-      "frameworkStatus":"live",
-      "title":"I need Research Participants",
-      "organisation":"GDS",
-      "lotSlug":"user-research-participants",
-      "frameworkSlug":"digital-outcomes-and-specialists",
-      "applicationsClosedAt":"2016-03-24T00:00:00.000000Z",
-      "lotName":"User research participants",
-      "clarificationQuestions":[
-
-      ],
-      "backgroundInformation":"Here is the first requirements summary.",
-      "frameworkName":"Digital Outcomes and Specialists",
       "location":"International (outside the UK)",
       "lot":"user-research-participants",
-      "updatedAt":"2016-03-09T15:56:32.487141Z",
+      "lotName":"User research participants",
+      "lotSlug":"user-research-participants",
+      "niceToHaveRequirements": [],
+      "numberOfSuppliers": 5,
+      "organisation":"GDS",
+      "priceWeighting": 20,
       "publishedAt":"2016-03-09T16:02:51.591567Z",
-      "id":17,
-      "createdAt":"2016-03-09T15:23:48.328413Z"
+      "researchDates": "1 year contract with option to extend for one additional year commencing approx mid/end June",
+      "status":"live",
+      "summary": "Find out those user needs!",
+      "technicalWeighting": 50,
+      "title":"I need Research Participants",
+      "updatedAt":"2016-03-09T15:56:32.487141Z"
     },
     {
-      "startDate":"29th March",
-      "links":{
-        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists-2",
-        "self":"http://localhost:5000/briefs/4"
-      },
-      "evaluationType":[
-        "provide a case study or evidence of previous work",
-        "presentation"
-      ],
-      "niceToHaveRequirements":[
-        "Nice people"
-      ],
+      "additionalTerms":"You'll never work in this town again.",
       "applicationsClosedAt":"2016-03-22T00:00:00.000000Z",
-      "essentialRequirements":[
-        "Can provide an outcome",
-        "Available from 29h March"
-      ],
       "backgroundInformation":"We'd like to build a thing to do athing.",
-      "updatedAt":"2016-02-16T14:04:22.617017Z",
-      "id":4,
-      "createdAt":"2016-02-12T16:30:55.808730Z",
-      "clarificationQuestionsAreClosed":true,
-      "frameworkFramework":"digital-outcomes-and-specialists",
-      "clarificationQuestionsClosedAt":"2016-03-15T00:00:00.000000Z",
-      "lotSlug":"digital-specialists",
-      "workingArrangements":"Work",
-      "organisation":"GDS",
-      "frameworkStatus":"live",
-      "lotName":"Digital specialists",
-      "location":"East of England",
-      "lot":"digital-specialists",
-      "status":"live",
-      "specialistRole":"businessAnalyst",
-      "importantDates":"29th March",
-      "contractLength":"3 Months",
-      "currentTechnologies":"Business Focus Plus",
       "clarificationQuestions":[
         {
           "answer":"Because",
@@ -72,11 +51,56 @@
           "publishedAt":"2016-03-04T09:19:42.138442Z"
         }
       ],
-      "title":"Another requirement",
-      "frameworkSlug":"digital-outcomes-and-specialists-2",
-      "additionalTerms":"You'll never work in this town again.",
+      "clarificationQuestionsAreClosed":true,
+      "clarificationQuestionsClosedAt":"2016-03-15T00:00:00.000000Z",
+      "clarificationQuestionsPublishedBy": "2016-03-18T23:59:59.000000Z",
+      "contractLength":"3 Months",
+      "createdAt":"2016-02-12T16:30:55.808730Z",
+      "currentTechnologies":"Business Focus Plus",
+      "culturalFitCriteria": [
+        "Ability to work with clients with limited technical knowledge"
+      ],
+      "culturalWeighting": 10,
+      "earlyMarketEngagement": "N/A",
+      "essentialRequirements":[
+        "Can provide an outcome",
+        "Available from 29h March"
+      ],
+      "evaluationType":[
+        "provide a case study or evidence of previous work",
+        "presentation"
+      ],
+      "frameworkFramework":"digital-outcomes-and-specialists",
       "frameworkName":"Digital Outcomes and Specialists 2",
-      "publishedAt":"2016-03-07T16:02:51.591567Z"
+      "frameworkSlug":"digital-outcomes-and-specialists-2",
+      "frameworkStatus":"live",
+      "id": 4,
+      "importantDates":"29th March",
+      "links":{
+        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists-2",
+        "self":"http://localhost:5000/briefs/4"
+      },
+      "location":"East of England",
+      "lot":"digital-specialists",
+      "lotName":"Digital specialists",
+      "lotSlug":"digital-specialists",
+      "niceToHaveRequirements":[
+        "Nice people"
+      ],
+      "numberOfSuppliers": 4,
+      "organisation":"GDS",
+      "phase": "discovery",
+      "priceCriteria": "Fixed price",
+      "priceWeighting": 30,
+      "publishedAt":"2016-03-07T16:02:51.591567Z",
+      "specialistRole":"businessAnalyst",
+      "startDate":"2017-5-6",
+      "status":"live",
+      "summary": "Build a portal",
+      "technicalWeighting": 60,
+      "title":"Another requirement",
+      "updatedAt":"2016-02-16T14:04:22.617017Z",
+      "workingArrangements":"Work"
     }
   ],
   "links":{

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -441,7 +441,7 @@ class TestBriefPage(BaseBriefPageTest):
         assert section_heading.get('id') == 'opportunity-attributes-1'
         assert section_heading.text.strip() == 'Overview'
         assert start_date_key[0] == 'Latest start date'
-        assert start_date_value[0] == '01/03/2017'
+        assert start_date_value[0] == 'Wednesday 1 March 2017'
         assert contract_length_key[0] == 'Expected contract length'
         assert contract_length_value[0] == '4 weeks'
 


### PR DESCRIPTION
### Singular brief fixture
- We update the brief fixture to be on the latest framework.
- We update the format of `startDate` to be saved in the parseable
date format rather than just a simple string.
- We add keys that usually exist on a brief that were not included,
such as `technicalWeighting` and `requirementsLength`.
- We add keys related to the clarification question time period.
These before had not been added and it was therefore assumed
that the brief was open for clarification questions. To make this
more explicit we give dates for `clarificationQuestionsClosedAt`
and `clarificationQuestionsPublishedBy` that are realistic compared
to the `publishedAt` date.

This means that our fixture now represents a brief it were to
be published 'today' and our tests should have more realistic
coverage.

### Multiple brief fixtures
- Order keys alphabetically for better readability
- Add keys that would normally exist on a brief but were missing from our stubs
- Update `startDate` to use our new dateformat for one of the briefs

On the downside with all of these fixtures, by updating it we may lose coverage for whatever was being tested before...