### PR TITLE
Changing category preserves filters

### DIFF
--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -96,7 +96,7 @@ def _get_category_filter_key_set(category_filter_group):
     """
     Returns the set of keys used in the category filter group. In practice
     there should only be one, but for completeness we allow for the possibility
-    of their being several. In G6/7/8, this was {'serviceTypes'}, in G9 it's
+    of there being several. In G6/7/8, this was {'serviceTypes'}, in G9 it's
     {'serviceCategories'} .
     :return: set[string]
     """
@@ -143,7 +143,7 @@ def get_lots_and_categories_selection(lots, category_filter_group, request):
     for lot in lots:
         selected_categories = []
         lot_selected = (lot['slug'] == current_lot_slug)
-        lot_filter = dict(lot)
+        lot_filter = lot.copy()
         if lot_selected:
             lot_filter['selected'] = True
             categories = category_filter_group['filters'] if category_filter_group else []
@@ -160,7 +160,6 @@ def get_lots_and_categories_selection(lots, category_filter_group, request):
             lot_filter['link'] = search_link_builder(url_args)
 
         if lot_selected or current_lot_slug is None:
-            # only place this lot into the tree if it is selected (or if no lot is selected at all)
             root_node['children'].append(lot_filter)
 
     return selection

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -11,7 +11,7 @@ from ...main import main
 from ..presenters.search_presenters import (
     filters_for_lot,
     set_filter_states,
-    annotate_lots_with_categories_selection,
+    get_lots_and_categories_selection,
 )
 from ..presenters.search_results import SearchResults
 from ..presenters.search_summary import SearchSummary
@@ -196,7 +196,7 @@ def search_services():
     category_filter_group = filters.pop('categories') if 'categories' in filters else None
 
     lots = framework['lots']
-    current_category_filter = annotate_lots_with_categories_selection(lots, category_filter_group, request)
+    category_tree_selection = get_lots_and_categories_selection(lots, category_filter_group, request)
 
     current_lot = lots_by_slug.get(current_lot_slug)
 
