### PR TITLE
Add autospec to many of our mocks

### DIFF
--- a/tests/buyers/views/test_buyers.py
+++ b/tests/buyers/views/test_buyers.py
@@ -64,7 +64,7 @@ def find_briefs_mock():
     return find_briefs_response
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
 class TestBuyerDashboard(BaseApplicationTest):
 
     def setup_method(self, method):
@@ -134,7 +134,7 @@ class TestBuyerDashboard(BaseApplicationTest):
         assert "View responses" not in withdrawn_row[2]
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
 class TestStartNewBrief(BaseApplicationTest):
     def test_show_start_brief_page(self, data_api_client):
         with self.app.app_context():
@@ -203,7 +203,7 @@ class TestStartNewBrief(BaseApplicationTest):
                 assert res.status_code == 404
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
 class TestCreateNewBrief(BaseApplicationTest):
     def test_create_new_digital_specialists_brief(self, data_api_client):
         self.login_as_buyer()
@@ -447,8 +447,8 @@ class TestEveryDamnPage(BaseApplicationTest):
     def _load_page(self, url, status_code, method='get', data=None, framework_status='live', brief_status='draft'):
         data = {} if data is None else data
         baseurl = "/buyers/frameworks/digital-outcomes-and-specialists/requirements"
-        with mock.patch('app.buyers.views.buyers.content_loader') as content_loader, \
-                mock.patch('app.buyers.views.buyers.data_api_client') as data_api_client:
+        with mock.patch('app.buyers.views.buyers.content_loader', autospec=True) as content_loader, \
+                mock.patch('app.buyers.views.buyers.data_api_client', autospec=True) as data_api_client:
             self.login_as_buyer()
             data_api_client.get_framework.return_value = api_stubs.framework(
                 slug='digital-outcomes-and-specialists',
@@ -561,7 +561,7 @@ class TestEveryDamnPage(BaseApplicationTest):
         )
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
 class TestEditBriefSubmission(BaseApplicationTest):
 
     def _test_breadcrumbs_on_question_page(self, response, has_summary_page=False, section_name=None):
