### PR TITLE
Bugfix: Square search bar on iOS

### DIFF
--- a/app/assets/scss/_service-page.scss
+++ b/app/assets/scss/_service-page.scss
@@ -1,5 +1,5 @@
 // styles specific to service pages
-@import "shared_placeholders/_visuallyhidden.scss";
+@import "shared_placeholders/_visually-hidden.scss";
 
 %sub-heading {
   @include core-24;
@@ -57,19 +57,19 @@
   %meta-item {
     margin-bottom: $gutter;
   }
-  
+
   .document-link-with-icon {
     font-size: 16px;
   }
 
   .contact-details-organisation {
-    @extend %visuallyhidden;
+    @extend %visually-hidden;
   }
 
   .framework-name {
     @extend %meta-item;
   }
-  
+
   .service-id {
     @extend %meta-item;
   }

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.3",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.4",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.4.12"
   }


### PR DESCRIPTION
A bug was reported the other day where iOS devices show a rounded search bar.  [Here's the trello card](https://trello.com/c/svwLalaz/153-form-inputs-on-g-cloud-release-when-looking-on-iphone-don-t-appear-to-be-as-intended). [There are a few other tiny layout fixes in this update](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/350), but the search bar is the main one.

### before

![img_6333_720](https://cloud.githubusercontent.com/assets/2454380/26449957/0091624e-414d-11e7-8687-b00ef6c13ac8.png)

### after

![screen shot 2017-05-25 at 13 17 22](https://cloud.githubusercontent.com/assets/2454380/26449973/0e318ef6-414d-11e7-8317-e8b79b7f4133.png)


***

Note: [we changed all the visuallyhiddens to visually-hidden in the frontend toolkit](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/347) and I didn't think it was a breaking change, but it looks like it might have been.  This pull request makes the relevant fixes (ie, adds two hyphens) in the buyer app.