### PR TITLE
Update frameworks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.4",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.4.12"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.5.2"
   }
 }


### PR DESCRIPTION
## Summary
Pulls in frameworks 8.5.2, which removes a duplicated key `userAuthenticationDescription` from the display_service manifest.

## Ticket
https://trello.com/c/WtXwWwl8/507-authentication-field-repeating-in-manifest