### PR TITLE
Bump utils version for format_links fix

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,6 +5,6 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.1#egg=digitalmarketplace-utils==27.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.1#egg=digitalmarketplace-utils==27.2.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1
 
@@ -14,16 +14,16 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digi
 asn1crypto==0.22.0
 backoff==1.0.7
 boto3==1.4.4
-botocore==1.5.84
+botocore==1.5.95
 cffi==1.10.0
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
-docutils==0.13.1
+docutils==0.14
 Flask-FeatureFlags==0.6
 Flask-Script==2.0.5
 future==0.16.0
-idna==2.5
+idna==2.6
 inflection==0.2.1
 itsdangerous==0.24
 Jinja2==2.9.6


### PR DESCRIPTION
Bug fix for displaying links in the Brief summary: bumps the utils version to include the bug fix.

See https://github.com/alphagov/digitalmarketplace-utils/pull/321 for details of the `format_link` filter fix for Python3.