### PR TITLE
Flash messages move

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -23,6 +23,7 @@
   {% block breadcrumb %}{% endblock %}
   <div id="wrapper">
     <main id="content" role="main">
+      {% include "toolkit/flash_messages.html" %}
       {% block main_content %}
       {% endblock %}
     </main>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -4,47 +4,6 @@
 
 {% block main_content %}
 
-{% with messages = get_flashed_messages(with_categories=true) %}
-{% if messages %}
-{% for category, message in messages %}
-    {% if category == 'error' %}
-      <div class="banner-destructive-without-action">
-    {% elif category != 'must_login' %}
-      <div class="banner-success-without-action">
-    {% endif %}
-            {% if message == 'no_account' %}
-              <p class="banner-message">
-                Make sure you've entered the right email address and password.
-                Accounts are locked after 5 failed attempts. If you think your
-                account has been locked, email
-                <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.
-              </p>
-            {% elif message == 'password_updated' %}
-              <p class="banner-message">
-                You have successfully changed your password.
-              </p>
-            {% elif message == 'password_not_updated' %}
-              <p class="banner-message">
-                Could not update password due to an error.
-              </p>
-            {% elif message == 'supplier-role-required' %}
-              <p class="banner-message">
-                You must log in with a supplier account to see this page.
-              </p>
-            {% elif message == 'buyer-role-required' %}
-              <p class="banner-message">
-                  You must log in with a buyer account to see this page.
-              </p>
-            {% elif category != 'must_login' %}
-              {{ message }}
-            {% endif %}
-    {% if category != 'must_login' %}
-      </div>
-    {% endif %}
-{% endfor %}
-{% endif %}
-{% endwith %}
-
 {% if form.errors|length > 1 %}
     <div class="validation-masthead" aria-labelledby="validation-masthead-heading">
         <h3 class="validation-masthead-heading" id="validation-masthead-heading">

--- a/app/templates/auth/request-password-reset.html
+++ b/app/templates/auth/request-password-reset.html
@@ -4,31 +4,6 @@
 
 {% block main_content %}
 
-{% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-        {% for category, message in messages %}
-            {% if category == 'error' %}
-                <div class="banner-destructive-without-action">
-            {% else %}
-                <div class="banner-success-without-action">
-            {% endif %}
-                    <p class="banner-message">
-                        {% if message == 'email_sent' %}
-                        If the email address you've entered belongs to a Digital Marketplace account,
-                        we'll send a link to reset the password.
-
-                        {% elif message == 'token_expired' or message == 'token_invalid' %}
-                        This password reset link has expired. Enter your email address and we’ll send you a new one.
-                        Password reset links are only valid for 24 hours.
-                        {% else %}
-                        {{ message }}
-                        {% endif %}
-                    </p>
-                </div>
-        {% endfor %}
-    {% endif %}
-{% endwith %}
-
 <header class="page-heading">
     <h1>Reset password</h1>
 </header>

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.5",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.6.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.5.4"
   }

--- a/tests/main/views/test_login.py
+++ b/tests/main/views/test_login.py
@@ -9,20 +9,19 @@ from lxml import html, cssselect
 import mock
 import pytest
 
+from app.main.views import login
+
+
 EMAIL_EMPTY_ERROR = "You must provide an email address"
 EMAIL_INVALID_ERROR = "You must provide a valid email address"
-EMAIL_SENT_MESSAGE = "If the email address you've entered belongs to a Digital Marketplace account, we'll send a link to reset the password."  # noqa
 PASSWORD_EMPTY_ERROR = "You must provide your password"
 PASSWORD_INVALID_ERROR = "Passwords must be between 10 and 50 characters"
 PASSWORD_MISMATCH_ERROR = "The passwords you entered do not match"
-NEW_PASSWORD_SUCCESS = "You have successfully changed your password"
-NEW_PASSWORD_FAIL = "Could not update password due to an error"
 NEW_PASSWORD_EMPTY_ERROR = "You must enter a new password"
 NEW_PASSWORD_CONFIRM_EMPTY_ERROR = "Please confirm your new password"
 
 PASSWORD_RESET_EMAIL_ERROR = "Failed to send password reset."
 
-TOKEN_CREATED_BEFORE_PASSWORD_LAST_CHANGED_ERROR = "This password reset link has expired."
 USER_LINK_EXPIRED_ERROR = "The link you used to create an account may have expired."
 
 
@@ -262,7 +261,7 @@ class TestResetPassword(BaseApplicationTest):
         }, follow_redirects=True)
         assert res.status_code == 200
         content = self.strip_all_whitespace(res.get_data(as_text=True))
-        assert self.strip_all_whitespace(EMAIL_SENT_MESSAGE) in content
+        assert self.strip_all_whitespace(login.EMAIL_SENT_MESSAGE) in content
 
     @mock.patch('app.main.views.login.send_email')
     def test_should_strip_whitespace_surrounding_reset_password_email_address_field(self, send_email):
@@ -362,7 +361,7 @@ class TestResetPassword(BaseApplicationTest):
             assert res.location == 'http://localhost/login'
             res = self.client.get(res.location)
 
-            assert NEW_PASSWORD_SUCCESS in res.get_data(as_text=True)
+            assert login.PASSWORD_UPDATED_MESSAGE in res.get_data(as_text=True)
 
     def test_password_change_unknown_failure(self):
         self.data_api_client_mock.update_user_password.return_value = False
@@ -381,7 +380,7 @@ class TestResetPassword(BaseApplicationTest):
             assert res.location == 'http://localhost/login'
             res = self.client.get(res.location)
 
-            assert NEW_PASSWORD_FAIL in res.get_data(as_text=True)
+            assert login.PASSWORD_NOT_UPDATED_MESSAGE in res.get_data(as_text=True)
         self.data_api_client_mock.update_user_password.return_value = True
 
     def test_should_not_strip_whitespace_surrounding_reset_password_password_field(self):
@@ -423,7 +422,7 @@ class TestResetPassword(BaseApplicationTest):
             error_selector = cssselect.CSSSelector('div.banner-destructive-without-action')
             error_elements = error_selector(document)
             assert len(error_elements) == 1
-            assert TOKEN_CREATED_BEFORE_PASSWORD_LAST_CHANGED_ERROR in error_elements[0].text_content()
+            assert login.BAD_TOKEN_MESSAGE in error_elements[0].text_content()
 
     @mock.patch('app.main.views.login.send_email')
     def test_should_call_send_email_with_correct_params(


### PR DESCRIPTION
Move flash messages into single location for sharing between apps.

 - we want to be able to set flash messages from anywhere;
 - therefore this needs to be centralised, despite therefore various login-related messages now appearing in a general template;
 - potential for further refactoring to remove the 'named messages' concept, e.g. the message text should constants in the app.main.views.login module.
 - added some tests for login messages that were not already tested.

https://trello.com/c/Uak7y047/8-feedback-forms

See also https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/355