### PR TITLE
Time displayed for closing dates

### DIFF
--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -2,8 +2,8 @@
 {% call(item) summary.list_table(
   [
     {"label": "Published", "value": brief.publishedAt|dateformat},
-    {"label": "Deadline for asking questions", "value": brief.clarificationQuestionsClosedAt|dateformat},
-    {"label": "Closing date for applications", "value": brief.applicationsClosedAt|dateformat}
+    {"label": "Deadline for asking questions", "value": brief.clarificationQuestionsClosedAt|utcdatetimeformat},
+    {"label": "Closing date for applications", "value": brief.applicationsClosedAt|utcdatetimeformat}
   ],
   caption="Important dates",
   field_headings=[

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ unicodecsv==0.14.1
 werkzeug==0.10.4
 odfpy==1.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.1.0#egg=digitalmarketplace-utils==27.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.1#egg=digitalmarketplace-utils==27.2.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.0#egg=digitalmarketplace-apiclient==8.10.0


### PR DESCRIPTION
The clarification question deadline and the application closing date both use a new date filter `utcdatetimeformat` from dmutils (see https://github.com/alphagov/digitalmarketplace-utils/pull/317). 

Closing dates are now shown as "Thursday 12 May 2016 at 11:59pm". If daylight savings time means the localised string would end up being "Friday 13 May 2016 at 12.59am", the new filter will force the timestamp to still display 11.59pm on the correct day, rather than 12.59am on the following day. This might reduce the window by an hour, but will hopefully reduce confusion about dates for the supplier.

Also includes some cleanup on the `test_marketplace` module (caught by Pycharm code inspect).

Ticket: https://trello.com/c/8CJAv25W/714-show-time-opportunity-closes
