### PR TITLE
Preserve line breaks for textarea formatted text

### DIFF
--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -33,7 +33,9 @@
     ) %}
       {% call summary.row() %}
         {{ summary.field_name(item.label) }}
-        {{ summary[item.type](item.value) | format_links}}
+        {% with item_value = summary[item.type](item.value) | format_links %}
+            {{ (item_value | preserve_line_breaks) if item.type == 'textbox_large' else item_value }}
+        {% endwith %}
       {% endcall %}
     {% endcall %}
 {% endfor %}

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -25,9 +25,9 @@
   {% call summary.row() %}
     {% call summary.field(first=True, wide=False) -%}
       <span aria-label="question">{{ question.number }}.</span>
-      {{ question.question }}
+      {{ question.question | preserve_line_breaks }}
     {%- endcall %}
-    {{ summary.text(question.answer | format_links) }}
+    {{ summary.text(question.answer | format_links | preserve_line_breaks) }}
   {% endcall %}
 {% endcall %}
 

--- a/app/templates/_service_attributes.html
+++ b/app/templates/_service_attributes.html
@@ -12,8 +12,9 @@
       {% if not question.is_empty %}
         {% call summary.row() %}
           {{ summary.field_name(question.label) }}
-          {{ summary[question.type](question.filter_value|capitalize_first, question.assurance) }}
-
+          {% with item_value = summary[question.type](question.filter_value|capitalize_first, question.assurance) %}
+            {{ (item_value | preserve_line_breaks) if question.type == 'textbox_large' else item_value }}
+          {% endwith %}
         {% endcall %}
       {% endif %}
     {% endcall %}

--- a/app/templates/_service_summary_features_and_benefits.html
+++ b/app/templates/_service_summary_features_and_benefits.html
@@ -1,4 +1,4 @@
-<p class="service-summary-lede">{{ service.serviceSummary or service.serviceDescription }}</p> {# G-Cloud 9 uses serviceDescription, not serviceSummary. #}
+<p class="service-summary-lede">{{ (service.serviceSummary or service.serviceDescription) | preserve_line_breaks }}</p> {# G-Cloud 9 uses serviceDescription, not serviceSummary. #}
 {% if service.features %}
 <h2 class="service-summary-heading">Features</h2>
 <ul class="service-summary-features-and-benefits">

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ unicodecsv==0.14.1
 werkzeug==0.10.4
 odfpy==1.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@26.2.1#egg=digitalmarketplace-utils==26.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.0#egg=digitalmarketplace-utils==27.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.0#egg=digitalmarketplace-apiclient==8.10.0


### PR DESCRIPTION
We're going to allow newline formatting for `textbox_large` content submitted to us and displayed back to users.

In this pull request, we're allowing newlines in:

- textbox_large areas of individual brief pages
  (brief summary, workplace description, etc.)
- clarification questions and answers for briefs
- textbox_large areas of individual G8/G9 service pages
  (includes most of the follow-up questions)

Where we can, we're checking if the question type is `textbox_large` before applying the filter. But on the brief questions and answers, for example, we don't have a question object to inspect -- only a list of strings. We know they're all textbox large questions anyway, so there we just use the filter without checking.

We are *not* adding this to search results because search result rankings are a competitive space and we don't want there to be an incentive to create very large service summaries and/or brief descriptions.

## example

This example is a lot like [the one in the briefs app](https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/5), but here we also have a search result page.

### with this json 

```json
  {"summary": "As Engagement Lead, you will:\r\n\r\n* Lead on DAS engagement  and 
    DAS stakeholder engagement requirements with stakeholders and as part of the 
    multidisciplinary delivery team.\r\n\r\n* Create briefing and communications 
    materials for inter-team and cross-government engagement\r\n\r\n* Represent needs 
    of stakeholders and communications activity in the DAS senior management team"
  }
```
<sub>ie, [Engagement Lead](https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/127)</sub>

| before & after |
|--------|
| ![screen shot 2017-07-03 at 14 32 57](https://user-images.githubusercontent.com/2454380/27795567-8b7ef338-5ffe-11e7-9959-bd581d36dbed.png) |


| search results are _not_ formatted |
|--------|
| ![screen shot 2017-07-03 at 14 33 24](https://user-images.githubusercontent.com/2454380/27795584-a19cd50e-5ffe-11e7-92dc-4a09f31c2f72.png) |