### PR TITLE
Pull in latest frameworks

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,6 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.4.5",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.5.4"
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.8.0"
   }
 }

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -216,15 +216,15 @@ class TestSearchResults(BaseApplicationTest):
         self._search_api_client.search_services.return_value = return_value
 
         res = self.client.get(
-            '/g-cloud/search?q=email&lot=cloud-software&phoneSupport=true&supportAvailableToThirdParty=true')
+            '/g-cloud/search?q=email&lot=cloud-software&phoneSupport=true&onsiteSupport=yes')
         assert res.status_code == 200
         summary = find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found' \
             ' containing <em>email</em> in' \
             ' <em>Cloud software</em>' in summary
         assert ' where user support is available ' in summary
-        assert 'that <em>can be used by third parties</em>' in summary
         assert 'by <em>phone</em>' in summary
+        assert 'through <em>onsite support</em>' in summary
 
     def test_should_render_summary_with_a_group_of_1_array_filter(self):
         return_value = self.search_results_multiple_page


### PR DESCRIPTION
## Summary
Pull in frameworks 8.8.0 (https://github.com/alphagov/digitalmarketplace-frameworks/pull/458) which removes some G-Cloud filters.