### PR TITLE
Bugfixes for G-Cloud search

### DIFF
--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -4,8 +4,9 @@ from math import ceil
 from werkzeug.datastructures import MultiDict
 
 
-def get_lot_from_request(request):
-    return request.args.get('lot', None)
+def get_lot_from_request(request, all_lots):
+    lot = request.args.get('lot', None)
+    return lot if (not lot or lot in all_lots) else None
 
 
 def get_keywords_from_request(request):

--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -50,7 +50,7 @@ def allowed_request_lot_filters(lot_filters):
     return filters
 
 
-def clean_request_args(request_args, lot_filters, lots_by_slug):
+def clean_request_args(request_args, lot_filters, lots_by_slug, for_aggregation=False):
     """Removes any unknown args keys or values from request.
 
     Compares every key/value pair from request query parameters
@@ -68,12 +68,17 @@ def clean_request_args(request_args, lot_filters, lots_by_slug):
         if f in allowed_filters
     ])
 
-    for key in ['q', 'page']:
-        if request_args.get(key):
-            clean_args[key] = request_args[key]
+    restore_keys = ['q']
 
-    if request_args.get('lot') in lots_by_slug.keys():
-        clean_args['lot'] = request_args.get('lot')
+    if not for_aggregation:
+        restore_keys.append('page')
+
+    if request_args.get('lot') in lots_by_slug:
+        restore_keys.append('lot')
+
+    for key in restore_keys:
+        if request_args.get(key):
+            clean_args[key] = request_args.get(key)
 
     return clean_args
 
@@ -135,7 +140,7 @@ def get_filter_value_from_question_option(option):
     return (option.get('value') or option.get('label', '')).lower().replace(',', '')
 
 
-def build_search_query(request_args, lot_filters, content_builder, lots_by_slug):
+def build_search_query(request_args, lot_filters, content_builder, lots_by_slug, for_aggregation=False):
     """Match request args with known filters.
 
     Removes any unknown query parameters, and will only keep `page`, `q`
