### PR TITLE
Fix search summary 500

### DIFF
--- a/app/main/helpers/search_summary_manifest.yml
+++ b/app/main/helpers/search_summary_manifest.yml
@@ -143,6 +143,8 @@
     id: TLS (version 1.2 or above)
   - preposition:
     id: IPsec or TLS VPN gateway
+  - preposition:
+    id: bonded fibre optic connections
 
 - id: Data protection within supplier network
   labelPreposition: where data protection within supplier network includes


### PR DESCRIPTION
## Summary
One of the filter rules for buyer->supplier networks was missing, causing a 500 if that was the only filter selected from its group. This adds the filter rule. As part of this I've checked all filters and confirmed that this is the only remaining broken rule. We (Catalogues) are discussing the search summary itself and how we might iterate upon it, so don't want to commit to any more involved fixes until we have decided it's future.

## Testing
The /g-cloud/search page presents a number of filters which can be used to reduce the number of services a buyer is looking at. One of the cloud-hosting/cloud-software filters, 'Bonded fibre optic connections', was missing a filter rule which is used to construct human-readable search summaries describing how the user has filtered the catalogue of G-Cloud services. If you filter services with only that checked on preview/staging, it will break - running this branch locally, it should work correctly and construct a valid sentence.

## Ticket
https://trello.com/c/lOQ8Fno2/520-crash-in-search-summary