### PR TITLE
Restore legacy brief start/ continue functionality

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -80,15 +80,16 @@ def get_brief_by_id(framework_framework, brief_id):
         status='draft,submitted'
     ).get('briefResponses')
     started_brief_responses_count = len([response for response in brief_responses if response['status'] == 'draft'])
-    completed_brief_responses_count = len(
-        [response for response in brief_responses if response['status'] == 'submitted']
-    )
+    completed_brief_responses = [response for response in brief_responses if response['status'] == 'submitted']
+    completed_brief_responses_count = len(completed_brief_responses)
 
     if brief['status'] not in ['live', 'closed', 'withdrawn'] or brief['frameworkFramework'] != framework_framework:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
 
     try:
-        has_supplier_responded_to_brief = current_user.supplier_id in [i['supplierId'] for i in brief_responses]
+        has_supplier_responded_to_brief = (
+            current_user.supplier_id in [response['supplierId'] for response in completed_brief_responses]
+        )
     except AttributeError:
         has_supplier_responded_to_brief = False
 

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -513,6 +513,15 @@ class TestBriefPage(BaseBriefPageTest):
 
         self._assert_start_application(document, brief_id)
 
+    def test_apply_button_visible_if_status_is_draft(self):
+        self.brief_responses['briefResponses'][0]['status'] = 'draft'
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+
+        self._assert_start_application(document, brief_id)
+
     def test_cannot_apply_to_closed_brief(self):
         self.brief['briefs']['status'] = "closed"
         self.brief['briefs']['applicationsClosedAt'] = "2016-12-15T11:08:28.054129Z"


### PR DESCRIPTION
Fixes this functional test failure
https://ci.marketplace.team/job/functional-tests-preview/18877/functional_test_report
introduced in 
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/569

We went from considering that a supplier had applied to a brief if they had a _'submitted'_ brief response to considering them applied if they had a _'draft' or 'submitted'_ brief response.

This restored the previous functionality. We only consider a supplier as having applied if they have a _'submitted'_ brief response.