@@ -148,7 +153,8 @@ def build_search_query(request_args, lot_filters, content_builder, lots_by_slug)
     query = clean_request_args(
         request_args,
         lot_filters,
-        lots_by_slug
+        lots_by_slug,
+        for_aggregation=for_aggregation
     )
 
     if 'q' in query:

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -302,7 +302,7 @@ def _annotate_categories_with_selection(lot_slug, category_filters, request, url
                                                                   keys_to_remove,
                                                                   lot_slug=lot_slug,
                                                                   category=category,
-                                                                  parent_category=request.values.get('parentCategory'))
+                                                                  parent_category=parent_category)
             category['link'] = search_link_builder(url_args)
 
     # When there's a selection, and the selected category has children, remove sibling subcategories,

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -186,7 +186,7 @@ def build_lots_and_categories_link_tree(framework, lots, category_filter_group, 
     :param content_manifest: a ContentManifest instance for G-Cloud search_filters.
     :return: list of selected category and lot filters, starting with the 'all categories' root node node
     """
-    current_lot_slug = get_lot_from_request(request)
+    current_lot_slug = get_lot_from_request(request, [lot['slug'] for lot in lots])
 
     # Links in the tree should preserve all the filters, except those relating to this tree (i.e. lot
     # and category).

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -131,7 +131,8 @@ def _get_aggregations_for_lot_with_filters(lot, content_manifest, framework, req
                                                                   **build_search_query(aggregate_request_args,
                                                                                        filters.values(),
                                                                                        content_manifest,
-                                                                                       lots_by_slug))
+                                                                                       lots_by_slug,
+                                                                                       for_aggregation=True))
 
     return AggregationResults(aggregate_api_response)
 

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -204,9 +204,13 @@ def build_lots_and_categories_link_tree(framework, lots, category_filter_group, 
     root_node['children'] = list()
     selected_filters.append(root_node)
 
+    # If we're searching against a specific lot, we should only build the tree for that lot.
+    if current_lot_slug:
+        lots = list(filter(lambda lot: lot['slug'] == current_lot_slug, lots))
+
     aggregations_by_lot = {lot['slug']: _get_aggregations_for_lot_with_filters(lot['slug'], content_manifest,
                                                                                framework, request)
-                           for lot in framework['lots']}
+                           for lot in lots}
 
     for lot in lots:
         selected_categories = []

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -156,8 +156,9 @@ def search_services():
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
     framework = framework_helpers.get_latest_live_framework(all_frameworks, 'g-cloud')
 
-    current_lot_slug = get_lot_from_request(request)
     lots_by_slug = framework_helpers.get_lots_by_slug(framework)
+
+    current_lot_slug = get_lot_from_request(request, lots_by_slug)
 
     # the bulk of the possible filter parameters are defined through the content loader. they're all boolean and the
     # search api uses the same "question" labels as the content for its attributes, so we can really use those labels

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -436,6 +436,19 @@ class TestSearchResults(BaseApplicationTest):
             category_name, number_of_services = category_matcher.match(category.text_content()).groups()
             assert expected_lot_counts[category_name] == int(number_of_services)
 
+    def test_search_results_subcategory_links_include_parent_category_param(self):
+        self._search_api_client.search_services.return_value = self.g9_search_results
+
+        res = self.client.get('/g-cloud/search?lot=cloud-software&serviceCategories=accounting+and+finance')
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        categories_anchors = document.xpath('//div[@class="lot-filters"]//ul[@class="lot-filters--last-list"]//li/a')
+
+        for category_anchor in categories_anchors:
+            assert 'parentCategory=accounting+and+finance' in category_anchor.get('href')
+
     def test_lot_links_retain_all_category_filters(self):
         self._search_api_client.search_services.return_value = self.g9_search_results
 

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -349,6 +349,19 @@ class TestSearchResults(BaseApplicationTest):
         res = self.client.get('/g-cloud/search?lot=cloud-hosting&page=potato')
         assert res.status_code == 404
 
+    def test_search_results_with_invalid_lot_fall_back_to_all_categories(self):
+        self._search_api_client.search_services.return_value = self.g9_search_results
+
+        res = self.client.get('/g-cloud/search?lot=bad-lot-slug')
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        lots = document.xpath('//div[@class="lot-filters"]//ul[@class="lot-filters--last-list"]//li/a')
+        assert lots[0].text_content().startswith('Cloud hosting')
+        assert lots[1].text_content().startswith('Cloud software')
+        assert lots[2].text_content().startswith('Cloud support')
+
     def test_search_results_show_aggregations_by_lot(self):
         self._search_api_client.search_services.return_value = self.g9_search_results
 

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -401,6 +401,17 @@ class TestSearchResults(BaseApplicationTest):
 
         assert self._search_api_client_presenters.aggregate_services.call_count == call_count
 
+    def test_search_results_sends_aggregation_request_without_page_filter(self):
+        self._search_api_client.search_services.return_value = self.g9_search_results
+
+        res = self.client.get('/g-cloud/search?page=2')
+        assert res.status_code == 200
+
+        self._search_api_client_presenters.aggregate_services.assert_called_with(
+            lot='cloud-support',
+            aggregations={'serviceCategories', 'lot'}
+        )
+
     def test_search_results_does_not_show_aggregation_for_lot_or_parent_category_if_child_selected(self):
         self._search_api_client.search_services.return_value = self.g9_search_results
 


### PR DESCRIPTION
## Summary
Three bugfixes and one optimisation for G-Cloud search. It's probably best to review these per-commit as they should be self-contained that way.

1) Page 2 on DM shows zero results for service aggregations
2) Searching with an invalid lot shows broken links
3) Subcategories no longer pass the parentCategory query param.
4) Reduce the number of search-api aggregation calls when a lot has already been selected.

## Ticket
https://trello.com/c/WPzIXFIk/557-bug-category-links-g8-services-pagination-and-parent-categories