### PR TITLE
Pull in latest utils to capitalise lists on service page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ unicodecsv==0.14.1
 werkzeug==0.10.4
 odfpy==1.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@26.2.0#egg=digitalmarketplace-utils==26.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@26.2.1#egg=digitalmarketplace-utils==26.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.8.0#egg=digitalmarketplace-apiclient==8.8.0
 


### PR DESCRIPTION
Depends on: 
 - [ ] https://github.com/alphagov/digitalmarketplace-utils/pull/312

Final tweak for this card: https://trello.com/c/05zayTOU/442-service-page-radio-button-responses-alternative-labels

 * When capitalising the first letter of supplier responses we should also capitalise items in lists.

And also does point 1 on this card while I was in there: https://trello.com/c/HVAOKOwe/476-service-page-uris-in-data-fields 

* When a service page includes a URI and it starts at the first character, the 'h' of HTTP (only) is capitalized, this looks weird.