### PR TITLE
Implement filter-on-click

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,8 @@
 //= include ../../../bower_components/jquery/dist/jquery.js
 //= include ../../../bower_components/hogan/web/builds/3.0.2/hogan-3.0.2.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/option-select.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/support.js
+//= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/live-search.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
 //= include ../../../bower_components/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -86,15 +86,16 @@ def set_filter_states(filter_groups, request):
     request_filters = get_filters_from_request(request)
 
     for filter_group in filter_groups:
-        for filter in filter_group['filters']:
-            filter['checked'] = False
+        for filter_item in filter_group['filters']:
+            filter_item['checked'] = False
+
             param_values = request_filters.getlist(
-                filter['name'],
+                filter_item['name'],
                 type=str
             )
             if len(param_values) > 0:
-                filter['checked'] = (
-                    filter['value'] in param_values
+                filter_item['checked'] = (
+                    filter_item['value'] in param_values
                 )
 
 

--- a/app/templates/search/_filters.html
+++ b/app/templates/search/_filters.html
@@ -7,4 +7,4 @@
     {% include "toolkit/forms/option-select.html" %}
   {% endwith %}
 {% endfor %}
-<button class="button-save" type="submit">Filter</button>
+<button class="button-save js-hidden js-dm-live-search" type="submit">Filter</button>

--- a/app/templates/search/_services_categories_wrapper.html
+++ b/app/templates/search/_services_categories_wrapper.html
@@ -1,0 +1,7 @@
+<div id="js-dm-live-search-categories" class="js-dm-live-search-fade">
+  <div class="lot-filters">
+    <h2>Choose a category</h2>
+    {% from 'search/_categories.html' import top_level_link, category_list %}
+    {{ category_list([category_tree_root]) }}
+  </div>
+</div>

--- a/app/templates/search/_services_filters.html
+++ b/app/templates/search/_services_filters.html
@@ -8,11 +8,7 @@
   {% include "toolkit/forms/keyword-search.html" %}
 {% endwith %}
 
-<div class="lot-filters">
-  <h2>Choose a category</h2>
-  {% from 'search/_categories.html' import top_level_link, category_list %}
-  {{ category_list([category_tree_root]) }}
-</div>
+{% include 'search/_services_categories_wrapper.html' %}
 
 {% for f in filter_form_hidden_fields %}
   <input type="hidden" name="{{ f.name }}" value="{{ f.value }}" />

--- a/app/templates/search/_services_results_wrapper.html
+++ b/app/templates/search/_services_results_wrapper.html
@@ -1,0 +1,4 @@
+<div id="js-dm-live-search-results" class="js-dm-live-search-fade">
+  {% include 'search/_services_results.html' %}
+  {% include 'search/_services_pagination.html' %}
+</div>

--- a/app/templates/search/_services_summary.html
+++ b/app/templates/search/_services_summary.html
@@ -1,3 +1,5 @@
-<p class="search-summary">
-  {{ summary }}
-</p>
+<div id="js-dm-live-search-summary">
+  <p class="search-summary">
+    {{ summary }}
+  </p>
+</div>

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -43,16 +43,15 @@
 <header class="page-heading">
         <h1>Search results</h1>
 </header>
-    <div class="grid-row">
-        <section class="column-one-third search-page-filters" aria-label="Search filters">
-            <form action="{{ url_for('.search_services') }}" method="get">
-                {% include 'search/_services_filters.html' %}
-            </form>
-        </section>
-        <section class="column-two-thirds" aria-label="Services found">
-            {% include 'search/_services_summary.html' %}
-            {% include 'search/_services_results.html' %}
-            {% include 'search/_services_pagination.html' %}
-        </section>
-    </div>
+  <div id="js-dm-live-search-wrapper" class="grid-row">
+    <section class="column-one-third search-page-filters" aria-label="Search filters">
+        <form action="{{ url_for('.search_services') }}" method="get" id="js-dm-live-search-form">
+            {% include 'search/_services_filters.html' %}
+        </form>
+    </section>
+    <section class="column-two-thirds" aria-label="Search results">
+      {% include 'search/_services_summary.html' %}
+      {% include 'search/_services_results_wrapper.html' %}
+    </section>
+  </div>
 {% endblock %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.6.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v22.7.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.8.0"
   }


### PR DESCRIPTION
# Summary
Adds filter-on-click functionality to the G-Cloud catalogue. Borrows heavily from the GOV.UK Finder-Frontend, but has been adapted to allow the replacement of an arbitrary set of elements with pre-rendered HTML so that we take advantage of our server-side templating, which does quite a bit of work, especially when rendering the lot/categories links and numbers.

## Details
The frontend-toolkit pattern for this expects the view to detect a `live-results` query parameter, and based on that, switches to returning a JSON blob for all of the dynamic parts of the part. Some refactoring was required to split the dynamic parts into individual templates that can be rendered separately. Other than that refactoring, this just pulls in the new frontend-toolkit and implements the JSON return segment of the G-Cloud search view.

## How to test
Get everything up and running using this PR (no special linking necessary). Navigate to `/g-cloud/search` and play around with the filters and the text search. The page results and related navigation links should all update accordingly.

## Example
![filter on click - high - 640](https://user-images.githubusercontent.com/2920760/28166968-cfd23eca-67d1-11e7-9610-7f8b3a7dcf6f.gif)


## Ticket
https://trello.com/c/SGxQeBdA/502-filter-on-click