### PR TITLE
Update search summary to match filter name in framework filter manifest.

### DIFF
--- a/app/main/helpers/search_summary_manifest.yml
+++ b/app/main/helpers/search_summary_manifest.yml
@@ -105,18 +105,9 @@
   - preposition: an
     id: API
 
-- id: Service usage metrics
-  labelPreposition: where usage metrics are provided
+- id: Metrics reporting
+  labelPreposition: where usage metrics are provided through
   conjunction: and
-  filterRules:
-  - preposition: through
-    id: real-time dashboards
-  - preposition: through
-    id: regular reports
-  - preposition: through
-    id: reports on request
-  - preposition:
-    id: API access
 
 - id: Infrastructure or application metrics
   labelPreposition: where infrastructure or application metrics are provided for


### PR DESCRIPTION
Update search summary to match filter group name in framework filter manifest.

 - API access should share same preposition as other filters, so remove the filterRules override.

https://trello.com/c/WfqYkQhr/486-metrics-reporting-filter-change