### PR TITLE
Dh 552 add a heading above the filters and make the headings consistent

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -76,6 +76,14 @@ em.search-result-highlighted-text {
     }
   }
 
+  .dm-filters {
+
+    .apply-filters-title {
+      margin-bottom: 10px;
+    }
+
+  }
+
   .govuk-option-select {
     margin-bottom: $gutter;
   }

--- a/app/templates/search/_filters.html
+++ b/app/templates/search/_filters.html
@@ -1,10 +1,13 @@
-{% for filter in filters %}
-  {%
-    with
-    label = filter.label,
-    options = filter.filters
-  %}
-    {% include "toolkit/forms/option-select.html" %}
-  {% endwith %}
-{% endfor %}
-<button class="button-save{% if framework_family == 'g-cloud' %} js-hidden js-dm-live-search{% endif %}" type="submit">Filter</button>
+<div class="dm-filters">
+  <h2 class="apply-filters-title">Apply filters</h2>
+  {% for filter in filters %}
+    {%
+      with
+      label = filter.label,
+      options = filter.filters
+    %}
+      {% include "toolkit/forms/option-select.html" %}
+    {% endwith %}
+  {% endfor %}
+  <button class="button-save{% if framework_family == 'g-cloud' %} js-hidden js-dm-live-search{% endif %}" type="submit">Filter</button>
+</div>

--- a/app/templates/search/_services_filters.html
+++ b/app/templates/search/_services_filters.html
@@ -2,7 +2,7 @@
   with
   id = "keywords",
   name = "q",
-  label = "Keywords",
+  label = "Keyword search",
   value = search_keywords
 %}
   {% include "toolkit/forms/keyword-search.html" %}


### PR DESCRIPTION
**Changes**
- Changes wording on Keyword Search from "Keywords" to "Keyword Search".
- Adds in "Apply Filters" header for filters.

Ticket: https://trello.com/c/P7HpqQAU/552-add-a-heading-above-the-filters-and-make-the-headings-consistent