### PR TITLE
Bug fix for search result highlighting

### DIFF
--- a/app/main/presenters/search_results.py
+++ b/app/main/presenters/search_results.py
@@ -23,10 +23,11 @@ class SearchResults(object):
 
     def _add_highlighting(self, service):
         if 'highlight' in service:
-            if 'serviceSummary' in service['highlight']:
-                service['serviceSummary'] = Markup(
-                    ''.join(service['highlight']['serviceSummary'])
-                )
+            for highlighted_field in ['serviceSummary', 'serviceDescription']:
+                if highlighted_field in service['highlight']:
+                    service[highlighted_field] = Markup(
+                        ''.join(service['highlight'][highlighted_field])
+                    )
 
 
 class AggregationResults(object):


### PR DESCRIPTION
## Summary
Brings back search result highlighting in the G-Cloud catalogue; lost due to the serviceDescription/serviceSummary key duplication.

## Old (digitalmarketplace.service.gov.uk)
<img width="1186" alt="screen shot 2017-06-27 at 11 21 05" src="https://user-images.githubusercontent.com/2920760/27582994-db2fa112-5b2a-11e7-9631-226c54a5f668.png">

## New (localhost)
<img width="1094" alt="screen shot 2017-06-27 at 11 21 11" src="https://user-images.githubusercontent.com/2920760/27583000-def1bd6c-5b2a-11e7-8d58-be8c9cc5d15b.png">

## Ticket
N/A