### PR TITLE
Ignore incomplete summary manifest

### DIFF
--- a/app/main/presenters/search_summary.py
+++ b/app/main/presenters/search_summary.py
@@ -232,9 +232,10 @@ class SummaryFragment(object):
             return processed_filters
         else:
             for filter in filters:
+                filter_string = _mark_up_filter(filter)
                 if filter in self.rules.filter_rules_ids:
-                    filter_string = _mark_up_filter(filter)
                     filter_string = self.rules.add_filter_preposition(
                         filter_id=filter, filter_string=filter_string)
-                    processed_filters.append(filter_string)
+                processed_filters.append(filter_string)
+
         return processed_filters

--- a/tests/main/presenters/test_search_summary.py
+++ b/tests/main/presenters/test_search_summary.py
@@ -501,6 +501,16 @@ class TestSummaryFragment(object):
             u" or aligned with <em>uptime institute tier 2</em>"
         )
 
+        # now check we can still create a summary if some of the filters are missing from the filter-rules list
+        self.rules_instance_mock.filter_rules_ids = ['uptime institute tier 1']
+        summary_fragment = SummaryFragment(
+            id, filters, self.rules_instance_mock)
+        assert summary_fragment.str() == (
+            u"datacentre tiers <em>TIA-942 Tier 1</em>" +
+            u", met with a <em>uptime institute tier 1</em>" +
+            u" or <em>uptime institute tier 2</em>"
+        )
+
     def test_str_method_works(self):
         id = 'Datacentre tier'
         filters = ['TIA-942 Tier 1']


### PR DESCRIPTION
This PR replaces https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/502

There is a crasher in the buyer frontend when a summary manifest contains an incomplete list of `filterRules` for a given filter group. This change ignores the missing data as suggested in the discussion on PR 502.

The test is tacked onto an existing test, because the setup is quite involved (and I'd probably argue these tests are wrong, because the mocked SummaryRules objects are completely unlike the real ones, but rewriting them is out of scope).