### PR TITLE
Show the role for specialist opportunity on the list page

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -106,7 +106,7 @@ def get_service_by_id(service_id):
 
         service_view_data = Service(
             service_data,
-            content_loader.get_builder(framework_slug, 'display_service').filter(
+            content_loader.get_manifest(framework_slug, 'display_service').filter(
                 service_data
             ),
             framework_helpers.get_lots_by_slug(framework)

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -89,7 +89,7 @@ def get_brief_by_id(framework_framework, brief_id):
         for index, question in enumerate(brief['clarificationQuestions'])
     ]
 
-    brief_content = content_loader.get_builder(brief['frameworkSlug'], 'display_brief').filter(brief)
+    brief_content = content_loader.get_manifest(brief['frameworkSlug'], 'display_brief').filter(brief)
 
     return render_template(
         'brief.html',
@@ -118,7 +118,7 @@ def list_opportunities(framework_framework):
 
     briefs = [{
         "data": brief,
-        "content": content_loader.get_builder(brief['frameworkSlug'], 'display_brief').filter(brief)
+        "content": content_loader.get_manifest(brief['frameworkSlug'], 'display_brief').filter(brief)
     } for brief in api_result["briefs"]]
 
     links = api_result["links"]

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -89,9 +89,7 @@ def get_brief_by_id(framework_framework, brief_id):
         for index, question in enumerate(brief['clarificationQuestions'])
     ]
 
-    brief_content = content_loader.get_builder(brief['frameworkSlug'], 'display_brief').filter(
-        brief
-    )
+    brief_content = content_loader.get_builder(brief['frameworkSlug'], 'display_brief').filter(brief)
 
     return render_template(
         'brief.html',
@@ -118,7 +116,11 @@ def list_opportunities(framework_framework):
 
     api_result = form.get_briefs()
 
-    briefs = api_result["briefs"]
+    briefs = [{
+        "data": brief,
+        "content": content_loader.get_builder(brief['frameworkSlug'], 'display_brief').filter(brief)
+    } for brief in api_result["briefs"]]
+
     links = api_result["links"]
 
     api_prev_link_args = parse_link(links, "prev")

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -1,44 +1,46 @@
 {% for brief in briefs %}
 <div class="search-result">
     <h2 class="search-result-title">
-        <a href="{{ url_for('.get_brief_by_id', framework_framework=framework.framework, brief_id=brief.id) }}">{{ brief.title }}</a>
+        <a href="{{ url_for('.get_brief_by_id', framework_framework=framework.framework, brief_id=brief.data.id) }}">{{ brief.data.title }}</a>
     </h2>
 
     <ul class="search-result-important-metadata">
         <li class="search-result-metadata-item">
-            {{ brief.organisation }}
+            {{ brief.data.organisation }}
         </li>
         <li class="search-result-metadata-item">
-            {{ brief.location }}
+            {{ brief.data.location }}
         </li>
     </ul>
 
     <ul class="search-result-metadata">
         <li class="search-result-metadata-item">
-            {{ brief.lotName }}
+            {{ brief.data.lotName }}
         </li>
+        {% if 'specialistRole' in brief.data %}
         <li class="search-result-metadata-item">
-            {{ brief.frameworkName }}
+            {{ brief.content.summary(brief.data).get_question("specialistRole").value }}
         </li>
+        {% endif %}
     </ul>
 
     <ul class="search-result-metadata">
-        {% if brief.status == 'closed' %}
+        {% if brief.data.status == 'closed' %}
             <li class="search-result-metadata-item">
                 Closed
             </li>
         {% else %}
             <li class="search-result-metadata-item">
-                Published: {{ brief.publishedAt|dateformat }}
+                Published: {{ brief.data.publishedAt|dateformat }}
             </li>
             <li class="search-result-metadata-item">
-                Closing: {{ brief.applicationsClosedAt|dateformat }}
+                Closing: {{ brief.data.applicationsClosedAt|dateformat }}
             </li>
         {% endif %}
     </ul>
 
     <p class="search-result-excerpt">
-        {{ brief.summary }}
+        {{ brief.data.summary }}
     </p>
 </div>
 

--- a/tests/buyers/helpers/test_buyers_helpers.py
+++ b/tests/buyers/helpers/test_buyers_helpers.py
@@ -11,7 +11,7 @@ from dmapiclient import api_stubs
 
 content_loader = ContentLoader('tests/fixtures/content')
 content_loader.load_manifest('dos', 'data', 'edit_brief')
-questions_builder = content_loader.get_builder('dos', 'edit_brief')
+questions_builder = content_loader.get_manifest('dos', 'edit_brief')
 
 
 class TestBuyersHelpers(object):

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -16,8 +16,8 @@ from ...helpers import BaseApplicationTest
 content_loader = ContentLoader('tests/fixtures/content')
 content_loader.load_manifest('g6', 'data', 'manifest')
 content_loader.load_manifest('g9', 'data', 'manifest')
-g6_builder = content_loader.get_builder('g6', 'manifest')
-g9_builder = content_loader.get_builder('g9', 'manifest')
+g6_builder = content_loader.get_manifest('g6', 'manifest')
+g9_builder = content_loader.get_manifest('g9', 'manifest')
 
 
 def _get_fixture_data():

--- a/tests/main/presenters/test_search_summary.py
+++ b/tests/main/presenters/test_search_summary.py
@@ -23,12 +23,12 @@ def setup_module(module):
 
     module.filter_groups = filters_for_lot(
         "saas",
-        content_loader.get_builder('g-cloud-6', 'search_filters')
+        content_loader.get_manifest('g-cloud-6', 'search_filters')
     ).values()
 
     module.g9_filter_groups = filters_for_lot(
         'cloud-software',
-        content_loader.get_builder('g-cloud-9', 'search_filters')
+        content_loader.get_manifest('g-cloud-9', 'search_filters')
     ).values()
 
 

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -40,7 +40,7 @@ class TestService(BaseApplicationTest):
         )
 
         self.service = Service(
-            self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'), self._lots_by_slug
+            self.fixture, content_loader.get_manifest('g-cloud-6', 'display_service'), self._lots_by_slug
         )
 
     def test_title_attribute_is_set(self):
@@ -54,19 +54,19 @@ class TestService(BaseApplicationTest):
 
     def test_Service_works_if_supplierName_is_not_set(self):
         del self.fixture['supplierName']
-        self.service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'),
+        self.service = Service(self.fixture, content_loader.get_manifest('g-cloud-6', 'display_service'),
                                self._lots_by_slug)
         assert not hasattr(self.service, 'supplierName')
 
     def test_Service_works_if_serviceFeatures_is_not_set(self):
         del self.fixture['serviceFeatures']
-        self.service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'),
+        self.service = Service(self.fixture, content_loader.get_manifest('g-cloud-6', 'display_service'),
                                self._lots_by_slug)
         assert not hasattr(self.service, 'features')
 
     def test_Service_works_if_serviceBenefits_is_not_set(self):
         del self.fixture['serviceBenefits']
-        self.service = Service(self.fixture, content_loader.get_builder('g-cloud-6', 'display_service'),
+        self.service = Service(self.fixture, content_loader.get_manifest('g-cloud-6', 'display_service'),
                                self._lots_by_slug)
         assert not hasattr(self.service, 'benefits')
 
@@ -81,7 +81,7 @@ class TestService(BaseApplicationTest):
     def test_service_properties_available_via_summary_manifest(self):
         service = Service(
             self.fixture,
-            content_loader.get_builder('g-cloud-6', 'display_service').filter({'lot': 'iaas'}),
+            content_loader.get_manifest('g-cloud-6', 'display_service').filter({'lot': 'iaas'}),
             self._lots_by_slug
         )
         assert service.summary_manifest.sections[0].name == 'Support'

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -864,8 +864,9 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         ss_elem = document.xpath("//p[@class='search-summary']")[0]
         assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "2 opportunities"
 
-        first_brief_specialist_role = document.xpath("//div[@class='search-result']/ul[2]/li[2]/text()")[0].strip()
-        assert first_brief_specialist_role == "Business analyst"
+        specialist_role_labels = document.xpath("//div[@class='search-result']/ul[2]/li[2]/text()")
+        assert len(specialist_role_labels) == 1  # only one brief has a specialist role so only one label should exist
+        assert specialist_role_labels[0].strip() == "Business analyst"
 
     def test_catalogue_of_briefs_page_filtered(self):
         original_url = "/digital-outcomes-and-specialists/opportunities?page=2&status=live&lot=lot-one&lot=lot-three"

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -864,10 +864,8 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         ss_elem = document.xpath("//p[@class='search-summary']")[0]
         assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "2 opportunities"
 
-        dos1_framework_label = document.xpath("//div[@class='search-result']/ul[2]/li[2]/text()")[0].strip()
-        dos2_framework_label = document.xpath("//div[@class='search-result']/ul[2]/li[2]/text()")[1].strip()
-        assert dos1_framework_label == "Digital Outcomes and Specialists"
-        assert dos2_framework_label == "Digital Outcomes and Specialists 2"
+        first_brief_specialist_role = document.xpath("//div[@class='search-result']/ul[2]/li[2]/text()")[0].strip()
+        assert first_brief_specialist_role == "Business analyst"
 
     def test_catalogue_of_briefs_page_filtered(self):
         original_url = "/digital-outcomes-and-specialists/opportunities?page=2&status=live&lot=lot-one&lot=lot-three"


### PR DESCRIPTION
### Context/Problem
Currently, Suppliers cannot identify specialists role for different opportunities until they click on the opportunity. The opportunity title does not always indicate the role.

### User need
As a supplier, I need to identify relevant specialist roles on the Digital Marketplace so that I only view opportunities I am interested in

### Acceptance criteria
Users can see the opportunities for the roles they are interested in
  
  
Trello card: https://trello.com/c/bZvmAPTQ/369-show-the-role-for-specialist-opportunity-on-the-list-page