@@ -608,7 +608,7 @@ class TestEditBriefSubmission(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
         assert document.xpath('//h1')[0].text_content().strip() == "Organisation the work is for"
 
-    @mock.patch("app.buyers.views.buyers.content_loader")
+    @mock.patch("app.buyers.views.buyers.content_loader", autospec=True)
     def test_edit_brief_submission_return_link_to_section_summary_if_section_has_description(
             self, content_loader, data_api_client
     ):
@@ -638,7 +638,7 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert secondary_action_link.text_content().strip() == "Return to section 4"
         self._test_breadcrumbs_on_question_page(response=res, has_summary_page=True, section_name='Section 4')
 
-    @mock.patch("app.buyers.views.buyers.content_loader")
+    @mock.patch("app.buyers.views.buyers.content_loader", autospec=True)
     def test_edit_brief_submission_return_link_to_section_summary_if_other_questions(self, content_loader,
     data_api_client):  # noqa
         self.login_as_buyer()
@@ -667,7 +667,7 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert secondary_action_link.text_content().strip() == "Return to section 1"
         self._test_breadcrumbs_on_question_page(response=res, has_summary_page=True, section_name='Section 1')
 
-    @mock.patch("app.buyers.views.buyers.content_loader")
+    @mock.patch("app.buyers.views.buyers.content_loader", autospec=True)
     def test_edit_brief_submission_return_link_to_brief_overview_if_single_question(self, content_loader,
     data_api_client):  # noqa
         self.login_as_buyer()
@@ -696,7 +696,7 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert secondary_action_link.text_content().strip() == "Return to overview"
         self._test_breadcrumbs_on_question_page(response=res, has_summary_page=False)
 
-    @mock.patch("app.buyers.views.buyers.content_loader")
+    @mock.patch("app.buyers.views.buyers.content_loader", autospec=True)
     def test_edit_brief_submission_multiquestion(self, content_loader, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
@@ -844,7 +844,7 @@ class TestEditBriefSubmission(BaseApplicationTest):
         assert res.status_code == 404
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
 class TestUpdateBriefSubmission(BaseApplicationTest):
     def test_update_brief_submission(self, data_api_client):
         self.login_as_buyer()
@@ -872,7 +872,7 @@ class TestUpdateBriefSubmission(BaseApplicationTest):
             updated_by='buyer@email.com'
         )
 
-    @mock.patch("app.buyers.views.buyers.content_loader")
+    @mock.patch("app.buyers.views.buyers.content_loader", autospec=True)
     def test_post_update_if_multiple_questions_redirects_to_section_summary(self, content_loader, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
@@ -906,7 +906,7 @@ class TestUpdateBriefSubmission(BaseApplicationTest):
             'buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-1'
         ) is True
 
-    @mock.patch("app.buyers.views.buyers.content_loader")
+    @mock.patch("app.buyers.views.buyers.content_loader", autospec=True)
     def test_post_update_if_section_description_redirects_to_section_summary(self, content_loader, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
@@ -940,7 +940,7 @@ class TestUpdateBriefSubmission(BaseApplicationTest):
             'buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/section-4'
         ) is True
 
-    @mock.patch("app.buyers.views.buyers.content_loader")
+    @mock.patch("app.buyers.views.buyers.content_loader", autospec=True)
     def test_post_update_if_single_question_no_description_redirects_to_overview(self, content_loader, data_api_client):
         self.login_as_buyer()
         data_api_client.get_framework.return_value = api_stubs.framework(
@@ -1102,7 +1102,7 @@ class TestUpdateBriefSubmission(BaseApplicationTest):
         assert not data_api_client.update_brief.called
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
 class TestPublishBrief(BaseApplicationTest):
     def test_publish_brief(self, data_api_client):
         self.login_as_buyer()
@@ -1459,7 +1459,7 @@ class TestPublishBrief(BaseApplicationTest):
             "can be published:" not in page_html
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
 class TestDeleteBriefSubmission(BaseApplicationTest):
     def test_delete_brief_submission(self, data_api_client):
         for framework_status in ['live', 'expired']:
@@ -1537,7 +1537,7 @@ class TestDeleteBriefSubmission(BaseApplicationTest):
         assert res.status_code == 404
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
 class TestBriefSummaryPage(BaseApplicationTest):
     def test_show_draft_brief_summary_page(self, data_api_client):
         with self.app.app_context():
@@ -1754,7 +1754,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
 
             assert res.status_code == 404
 
-    @mock.patch("app.buyers.views.buyers.content_loader")
+    @mock.patch("app.buyers.views.buyers.content_loader", autospec=True)
     def test_links_to_sections_go_to_the_correct_pages_whether_they_be_sections_or_questions(self, content_loader, data_api_client):  # noqa
         with self.app.app_context():
             self.login_as_buyer()
@@ -1906,7 +1906,7 @@ class TestBriefSummaryPage(BaseApplicationTest):
                     assert contract_link_text == "View the {} contract".format(framework_name)
 
 
-@mock.patch("app.buyers.views.buyers.data_api_client")
+@mock.patch("app.buyers.views.buyers.data_api_client", autospec=True)
 class TestAddBriefClarificationQuestion(BaseApplicationTest):
     def test_show_brief_clarification_question_form_for_live_and_expired_framework(self, data_api_client):
         framework_statuses = ['live', 'expired']
@@ -2112,7 +2112,7 @@ class AbstractViewBriefResponsesPage(BaseApplicationTest):
     def setup_method(self, method):
         super(AbstractViewBriefResponsesPage, self).setup_method(method)
 
-        self.data_api_client_patch = mock.patch('app.buyers.views.buyers.data_api_client')
+        self.data_api_client_patch = mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
 
         self.data_api_client.get_framework.return_value = api_stubs.framework(
@@ -2688,8 +2688,7 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
         self.instance.generate_ods.assert_called_once_with(context['brief'],
                                                            context['responses'])
 
-        self.instance.generate_ods.return_value.save\
-            .assert_called_once_with(buf)
+        self.instance.generate_ods.return_value.save.assert_called_once_with(buf)
 
         Response.assert_called_once_with(
             buf.getvalue.return_value,
@@ -2739,7 +2738,7 @@ class TestDownloadBriefResponsesView(BaseApplicationTest):
         self.instance.get_context_data.assert_called_once_with(**kwargs)
 
 
-@mock.patch("app.buyers.views.buyers.data_api_client")
+@mock.patch("app.buyers.views.buyers.data_api_client", autospec=True)
 class TestDownloadBriefResponsesCsv(BaseApplicationTest):
     url = "/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1234/responses/download"
 
@@ -2929,7 +2928,7 @@ class TestDownloadBriefResponsesCsv(BaseApplicationTest):
             assert res.status_code == 404
 
 
-@mock.patch('app.buyers.views.buyers.data_api_client')
+@mock.patch('app.buyers.views.buyers.data_api_client', autospec=True)
 class TestViewQuestionAndAnswerDates(BaseApplicationTest):
     def test_show_question_and_answer_dates_for_published_brief(self, data_api_client):
         for framework_status in ['live', 'expired']:

--- a/tests/buyers/views/test_digital_outcomes_and_specialists.py
+++ b/tests/buyers/views/test_digital_outcomes_and_specialists.py
@@ -7,7 +7,7 @@ import mock
 from lxml import html
 
 
-@mock.patch('app.buyers.views.digital_outcomes_and_specialists.data_api_client')
+@mock.patch('app.buyers.views.digital_outcomes_and_specialists.data_api_client', autospec=True)
 class TestStartBriefInfoPage(BaseApplicationTest):
     def test_show_start_brief_info_page(self, data_api_client):
         with self.app.app_context():
@@ -54,7 +54,7 @@ class TestStartBriefInfoPage(BaseApplicationTest):
             assert res.status_code == 404
 
 
-@mock.patch('app.buyers.views.digital_outcomes_and_specialists.data_api_client')
+@mock.patch('app.buyers.views.digital_outcomes_and_specialists.data_api_client', autospec=True)
 class TestStartStudiosInfoPage(BaseApplicationTest):
     def test_show_start_studios_info_page(self, data_api_client):
         with self.app.app_context():

--- a/tests/main/views/test_errors.py
+++ b/tests/main/views/test_errors.py
@@ -5,7 +5,7 @@ from dmapiclient import HTTPError
 from ...helpers import BaseApplicationTest
 
 
-@mock.patch('app.main.views.g_cloud.search_api_client')
+@mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
 class TestErrors(BaseApplicationTest):
     def test_404(self, search_api_mock):
         res = self.client.get('/g-cloud/service/1234')

--- a/tests/main/views/test_g_cloud.py
+++ b/tests/main/views/test_g_cloud.py
@@ -9,12 +9,13 @@ class TestGCloudIndexResults(BaseApplicationTest):
     def setup_method(self, method):
         super(TestGCloudIndexResults, self).setup_method(method)
 
-        self._search_api_client = mock.patch('app.main.views.g_cloud.search_api_client').start()
+        self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
+        self._search_api_client = self._search_api_client_patch.start()
 
         self.search_results = self._get_search_results_fixture_data()
 
     def teardown_method(self, method):
-        self._search_api_client.stop()
+        self._search_api_client_patch.stop()
 
     def test_renders_correct_search_links(self):
         self._search_api_client.search_services.return_value = self.search_results

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -27,7 +27,7 @@ class TestApplication(BaseApplicationTest):
             'Find out more about cookies</a></p>' in res.get_data(as_text=True)
 
 
-@mock.patch('app.main.views.marketplace.data_api_client')
+@mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
 class TestHomepageAccountCreationVirtualPageViews(BaseApplicationTest):
     def test_data_analytics_track_page_view_is_shown_if_account_created_flag_flash_message(self, data_api_client):
         with self.client.session_transaction() as session:
@@ -45,7 +45,7 @@ class TestHomepageAccountCreationVirtualPageViews(BaseApplicationTest):
         assert 'data-analytics="trackPageView" data-url="buyers?account-created=true"' not in data
 
 
-@mock.patch('app.main.views.marketplace.data_api_client')
+@mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
 class TestHomepageBrowseList(BaseApplicationTest):
 
     mock_live_dos_1_framework = {
@@ -222,7 +222,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         assert len(message_container_contents) > 0
         assert message_container_contents[0].xpath('text()')[0].strip() == "Sell services"
 
-    @mock.patch('app.main.views.marketplace.data_api_client')
+    @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
     def _load_homepage(self, framework_slugs_and_statuses, framework_messages, data_api_client):
         data_api_client.find_frameworks.return_value = self._find_frameworks(framework_slugs_and_statuses)
         res = self.client.get('/')
@@ -275,7 +275,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
         self._load_homepage(framework_slugs_and_statuses, framework_messages)
 
-    @mock.patch('app.main.views.marketplace.data_api_client')
+    @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
     def test_homepage_sidebar_messages_when_logged_out(self, data_api_client):
         data_api_client.find_frameworks.return_value = self._find_frameworks([
             ('digital-outcomes-and-specialists', 'live')
@@ -294,7 +294,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
         assert 'Create a supplier account' in sidebar_link_texts
 
-    @mock.patch('app.main.views.marketplace.data_api_client')
+    @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
     def test_homepage_sidebar_messages_when_logged_in(self, data_api_client):
         data_api_client.find_frameworks.return_value = self._find_frameworks([
             ('digital-outcomes-and-specialists', 'live')
@@ -316,7 +316,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         assert 'Create a supplier account' not in sidebar_link_texts
 
     # here we've given an valid framework with a valid status but there is no message.yml file to read from
-    @mock.patch('app.main.views.marketplace.data_api_client')
+    @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
     def test_g_cloud_6_open_blows_up(self, data_api_client):
         framework_slugs_and_statuses = [
             ('g-cloud-6', 'open')
@@ -346,16 +346,15 @@ class BaseBriefPageTest(BaseApplicationTest):
     def setup_method(self, method):
         super(BaseBriefPageTest, self).setup_method(method)
 
-        self._data_api_client = mock.patch(
-            'app.main.views.marketplace.data_api_client'
-        ).start()
+        self._data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
+        self._data_api_client = self._data_api_client_patch.start()
 
         self.brief = self._get_dos_brief_fixture_data()
         self.brief_id = self.brief['briefs']['id']
         self._data_api_client.get_brief.return_value = self.brief
 
     def teardown_method(self, method):
-        self._data_api_client.stop()
+        self._data_api_client_patch.stop()
 
 
 class TestBriefPage(BaseBriefPageTest):
@@ -773,9 +772,8 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
     def setup_method(self, method):
         super(TestCatalogueOfBriefsPage, self).setup_method(method)
 
-        self._data_api_client = mock.patch(
-            'app.main.views.marketplace.data_api_client'
-        ).start()
+        self._data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
+        self._data_api_client = self._data_api_client_patch.start()
 
         self.briefs = self._get_dos_brief_fixture_data(multi=True)
         self._data_api_client.find_briefs.return_value = self.briefs
@@ -820,7 +818,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         ]}
 
     def teardown_method(self, method):
-        self._data_api_client.stop()
+        self._data_api_client_patch.stop()
 
     def test_catalogue_of_briefs_page(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')
@@ -1016,7 +1014,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self._data_api_client.find_frameworks.assert_called_once_with()
 
 
-@mock.patch('app.main.views.marketplace.data_api_client')
+@mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
 class TestGCloudHomepageLinks(BaseApplicationTest):
 
     mock_live_g_cloud_framework = {

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -20,16 +20,15 @@ class TestSearchResults(BaseApplicationTest):
     def setup_method(self, method):
         super(TestSearchResults, self).setup_method(method)
 
-        self._search_api_client = mock.patch(
-            'app.main.views.g_cloud.search_api_client'
-        ).start()
+        self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
+        self._search_api_client = self._search_api_client_patch.start()
 
         self.search_results = self._get_search_results_fixture_data()
         self.search_results_multiple_page = \
             self._get_search_results_multiple_page_fixture_data()
 
     def teardown_method(self, method):
-        self._search_api_client.stop()
+        self._search_api_client_patch.stop()
 
     def test_search_page_results_service_links(self):
         self._search_api_client.search_services.return_value = \

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -8,20 +8,19 @@ class TestSuppliersPage(BaseApplicationTest):
     def setup_method(self, method):
         super(TestSuppliersPage, self).setup_method(method)
 
-        self._data_api_client = mock.patch(
-            'app.main.suppliers.data_api_client'
-        ).start()
+        self._data_api_client_patch = mock.patch('app.main.suppliers.data_api_client', autospec=True)
+        self._data_api_client = self._data_api_client_patch.start()
 
-        self.suppliers_by_prefix = self._get_suppliers_by_prefix_fixture_data()  # noqa
-        self.suppliers_by_prefix_page_2 = self._get_suppliers_by_prefix_fixture_data_page_2()  # noqa
-        self.suppliers_by_prefix_next_and_prev = self._get_suppliers_by_prefix_fixture_with_next_and_prev()  # noqa
-        self.supplier = self._get_supplier_fixture_data()  # noqa
-        self.supplier_with_minimum_data = self._get_supplier_with_minimum_fixture_data()  # noqa
-        self._data_api_client.find_suppliers.return_value = self.suppliers_by_prefix  # noqa
-        self._data_api_client.get_supplier.return_value = self.supplier  # noqa
+        self.suppliers_by_prefix = self._get_suppliers_by_prefix_fixture_data()
+        self.suppliers_by_prefix_page_2 = self._get_suppliers_by_prefix_fixture_data_page_2()
+        self.suppliers_by_prefix_next_and_prev = self._get_suppliers_by_prefix_fixture_with_next_and_prev()
+        self.supplier = self._get_supplier_fixture_data()
+        self.supplier_with_minimum_data = self._get_supplier_with_minimum_fixture_data()
+        self._data_api_client.find_suppliers.return_value = self.suppliers_by_prefix
+        self._data_api_client.get_supplier.return_value = self.supplier
 
     def teardown_method(self, method):
-        self._data_api_client.stop()
+        self._data_api_client_patch.stop()
 
     def test_should_call_api_with_correct_params(self):
         self.client.get('/g-cloud/suppliers')

--- a/tests/status/views/test_status.py
+++ b/tests/status/views/test_status.py
@@ -9,22 +9,20 @@ class TestStatus(BaseApplicationTest):
     def setup_method(self, method):
         super(TestStatus, self).setup_method(method)
 
-        self._data_api_client = mock.patch(
-            'app.status.views.data_api_client'
-        ).start()
-        self._search_api_client = mock.patch(
-            'app.status.views.search_api_client'
-        ).start()
+        self._data_api_client_patch = mock.patch('app.status.views.data_api_client', autospec=True)
+        self._data_api_client = self._data_api_client_patch.start()
+
+        self._search_api_client_patch = mock.patch('app.status.views.search_api_client', autospec=True)
+        self._search_api_client = self._search_api_client_patch.start()
 
     def teardown_method(self, method):
-        self._data_api_client.stop()
-        self._search_api_client.stop()
+        self._data_api_client_patch.stop()
+        self._search_api_client_patch.stop()
 
-    @mock.patch('app.status.views.data_api_client')
-    def test_should_return_200_from_elb_status_check(self, data_api_client):
+    def test_should_return_200_from_elb_status_check(self):
         status_response = self.client.get('/_status?ignore-dependencies')
         assert status_response.status_code == 200
-        assert data_api_client.called is False
+        assert self._data_api_client.called is False
 
     def test_status_ok(self):
         self._data_api_client.get_status.return_value = {


### PR DESCRIPTION
For this tech debt story - https://trello.com/c/qL9vEC1r/392-ensure-autospec-on-buyer-frontend-mocks.

I have already gone through all of our applications and bumped the mock library to `2.0.0`. This brings in the lovely new feature where if you misspell a test assertion then it will realise for you. (https://bugs.python.org/issue21238). This means that if we have `assret_called_once_with` or `assert_calld_once_with` in our tests then these will raise errors. This essentially is the low hanging fruit picked off.

Until I discovered this, I had trawled through the buyer frontend tests manually and added autospec to nearly all the mocks. This is the results of my effort. Note, I tried changing the `tests/main/test_login.py` file to add autospec but ran into issues and so have not touched this one or spent the time trying to get to the bottom of it.

I think this is a useful PR but I don't know whether I would now suggest doing the same in all of the other apps given the `mock` bump should prevent the majority of errors. We should still be using autospec with new tests but I don't know if we will be adding much value going through our entire codebase. Happy to hear thoughts.