@@ -212,7 +212,7 @@ def search_services():
     return render_template(
         'search/services.html',
         current_lot=current_lot,
-        current_category_filter=current_category_filter,
+        category_tree_root=category_tree_selection[0],
         filters=filters.values(),
         lots=lots,
         pagination=pagination_config,

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -11,7 +11,7 @@ from ...main import main
 from ..presenters.search_presenters import (
     filters_for_lot,
     set_filter_states,
-    get_lots_and_categories_selection,
+    build_lots_and_categories_link_tree,
 )
 from ..presenters.search_results import SearchResults
 from ..presenters.search_summary import SearchSummary
@@ -196,7 +196,7 @@ def search_services():
     category_filter_group = filters.pop('categories') if 'categories' in filters else None
 
     lots = framework['lots']
-    category_tree_selection = get_lots_and_categories_selection(lots, category_filter_group, request)
+    category_tree_root = build_lots_and_categories_link_tree(lots, category_filter_group, request)
 
     current_lot = lots_by_slug.get(current_lot_slug)
 
@@ -212,7 +212,7 @@ def search_services():
     return render_template(
         'search/services.html',
         current_lot=current_lot,
-        category_tree_root=category_tree_selection[0],
+        category_tree_root=category_tree_root,
         filters=filters.values(),
         lots=lots,
         pagination=pagination_config,

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -196,7 +196,12 @@ def search_services():
     category_filter_group = filters.pop('categories') if 'categories' in filters else None
 
     lots = framework['lots']
-    category_tree_root = build_lots_and_categories_link_tree(lots, category_filter_group, request)
+    selected_category_tree_filters = build_lots_and_categories_link_tree(lots, category_filter_group, request)
+
+    # Filter form should also filter by lot, and by category, when any of those are selected.
+    # (But if a sub-category is selected, there is no need to filter by the parent category as,
+    # well, so we can just take one hidden field per key - sub-cat will be last.)
+    filter_form_hidden_fields_by_name = {f['name']: f for f in selected_category_tree_filters[1:]}
 
     current_lot = lots_by_slug.get(current_lot_slug)
 
@@ -212,7 +217,8 @@ def search_services():
     return render_template(
         'search/services.html',
         current_lot=current_lot,
-        category_tree_root=category_tree_root,
+        category_tree_root=selected_category_tree_filters[0],
+        filter_form_hidden_fields=filter_form_hidden_fields_by_name.values(),
         filters=filters.values(),
         lots=lots,
         pagination=pagination_config,

--- a/app/templates/search/_categories.html
+++ b/app/templates/search/_categories.html
@@ -38,9 +38,9 @@
   <ul {% if last_list %}class="lot-filters--last-list"{% endif %}>
     {% for item in items %}
       {% if item.get(_keys['selected']) %}
-         {{ list_item__selected(text=item.label or item.name, url=item.get(_keys['url']), nested_items=item.get(_keys['nested_items'])) }}
+         {{ list_item__selected(text=item.label, url=item.get(_keys['url']), nested_items=item.get(_keys['nested_items'])) }}
       {% elif item.get(_keys['url']) %}
-        {{ list_item__unselected(text=item.label or item.name, url=item.get(_keys['url'])) }}
+        {{ list_item__unselected(text=item.label, url=item.get(_keys['url'])) }}
       {% endif %}
     {% endfor %}
   </ul>

--- a/app/templates/search/_categories.html
+++ b/app/templates/search/_categories.html
@@ -15,7 +15,7 @@
   {% endif %}
 
   {% if nested_items %}
-    {{ category_list(nested_items, keys={'text': 'label', 'nested_items': 'children'}) }}
+    {{ category_list(nested_items) }}
   {% endif %}
   </li>
 {%- endmacro -%}
@@ -26,7 +26,7 @@
         'text': 'text',
         'url': 'link',
         'selected': 'selected',
-        'nested_items': 'nested_items'
+        'nested_items': 'children'
       }
   %}
   {% set _ = _keys.update(keys or {}) %}
@@ -38,9 +38,9 @@
   <ul {% if last_list %}class="lot-filters--last-list"{% endif %}>
     {% for item in items %}
       {% if item.get(_keys['selected']) %}
-         {{ list_item__selected(text=item.get(_keys['text']), url=item.get(_keys['url']), nested_items=item.get(_keys['nested_items'])) }}
+         {{ list_item__selected(text=item.label or item.name, url=item.get(_keys['url']), nested_items=item.get(_keys['nested_items'])) }}
       {% elif item.get(_keys['url']) %}
-        {{ list_item__unselected(text=item.get(_keys['text']), url=item.get(_keys['url'])) }}
+        {{ list_item__unselected(text=item.label or item.name, url=item.get(_keys['url'])) }}
       {% endif %}
     {% endfor %}
   </ul>

--- a/app/templates/search/_services_filters.html
+++ b/app/templates/search/_services_filters.html
@@ -14,12 +14,8 @@
   {{ category_list([category_tree_root]) }}
 </div>
 
-{% if current_lot %}
-<input type="hidden" name="lot" value="{{ current_lot.slug }}" />
-{% endif %}
-
-{% if current_category_filter %}
-<input type="hidden" name="{{ current_category_filter.name }}" value="{{ current_category_filter.value }}" />
-{% endif %}
+{% for f in filter_form_hidden_fields %}
+  <input type="hidden" name="{{ f.name }}" value="{{ f.value }}" />
+{% endfor %}
 
 {% include 'search/_filters.html' %}

--- a/app/templates/search/_services_filters.html
+++ b/app/templates/search/_services_filters.html
@@ -11,17 +11,7 @@
 <div class="lot-filters">
   <h2>Choose a category</h2>
   {% from 'search/_categories.html' import top_level_link, category_list %}
-  {% set lots = lots|selectattr("selected")|list or lots %}
-  <ul>
-    <li>
-    {% if current_lot %}
-      {{ top_level_link( text='All categories', url=url_for('.search_services', q=search_keywords)) }}
-    {% else %}
-      All categories
-    {% endif %}
-      {{ category_list(lots, keys={'text': 'name', 'nested_items': 'categories'}) }}
-    </li>
-  </ul>
+  {{ category_list([category_tree_root]) }}
 </div>
 
 {% if current_lot %}

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -200,7 +200,7 @@ class TestSearchFilters(BaseApplicationTest):
         # in this test, the key 'category' key is 'checkboxTreeExample'
 
         # first test with a top-level category selected
-        url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&checkboxTreeExample=option+1"
+        url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&checkboxTreeExample=option+1&page=2"
         with self.app.test_request_context(url):
             selection = build_lots_and_categories_link_tree(lots, category_filter_group, flask.request)
             assert len(selection) == 3  # all -> software -> option1
@@ -229,6 +229,7 @@ class TestSearchFilters(BaseApplicationTest):
             for f in itertools.chain(category_filters, sub_category_filters):
                 if f.get('link'):
                     assert 'otherfilter=somevalue' in f['link']
+                    assert 'page=' not in f['link']
 
         # now test with a sub-category selected
         url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&checkboxTreeExample=option+2.2"

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -202,15 +202,17 @@ class TestSearchFilters(BaseApplicationTest):
         # first test with a top-level category selected
         url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&checkboxTreeExample=option+1"
         with self.app.test_request_context(url):
-            tree_root = build_lots_and_categories_link_tree(lots, category_filter_group, flask.request)
+            selection = build_lots_and_categories_link_tree(lots, category_filter_group, flask.request)
+            assert len(selection) == 3  # all -> software -> option1
 
-            assert tree_root.get('name') == 'All categories'
+            tree_root = selection[0]
+            assert tree_root.get('label') == 'All categories'
 
             lot_filters = tree_root['children']
             selected_lot = next(f for f in lot_filters if f['selected'])
-            assert selected_lot.get('name') == 'Cloud software'
+            assert selected_lot.get('label') == 'Cloud software'
             # there should be a link to the lot without a category, as a category has been selected within it
-            assert 'lot={}'.format('cloud-software') in selected_lot['link']
+            assert 'lot=cloud-software' in selected_lot['link']
             assert 'checkboxTreeExample' not in selected_lot['link']
 
             # check that we have links in place to a search with the relevant category filter applied,
@@ -231,7 +233,10 @@ class TestSearchFilters(BaseApplicationTest):
         # now test with a sub-category selected
         url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&checkboxTreeExample=option+2.2"
         with self.app.test_request_context(url):
-            tree_root = build_lots_and_categories_link_tree(lots, category_filter_group, flask.request)
+            selection = build_lots_and_categories_link_tree(lots, category_filter_group, flask.request)
+            assert len(selection) == 4  # all -> software -> option2 -> option2.2
+
+            tree_root = selection[0]
             # check that only siblings of the selected sub-category are shown, and other categories
             # have been removed
             lot_filters = tree_root['children']


### PR DESCRIPTION
Preserve filters (other than category) when changing categories.
 - also preserve filters when changing lot (other than category and lot!)
 - also works for 'All categories' filter (involved some changes / simplification in the templates)
 - we now create 'lot filters' from the original lots, rather than annotate those lot objects, which was always a bit weird;
