### PR TITLE
Remove some logic gated on G-Cloud 9 being live

### DIFF
--- a/app/main/helpers/framework_helpers.py
+++ b/app/main/helpers/framework_helpers.py
@@ -16,14 +16,6 @@ def get_lots_by_slug(framework_data):
     return {lot['slug']: lot for lot in framework_data['lots']}
 
 
-def is_g9_live(all_frameworks):
-    """
-    :return: True iff G8 is no longer the latest live G-Cloud framework.
-    """
-    framework = get_latest_live_framework(all_frameworks, 'g-cloud')
-    return (framework['slug'] != 'g-cloud-8') if framework else False
-
-
 def get_framework_description(data_api_client, framework_family):
     frameworks = data_api_client.find_frameworks().get('frameworks')
     framework = get_latest_live_framework(frameworks, framework_family)

--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -28,9 +28,7 @@ class Service(object):
         self.summary_manifest = manifest.summary(service_data)
         # required attributes directly mapped to service_data values
         self.title = service_data['serviceName']
-        self.serviceSummary = service_data['serviceSummary']\
-            if 'serviceSummary' in service_data else \
-            service_data['serviceDescription']
+        self.serviceSummary = service_data.get('serviceSummary', service_data.get('serviceDescription'))
         self.lot = lots_by_slug.get(service_data['lot'])
         self.frameworkName = service_data['frameworkName']
         # optional attributes directly mapped to service_data values

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -156,9 +156,6 @@ def search_services():
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
     framework = framework_helpers.get_latest_live_framework(all_frameworks, 'g-cloud')
 
-    # TODO remove me after G-Cloud 9 goes live
-    is_g9_live = framework_helpers.is_g9_live(all_frameworks)
-
     current_lot_slug = get_lot_from_request(request)
     lots_by_slug = framework_helpers.get_lots_by_slug(framework)
 
@@ -196,10 +193,7 @@ def search_services():
 
     # for display purposes (but not for actual filtering purposes), we
     # remove 'categories' from the list of filters, and process them into a single structure with the lots
-    if is_g9_live:
-        category_filter_group = filters.pop('categories') if 'categories' in filters else None
-    else:
-        category_filter_group = None
+    category_filter_group = filters.pop('categories') if 'categories' in filters else None
 
     lots = framework['lots']
     current_category_filter = annotate_lots_with_categories_selection(lots, category_filter_group, request)

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -12,7 +12,7 @@ from dmcontent.content_loader import ContentNotFoundError
 
 from ...main import main
 from ..helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference, parse_link
-from ..helpers.framework_helpers import get_latest_live_framework, is_g9_live, get_framework_description
+from ..helpers.framework_helpers import get_latest_live_framework, get_framework_description
 
 from ..forms.brief_forms import BriefSearchForm
 
@@ -51,14 +51,12 @@ def index():
     # Capture the slug for the most recent live framework. There will only be multiple if currently transitioning
     # between frameworks and more than one has a `live` status.
     dos_framework = get_latest_live_framework(frameworks, 'digital-outcomes-and-specialists')
-    show_new_g9_content = is_g9_live(frameworks)
 
     return render_template(
         'index.html',
         dos_slug=dos_framework['slug'] if dos_framework else None,
         frameworks={framework['slug']: framework for framework in frameworks},
         temporary_message=temporary_message,
-        show_new_g9_content=show_new_g9_content,
         gcloud_framework_description=get_framework_description(data_api_client, 'g-cloud'),
     )
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -53,12 +53,12 @@
         {
           "link": "/g-cloud",
           "title": "Find " + gcloud_framework_description,
-          "body": "eg content delivery networks or accounting software" if show_new_g9_content else "eg web hosting or IT health checks",
+          "body": "eg content delivery networks or accounting software",
         },
         {
           "link": "/crown-hosting",
           "title": "Buy physical datacentre space",
-          "body": "eg access to mission-critical datacentres" if show_new_g9_content else "eg for services that can’t be migrated to the cloud",
+          "body": "eg access to mission-critical datacentres",
         }]
       %}
 


### PR DESCRIPTION
## Summary
Some parts of the app require a check for G-Cloud 9 being live to support two incompatible behaviours. Now that G-Cloud 9 is indeed live, let's remove the checks to support G-Cloud 8 and earlier.

## Ticket
https://trello.com/c/7hq3FqyB/425-clean-up-after-g-cloud-9-goes-live