### PR TITLE
Use section_id rather than section_slug in URL params

### DIFF
--- a/app/buyers/views/buyers.py
+++ b/app/buyers/views/buyers.py
@@ -136,7 +136,7 @@ def copy_brief(framework_slug, lot_slug, brief_id):
         framework_slug=new_brief["frameworkSlug"],
         lot_slug=new_brief["lotSlug"],
         brief_id=new_brief["id"],
-        section_slug=section.slug,
+        section_id=section.slug,
         question_id=section.questions[0].id
     ))
 
@@ -190,8 +190,8 @@ def view_brief_overview(framework_slug, lot_slug, brief_id):
     ), 200
 
 
-@buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/<section_slug>', methods=['GET'])
-def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_slug):
+@buyers.route('/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/<section_id>', methods=['GET'])
+def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_id):
     get_framework_and_lot(
         framework_slug,
         lot_slug,
@@ -206,7 +206,7 @@ def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_slug)
 
     content = content_loader.get_manifest(brief['frameworkSlug'], 'edit_brief').filter({'lot': brief['lotSlug']})
     sections = content.summary(brief)
-    section = sections.get_section(section_slug)
+    section = sections.get_section(section_id)
 
     if not section:
         abort(404)
@@ -219,9 +219,9 @@ def view_brief_section_summary(framework_slug, lot_slug, brief_id, section_slug)
 
 
 @buyers.route(
-    '/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_slug>/<question_id>',
+    '/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_id>/<question_id>',
     methods=['GET'])
-def edit_brief_question(framework_slug, lot_slug, brief_id, section_slug, question_id):
+def edit_brief_question(framework_slug, lot_slug, brief_id, section_id, question_id):
     get_framework_and_lot(framework_slug, lot_slug, data_api_client, allowed_statuses=['live'], must_allow_brief=True)
     brief = data_api_client.get_brief(brief_id)["briefs"]
 
@@ -231,7 +231,7 @@ def edit_brief_question(framework_slug, lot_slug, brief_id, section_slug, questi
     content = content_loader.get_manifest(brief['frameworkSlug'], 'edit_brief').filter(
         {'lot': brief['lotSlug']}
     )
-    section = content.get_section(section_slug)
+    section = content.get_section(section_id)
     if section is None or not section.editable:
         abort(404)
 
@@ -295,7 +295,7 @@ def update_brief_submission(framework_slug, lot_slug, brief_id, section_id, ques
                 framework_slug=brief['frameworkSlug'],
                 lot_slug=brief['lotSlug'],
                 brief_id=brief['id'],
-                section_slug=section.slug)
+                section_id=section.slug)
         )
 
     return redirect(

--- a/app/templates/buyers/brief_publish_confirmation.html
+++ b/app/templates/buyers/brief_publish_confirmation.html
@@ -40,7 +40,7 @@
         <p>All requirements are published on the Digital Marketplace where anyone can see them.</p>
       </div>
         {% if brief.lotSlug == 'digital-specialists' and not brief.requirementsLength %}
-          <p><a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug='set-how-long-your-requirements-will-be-open-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
+          <p><a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_id='set-how-long-your-requirements-will-be-open-for', question_id='requirementsLength') }}">Set how long your requirements will be open for</a></p>
           <div class="dmspeak">
             <p>This will show you what the supplier application deadline will be if you publish your requirements today.</p>
           </div>
@@ -69,7 +69,7 @@
           {% if question.answer_required and not question.id == 'requirementsLength' %}
             <ol>
               <li>
-                <a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.question }}</a>
+                <a href="{{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_id=section.slug, question_id=question.id) }}">{{ question.question }}</a>
               </li>
             </ol>
           {% endif %}
@@ -98,7 +98,7 @@
             {{ summary.field_heading_date("Before {}".format(dates.questions_close | shortdateformat), rowspan='3', scope='row') }}
             {{ summary.text_bold("Details of your question and answer session") }}
             {% if not published %}
-              {{ summary.edit_link("Edit", url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=question_and_answers.slug, question_id=question_and_answers.id)) }}
+              {{ summary.edit_link("Edit", url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_id=question_and_answers.slug, question_id=question_and_answers.id)) }}
             {% endif %}
           {% endcall %}
           {% call summary.row(no_border=True) %}

--- a/app/templates/buyers/edit_brief_question.html
+++ b/app/templates/buyers/edit_brief_question.html
@@ -19,7 +19,7 @@
     ]
   %}
   {% set section_breadcrumb = [{
-        "link": url_for(".view_brief_section_summary", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug),
+        "link": url_for(".view_brief_section_summary", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_id=section.slug),
         "label": section.name
       }] if section.has_summary_page else []
   %}

--- a/app/templates/buyers/section_summary.html
+++ b/app/templates/buyers/section_summary.html
@@ -65,7 +65,7 @@
           {% if question.answer_required or question.is_empty %}
             {% if brief.get('status') == 'draft' %}
               {% call summary.field() %}
-                <a href="{{ url_for('buyers.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id) }}">{{ question.empty_message or "Not answered" }}</a>
+                <a href="{{ url_for('buyers.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_id=section.slug, question_id=question.id) }}">{{ question.empty_message or "Not answered" }}</a>
               {% endcall %}
             {% else %}
               {{ summary.text("Not answered") }}
@@ -80,7 +80,7 @@
                 Optional
               {% endcall %}
             {% elif not question.answer_required %}
-              {{ summary.edit_link("Edit", url_for("buyers.edit_brief_question", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=question.id)) }}
+              {{ summary.edit_link("Edit", url_for("buyers.edit_brief_question", framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_id=section.slug, question_id=question.id)) }}
             {% else %}
               {% call summary.field() %}{% endcall %}
             {% endif %}

--- a/app/templates/macros/brief_links.html
+++ b/app/templates/macros/brief_links.html
@@ -1,9 +1,9 @@
 {% macro brief_link_url(from, section, brief) %}
   {% if section.has_summary_page %}
-    {{ url_for('.view_brief_section_summary', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug) }}
+    {{ url_for('.view_brief_section_summary', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_id=section.slug) }}
   {% else %}
     {% if from == 'grandparent' %}
-      {{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_slug=section.slug, question_id=section.questions[0].id) }}
+      {{ url_for('.edit_brief_question', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id, section_id=section.slug, question_id=section.questions[0].id) }}
     {% else %}
       {{ url_for('.view_brief_overview', framework_slug=brief.frameworkSlug, lot_slug=brief.lotSlug, brief_id=brief.id) }}
     {% endif %}


### PR DESCRIPTION
I noticed that the GET and POST views for one of our routes used different parameter names, which could be confusing:
```
GET 
 /buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_slug>/<question_id>
POST 
 /buyers/frameworks/<framework_slug>/requirements/<lot_slug>/<brief_id>/edit/<section_id>/<question_id>
```

I checked across apps and everywhere else (supplier and admin apps) we use `section_id` as a parameter rather than `section_slug`, so I went with keeping `section_id` for the views here.