### PR TITLE
404 on an invalid search results page param

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -170,6 +170,12 @@ def search_services():
         all_lots=framework['lots']
     )
 
+    try:
+        if int(request.args.get('page', 1)) <= 0:
+            abort(404)
+    except ValueError:
+        abort(404)
+
     search_api_response = search_api_client.search_services(
         **build_search_query(request, filters.values(), content_manifest, lots_by_slug)
     )

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -315,3 +315,16 @@ class TestSearchResults(BaseApplicationTest):
         assert u'<span class="search-summary-count">1</span> result found' \
             u' containing <em>email \U0001f47e</em> in' \
             u' <em>Software as a Service</em>' in summary
+
+    def test_should_404_on_invalid_page_param(self):
+        self._search_api_client.search_services.return_value = \
+            self.search_results_multiple_page
+
+        res = self.client.get('/g-cloud/search?lot=cloud-hosting&page=1')
+        assert res.status_code == 200
+
+        res = self.client.get('/g-cloud/search?lot=cloud-hosting&page=-1')
+        assert res.status_code == 404
+
+        res = self.client.get('/g-cloud/search?lot=cloud-hosting&page=potato')
+        assert res.status_code == 404


### PR DESCRIPTION
## Summary
G-Cloud search throws a 500 when an invalid `page` query param is included in the URL (eg `-1` or `potato`). This is caused by the search-api throwing a 400 due to strict handling of a valid page parameter, which isn't caught and handled appropriately by the frontend. The frontend will now check upfront that the page is valid before sending to the search-api; if not it will 404.

This seems weird to me, but it seems to be the preferred way of dealing with it and it's a quick fix.

## Ticket
https://trello.com/c/sIWxFUwY/321-page-0-of-search-returns-err-no-500-rather-than-400