### PR TITLE
bump toolkit version to version 23.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v23.2.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v23.2.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.10.0"
   }


### PR DESCRIPTION
Fixes a bug where link remains focused after clicking.

As a buyer
I need to be able to remove all of the filters I have applied quickly
So that I can improve my search results

Ticket:
https://trello.com/c/IrcO0G3U/491-add-clear-all-filters-link