### PR TITLE
Bump frontend toolkit to 22.4.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.4",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.5",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.5.4"
   }


### PR DESCRIPTION
This bugfix fixes the widths of the date fields.

https://trello.com/c/XCy5T0uU/160-date-fields-are-too-long

Old:
![image](https://cloud.githubusercontent.com/assets/7228605/26780741/0624d6b6-49e3-11e7-8af0-52c2e48201f0.png)


New:
![image](https://cloud.githubusercontent.com/assets/7228605/26780749/0c474254-49e3-11e7-8202-5aa1422bea52.png)
