### PR TITLE
Skeleton direct award pages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,11 +42,13 @@ def create_app(config_name):
                 content_loader.load_manifest(framework_data['slug'], 'briefs', 'display_brief')
 
     from .main import main as main_blueprint
+    from .main import direct_award as direct_award_blueprint
     from .external.views.external import external as external_blueprint
     from .status import status as status_blueprint
 
     application.register_blueprint(status_blueprint)
     application.register_blueprint(main_blueprint)
+    application.register_blueprint(direct_award_blueprint)
     application.register_blueprint(external_blueprint)
 
     login_manager.login_view = 'main.render_login'

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,6 +1,20 @@
-from flask import Blueprint
+from flask import Blueprint, flash, Markup, current_app
+from flask_login import login_required, current_user
+import flask_featureflags
 
 main = Blueprint('main', __name__)
+direct_award = Blueprint('direct_award', __name__, url_prefix='/buyers/direct-award')
+
+LOGIN_REQUIRED_MESSAGE = Markup("""You must log in with a buyer account to see this page.""")
+
+
+@direct_award.before_request
+@flask_featureflags.is_active_feature('DIRECT_AWARD_PROJECTS')
+@login_required
+def require_login():
+    if current_user.is_authenticated() and current_user.role != 'buyer':
+        flash(LOGIN_REQUIRED_MESSAGE, 'error')
+        return current_app.login_manager.unauthorized()
 
 from . import errors
 from .views import (

--- a/app/main/helpers/direct_award_helpers.py
+++ b/app/main/helpers/direct_award_helpers.py
@@ -1,0 +1,2 @@
+def is_direct_award_project_accessible(project, user_id):
+    return any([user['id'] == user_id for user in project['users']])

--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -170,8 +170,7 @@ def get_filter_value_from_question_option(option):
     return (option.get('value') or option.get('label', '')).lower().replace(',', '')
 
 
-def build_search_query(framework, request_args, lot_filters, content_builder, lots_by_slug,
-                       for_aggregation=False):
+def build_search_query(request_args, lot_filters, content_builder, lots_by_slug, for_aggregation=False):
     """Match request args with known filters.
 
     Removes any unknown query parameters, and will only keep `page`, `q`
@@ -188,13 +187,7 @@ def build_search_query(framework, request_args, lot_filters, content_builder, lo
         for_aggregation=for_aggregation
     )
 
-    if 'q' in query:
-        query['q'] = replace_g5_search_dots(query['q'])
-
-    params = group_request_filters(query, content_builder)
-    params.update({'index': framework['slug']})
-
-    return params
+    return group_request_filters(query, content_builder)
 
 
 def query_args_for_pagination(args):

--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -138,6 +138,25 @@ def group_request_filters(request_filters, content_builder):
     return filter_query
 
 
+def ungroup_request_filters(request_filters, content_builder):
+    """Carries out the inverse of the above method which is required when going from search api url parameters
+    to frontend url parameters. Where group_request_filters takes request_filters as a MultiDict, this method
+    takes request_filters as a tuple of tuple pairs ((param_name, param_value), ...)"""
+    filter_query = []
+
+    for key, value in request_filters:
+        if is_radio_type(content_builder, key):
+            if ',' in value:
+                for value in value.split(','):
+                    filter_query.append((key, value))
+            else:
+                filter_query.append((key, value))
+        else:
+            filter_query.append((key, value))
+
+    return tuple(filter_query)
+
+
 def is_radio_type(content_builer, key):
     if key == 'lot':
         return True

--- a/app/main/helpers/shared_helpers.py
+++ b/app/main/helpers/shared_helpers.py
@@ -1,7 +1,4 @@
-try:
-    from urlparse import urlparse, parse_qs
-except ImportError:
-    from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
 
 def parse_link(links, label):
@@ -13,3 +10,20 @@ def get_one_framework_by_status_in_order_of_preference(frameworks, statuses_in_o
         for framework in frameworks:
             if framework.get('status') == status:
                 return framework
+
+
+def construct_url_from_base_and_params(base_url, query_params):
+    """
+    Combine a base url (MUST NOT HAVE ANY QUERY PARAMS TO BE RETAINED) with supplied query params
+    :param base_url: A url e.g. http://localhost
+    :param query_params: A tuple of key/value tuples ((param_name, param_val), ...)
+    :return: A url with the query params inline e.g. http://localhost?param_name=param_val
+    """
+    # urlparse breaks a URL into six items (scheme, netloc, path, params, query, fragment)
+    parsed_url = list(urlparse(base_url))
+
+    # We want to use all existing segments except the current query params (5th item), which we'll overwrite.
+    parsed_url[4] = urlencode(query_params)
+
+    # Reconstruct the full URL with inline params from our six-item iterable
+    return urlunparse(parsed_url)

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -129,9 +129,9 @@ def _get_aggregations_for_lot_with_filters(lot, content_manifest, framework, req
 
     aggregate_request_args['lot'] = lot
 
-    aggregate_api_response = search_api_client.aggregate_services(aggregations=aggregate_on_fields,
-                                                                  **build_search_query(framework,
-                                                                                       aggregate_request_args,
+    aggregate_api_response = search_api_client.aggregate_services(index=framework['slug'],
+                                                                  aggregations=aggregate_on_fields,
+                                                                  **build_search_query(aggregate_request_args,
                                                                                        filters.values(),
                                                                                        content_manifest,
                                                                                        lots_by_slug,

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from flask import abort, render_template, request, redirect, current_app, url_for, flash, Markup
 from flask_login import current_user
-import flask_featureflags
 from werkzeug.datastructures import MultiDict
 
 from dmutils.formats import dateformat
@@ -351,7 +350,7 @@ def view_project(framework_framework, project_id):
     lots_by_slug = framework_helpers.get_lots_by_slug(framework)
 
     # Get the requested Direct Award Project.
-    project = data_api_client.get_direct_award_project(user_id=current_user.id, project_id=project_id)['project']
+    project = data_api_client.get_direct_award_project(project_id=project_id)['project']
     if not is_direct_award_project_accessible(project, current_user.id):
         abort(404)
 

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -29,12 +29,12 @@
   </header>
   <p>{{ search_summary.markup() }}</p>
   <div class="grid-row">
-    <form method="post" action="{{ url_for('direct_award.project_create') }}">
+    <form method="post" action="{{ url_for('direct_award.project_create', framework_framework=framework_framework) }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
       <input type="hidden" name="search_api_url" value="{{ search_api_url }}"/>
       {%
         with
-        question = "Name a new procurement project",
+        question = "Name a new project",
         name = "project_name"
       %}
         {% include "toolkit/forms/textbox.html" %}

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -1,0 +1,52 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Save your search - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with
+    items = [
+      {
+          "link": url_for('main.index'),
+          "label": "Digital Marketplace"
+      },
+      {
+          "label": "Save your search"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="index-page">
+  <header class="page-heading">
+    <h1>
+      Save your search
+    </h1>
+  </header>
+  <p>{{ search_summary.markup() }}</p>
+  <div class="grid-row">
+    <form method="post" action="{{ url_for('direct_award.project_create') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <input type="hidden" name="search_api_url" value="{{ search_api_url }}"/>
+      {%
+        with
+        question = "Name a new procurement project",
+        name = "project_name"
+      %}
+        {% include "toolkit/forms/textbox.html" %}
+      {% endwith %}
+      {%
+        with
+        type = "save",
+        label = "Create project and save search"
+      %}
+        {% include "toolkit/button.html" %}
+      {% endwith %}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -1,0 +1,40 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Save your search - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with
+    items = [
+      {
+          "link": url_for('main.index'),
+          "label": "Digital Marketplace"
+      },
+      {
+          "link": url_for('external.buyer_dashboard'),
+          "label": "View your account"
+      },
+      {
+          "label": project_name
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="index-page">
+  <header class="page-heading">
+    <h1>
+      Project - {{ project_name }}
+    </h1>
+  </header>
+  <div class="grid-row">
+    <p>{{ search_summary }}</p>
+    <p>{{ search_created_at|utcdatetimeformat}}</p>
+    <a href="{{ search_page_url }}">View your search</a>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Save your search - Digital Marketplace{% endblock %}
+{% block page_title %}project_name - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -33,7 +33,7 @@
   </header>
   <div class="grid-row">
     <p>{{ search_summary }}</p>
-    <p>{{ search_created_at|utcdatetimeformat}}</p>
+    <p>{{ search_created_at|utcdatetimeformat }}</p>
     <a href="{{ search_page_url }}">View your search</a>
   </div>
 </div>

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -46,7 +46,12 @@
   <div id="js-dm-live-search-wrapper" class="grid-row">
     <section class="column-one-third search-page-filters" aria-label="Search filters">
         <form action="{{ url_for('.search_services') }}" method="get" id="js-dm-live-search-form">
-            {% include 'search/_services_filters.html' %}
+          {% if show_save_button %}
+            <button id="save-search" class="button-save" role="button" type="submit" formaction="{{ url_for('direct_award.save_search') }}" style="text-align:center; margin-left:auto; margin-right: auto;">
+              Save your search
+            </button>
+          {% endif %}
+          {% include 'search/_services_filters.html' %}
         </form>
     </section>
     <section class="column-two-thirds" aria-label="Search results">

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -46,8 +46,8 @@
   <div id="js-dm-live-search-wrapper" class="grid-row">
     <section class="column-one-third search-page-filters" aria-label="Search filters">
         <form action="{{ url_for('.search_services') }}" method="get" id="js-dm-live-search-form">
-          {% if show_save_button %}
-            <button id="save-search" class="button-save" role="button" type="submit" formaction="{{ url_for('direct_award.save_search') }}" style="text-align:center; margin-left:auto; margin-right: auto;">
+          {% if 'DIRECT_AWARD_PROJECTS' is active_feature %}
+            <button id="save-search" class="button-save" role="button" type="submit" formaction="{{ url_for('direct_award.save_search', framework_framework=framework_family) }}" style="text-align:center; margin-left:auto; margin-right: auto;">
               Save your search
             </button>
           {% endif %}

--- a/config.py
+++ b/config.py
@@ -64,6 +64,7 @@ class Config(object):
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = False
+    FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = False
 
     # LOGGING
     DM_LOG_LEVEL = 'DEBUG'
@@ -117,6 +118,7 @@ class Test(Config):
     SECRET_KEY = "KEY"
 
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
+    FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = enabled_since('2017-08-15')
 
 
 class Development(Config):
@@ -135,6 +137,7 @@ class Development(Config):
     SHARED_EMAIL_KEY = "very_secret"
 
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
+    FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = enabled_since('2017-08-15')
 
 
 class Live(Config):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.0.0#egg=digitalmarketplace-apiclient==9.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.2.0#egg=digitalmarketplace-apiclient==9.2.0

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.2.0#egg=digitalmarketplace-apiclient==9.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.0.0#egg=digitalmarketplace-apiclient==10.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.0.0#egg=digitalmarketplace-apiclient==9.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.2.0#egg=digitalmarketplace-apiclient==9.2.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.2.0#egg=digitalmarketplace-apiclient==9.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.0.0#egg=digitalmarketplace-apiclient==10.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.22.0

--- a/tests/fixtures/direct_award_project_fixture.json
+++ b/tests/fixtures/direct_award_project_fixture.json
@@ -1,0 +1,18 @@
+{
+  "project": {
+    "active": true,
+    "createdAt": "2017-08-29T07:49:26.677778Z",
+    "id": 1,
+    "lockedAt": null,
+    "name": "My procurement project",
+    "users": [
+      {
+        "active": true,
+        "email": "buyer@example.com@",
+        "id": 123,
+        "name": "A Buyer",
+        "role": "buyer"
+      }
+    ]
+  }
+}

--- a/tests/fixtures/direct_award_project_fixture.json
+++ b/tests/fixtures/direct_award_project_fixture.json
@@ -8,7 +8,7 @@
     "users": [
       {
         "active": true,
-        "email": "buyer@example.com@",
+        "email": "buyer@example.com",
         "id": 123,
         "name": "A Buyer",
         "role": "buyer"

--- a/tests/fixtures/direct_award_project_searches_fixture.json
+++ b/tests/fixtures/direct_award_project_searches_fixture.json
@@ -6,7 +6,7 @@
       "createdBy": 10000,
       "id": 1,
       "projectId": 1,
-      "searchUrl": "http://search-api.digitalmarketplace.service.gov.uk/g-cloud/services/search?q=accelerator",
+      "searchUrl": "http://search-api.digitalmarketplace.service.gov.uk/g-cloud-9/services/search?q=accelerator",
       "searchedAt": null
     },
     {
@@ -15,7 +15,7 @@
       "createdBy": 10000,
       "id": 2,
       "projectId": 1,
-      "searchUrl": "http://search-api.digitalmarketplace.service.gov.uk/g-cloud/services/search?q=accelerating",
+      "searchUrl": "http://search-api.digitalmarketplace.service.gov.uk/g-cloud-9/services/search?q=accelerating",
       "searchedAt": null
     },
     {
@@ -24,7 +24,7 @@
       "createdBy": 10000,
       "id": 3,
       "projectId": 1,
-      "searchUrl": "http://search-api.digitalmarketplace.service.gov.uk/g-cloud/services/search?q=accelerated",
+      "searchUrl": "http://search-api.digitalmarketplace.service.gov.uk/g-cloud-9/services/search?q=accelerated",
       "searchedAt": null
     }
   ]

--- a/tests/fixtures/direct_award_project_searches_fixture.json
+++ b/tests/fixtures/direct_award_project_searches_fixture.json
@@ -1,0 +1,31 @@
+{
+  "searches": [
+    {
+      "active": true,
+      "createdAt": "2017-08-29T07:00:02.000000Z",
+      "createdBy": 10000,
+      "id": 1,
+      "projectId": 1,
+      "searchUrl": "http://search-api.digitalmarketplace.service.gov.uk/g-cloud/services/search?q=accelerator",
+      "searchedAt": null
+    },
+    {
+      "active": false,
+      "createdAt": "2017-08-29T07:00:01.000000Z",
+      "createdBy": 10000,
+      "id": 2,
+      "projectId": 1,
+      "searchUrl": "http://search-api.digitalmarketplace.service.gov.uk/g-cloud/services/search?q=accelerating",
+      "searchedAt": null
+    },
+    {
+      "active": false,
+      "createdAt": "2017-08-29T07:00:00.000000Z",
+      "createdBy": 10000,
+      "id": 3,
+      "projectId": 1,
+      "searchUrl": "http://search-api.digitalmarketplace.service.gov.uk/g-cloud/services/search?q=accelerated",
+      "searchedAt": null
+    }
+  ]
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -144,6 +144,14 @@ class BaseApplicationTest(object):
             'suppliers_by_prefix_fixture_page_with_next_and_prev.json')
 
     @staticmethod
+    def _get_direct_award_project_fixture():
+        return BaseApplicationTest._get_fixture_data('direct_award_project_fixture.json')
+
+    @staticmethod
+    def _get_direct_award_project_searches_fixture():
+        return BaseApplicationTest._get_fixture_data('direct_award_project_searches_fixture.json')
+
+    @staticmethod
     def _strip_whitespace(whitespace_in_this):
         return re.sub(r"\s+", "",
                       whitespace_in_this, flags=re.UNICODE)
@@ -184,15 +192,15 @@ class BaseApplicationTest(object):
             login_api_client.authenticate_user.assert_called_once_with(
                 "valid@email.com", "1234567890")
 
-    def login_as_buyer(self):
+    def login_as_buyer(self, user_id=123):
         with patch('app.main.views.login.data_api_client') as login_api_client:
             login_api_client.authenticate_user.return_value = self.user(
-                123, "buyer@email.com", None, None, 'Name')
+                user_id, "buyer@email.com", None, None, 'Name')
 
             self.get_user_patch = patch.object(
                 data_api_client,
                 'get_user',
-                return_value=self.user(123, "buyer@email.com", None, None, 'Some Buyer')
+                return_value=self.user(user_id, "buyer@email.com", None, None, 'Some Buyer')
             )
             self.get_user_patch.start()
 
@@ -236,6 +244,10 @@ class BaseApplicationTest(object):
     def strip_all_whitespace(content):
         pattern = re.compile(r'\s+')
         return re.sub(pattern, '', content)
+
+    @staticmethod
+    def find_search_summary(res_data):
+        return re.findall(r'<span class="search-summary-count">.+</span>[^\n]+', res_data)
 
     # Method to test flashes taken from http://blog.paulopoiati.com/2013/02/22/testing-flash-messages-in-flask/
     def assert_flashes(self, expected_message, expected_category='message'):

--- a/tests/main/helpers/test_search_helpers.py
+++ b/tests/main/helpers/test_search_helpers.py
@@ -1,6 +1,6 @@
 import mock
-
 import pytest
+import re
 from werkzeug.datastructures import MultiDict
 
 from ...helpers import BaseApplicationTest
@@ -230,9 +230,8 @@ class TestBuildSearchQueryHelpers(BaseApplicationTest):
             'question6': ['option1', 'option3'],
         })
 
-        assert search_helpers.build_search_query(self.g6_framework, request.args, self.lot_filters, self._loader(),
+        assert search_helpers.build_search_query(request.args, self.lot_filters, self._loader(),
                                                  self._lots_by_slug) == {
-            'index': 'g-cloud-6',
             'page': 5,
             'q': 'email',
             'lot': 'saas',
@@ -247,42 +246,39 @@ class TestBuildSearchQueryHelpers(BaseApplicationTest):
             'lot': 'saasaas',
         })
 
-        assert search_helpers.build_search_query(self.g6_framework, request.args, self.lot_filters, self._loader(),
-                                                 self._lots_by_slug) == {'index': 'g-cloud-6'}
+        assert search_helpers.build_search_query(request.args, self.lot_filters, self._loader(),
+                                                 self._lots_by_slug) == {}
 
     def test_build_search_query_multiple_lots_are_all_dropped(self):
         request = self._request({
             'lot': 'saas,paas',
         })
 
-        assert search_helpers.build_search_query(self.g6_framework, request.args, self.lot_filters, self._loader(),
-                                                 self._lots_by_slug) == {'index': 'g-cloud-6'}
+        assert search_helpers.build_search_query(request.args, self.lot_filters, self._loader(),
+                                                 self._lots_by_slug) == {}
 
     def test_build_search_query_no_keywords_drops_q_parameter(self):
         request = self._request({
             'q': '',
         })
 
-        assert search_helpers.build_search_query(self.g6_framework, request.args, self.lot_filters, self._loader(),
-                                                 self._lots_by_slug) == {'index': 'g-cloud-6'}
+        assert search_helpers.build_search_query(request.args, self.lot_filters, self._loader(),
+                                                 self._lots_by_slug) == {}
 
     def test_build_search_query_no_page_drops_page_parameter(self):
         request = self._request({
-            'index': 'g-cloud-6',
             'page': '',
         })
 
-        assert search_helpers.build_search_query(self.g6_framework, request.args, self.lot_filters, self._loader(),
-                                                 self._lots_by_slug) == {'index': 'g-cloud-6'}
+        assert search_helpers.build_search_query(request.args, self.lot_filters, self._loader(),
+                                                 self._lots_by_slug) == {}
 
     def test_build_search_query_g5_dots_id_search_replaces_dots_with_dashes(self):
         request = self._request({
-            'index': 'g-cloud-6',
             'q': 'some text 5.G4.1005.001',
         })
 
-        assert search_helpers.build_search_query(self.g6_framework, request.args, self.lot_filters, self._loader(),
+        assert search_helpers.build_search_query(request.args, self.lot_filters, self._loader(),
                                                  self._lots_by_slug) == {
-            'index': 'g-cloud-6',
             'q': 'some text 5-G4-1005-001',
         }

--- a/tests/main/helpers/test_search_helpers.py
+++ b/tests/main/helpers/test_search_helpers.py
@@ -272,13 +272,3 @@ class TestBuildSearchQueryHelpers(BaseApplicationTest):
 
         assert search_helpers.build_search_query(request.args, self.lot_filters, self._loader(),
                                                  self._lots_by_slug) == {}
-
-    def test_build_search_query_g5_dots_id_search_replaces_dots_with_dashes(self):
-        request = self._request({
-            'q': 'some text 5.G4.1005.001',
-        })
-
-        assert search_helpers.build_search_query(request.args, self.lot_filters, self._loader(),
-                                                 self._lots_by_slug) == {
-            'q': 'some text 5-G4-1005-001',
-        }

--- a/tests/main/helpers/test_shared_helpers.py
+++ b/tests/main/helpers/test_shared_helpers.py
@@ -1,0 +1,24 @@
+import pytest
+from app.main.helpers.shared_helpers import construct_url_from_base_and_params
+
+
+@pytest.mark.parametrize('expected_url,base_url,query_params',
+                         (
+                             ('http://localhost',
+                              'http://localhost',
+                              tuple()),
+                             ('https://www.digitalmarketplace.service.gov.uk',
+                              'https://www.digitalmarketplace.service.gov.uk',
+                              tuple()),
+                             ('https://www.digitalmarketplace.service.gov.uk/g-cloud/search',
+                              'https://www.digitalmarketplace.service.gov.uk/g-cloud/search',
+                              tuple()),
+                             ('https://www.digitalmarketplace.service.gov.uk/g-cloud/search?q=security',
+                              'https://www.digitalmarketplace.service.gov.uk/g-cloud/search',
+                              (('q', 'security'),)),
+                             ('http://localhost?q=hosting&lot=cloud-hosting&serviceCategories=cloud',
+                              'http://localhost',
+                              (('q', 'hosting'), ('lot', 'cloud-hosting'), ('serviceCategories', 'cloud'))),
+                         ))
+def test_construct_url_from_base_and_params(expected_url, base_url, query_params):
+    assert construct_url_from_base_and_params(base_url, query_params) == expected_url

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -2,7 +2,7 @@ from lxml import html
 import mock
 import pytest
 
-from app import data_api_client
+from app import data_api_client, search_api_client
 from dmutils.formats import utcdatetimeformat
 from ...helpers import BaseApplicationTest
 
@@ -40,19 +40,20 @@ class TestDirectAward(BaseApplicationTest):
         assert res.status_code == 200
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//button[@id="save-search" and @formaction="/buyers/direct-award/save-search"]')) == 1
+        assert len(doc.xpath('//button[@id="save-search"'
+                             ' and @formaction="/buyers/direct-award/g-cloud/save-search"]')) == 1
 
     def test_save_search_redirects_to_login(self):
-        res = self.client.get('/buyers/direct-award/save-search?lot=cloud-software')
+        res = self.client.get('/buyers/direct-award/g-cloud/save-search?lot=cloud-software')
         assert res.status_code == 302
         assert res.location == 'http://localhost/login?next=' \
-                               '%2Fbuyers%2Fdirect-award%2Fsave-search%3Flot%3Dcloud-software'
+                               '%2Fbuyers%2Fdirect-award%2Fg-cloud%2Fsave-search%3Flot%3Dcloud-software'
 
     def test_save_search_renders_summary_on_page(self):
         self.login_as_buyer()
         self._search_api_client.search_services.return_value = self.g9_search_results
 
-        res = self.client.get('/buyers/direct-award/save-search?lot=cloud-software')
+        res = self.client.get('/buyers/direct-award/g-cloud/save-search?lot=cloud-software')
         assert res.status_code == 200
 
         summary = self.find_search_summary(res.get_data(as_text=True))[0]
@@ -61,7 +62,7 @@ class TestDirectAward(BaseApplicationTest):
     def test_view_project_page_shows_title(self):
         self.login_as_buyer()
 
-        res = self.client.get('/buyers/direct-award/projects/1')
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1')
 
         doc = html.fromstring(res.get_data(as_text=True))
         project_name = self._get_direct_award_project_fixture()['project']['name']
@@ -70,7 +71,7 @@ class TestDirectAward(BaseApplicationTest):
     @pytest.mark.parametrize('user_id, expected_status_code', ((122, 404), (123, 200)))
     def test_view_project_checks_user_access_to_project_or_404s(self, user_id, expected_status_code):
         self.login_as_buyer(user_id=user_id)
-        res = self.client.get('/buyers/direct-award/projects/1')
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1')
         assert res.status_code == expected_status_code
 
     def test_view_project_shows_active_search_details(self):
@@ -78,7 +79,7 @@ class TestDirectAward(BaseApplicationTest):
         self._search_api_client.search_services.return_value = self.g9_search_results
         self._search_api_client.get_frontend_params_from_search_api_url.return_value = (('q', 'accelerator'), )
 
-        res = self.client.get('/buyers/direct-award/projects/1')
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1')
         assert res.status_code == 200
 
         body = res.get_data(as_text=True)
@@ -88,3 +89,52 @@ class TestDirectAward(BaseApplicationTest):
                '<em>All categories</em>' in summary
         assert utcdatetimeformat(self._get_direct_award_project_searches_fixture()['searches'][0]['createdAt']) in body
         assert len(doc.xpath('//a[@href="/g-cloud/search?q=accelerator"]')) == 1
+
+
+class TestDirectAwardURLGeneration(BaseApplicationTest):
+    def setup_method(self, method):
+        super(TestDirectAwardURLGeneration, self).setup_method(method)
+
+        self.g9_search_results = self._get_g9_search_results_fixture_data()
+
+        search_api_client.search_services = mock.Mock()
+        search_api_client.search_services.return_value = self.g9_search_results
+
+        data_api_client.get_direct_award_project = mock.Mock()
+        data_api_client.get_direct_award_project.return_value = self._get_direct_award_project_fixture()
+
+        data_api_client.find_direct_award_project_searches = mock.Mock()
+        data_api_client.find_direct_award_project_searches.return_value = \
+            self._get_direct_award_project_searches_fixture()
+
+    @pytest.mark.parametrize('search_api_url, frontend_url',
+                             (
+                                 ('https://search-api.digitalmarketplace.service.gov.uk/g-cloud-9/services/search',
+                                  '/g-cloud/search'),
+                                 ('https://search-api.digitalmarketplace.service.gov.uk/g-cloud-9/services/search?'
+                                  'filter_lot=cloud-hosting',
+                                  '/g-cloud/search?lot=cloud-hosting'),
+                                 ('https://search-api.digitalmarketplace.service.gov.uk/g-cloud-9/services/search?'
+                                  'filter_lot=cloud-hosting&filter_serviceCategories=firewall',
+                                  '/g-cloud/search?lot=cloud-hosting&serviceCategories=firewall'),
+                                 ('https://search-api.digitalmarketplace.service.gov.uk/g-cloud-9/services/search?'
+                                  'filter_lot=cloud-hosting&filter_serviceCategories=firewall&filter_governmentSe'
+                                  'curityClearances=dv%2Csc',
+                                  '/g-cloud/search?lot=cloud-hosting&serviceCategories=firewall&governmentSecurityCl'
+                                  'earances=dv&governmentSecurityClearances=sc')
+                             ))
+    def test_search_api_urls_convert_to_correct_frontend_urls(self, search_api_url, frontend_url):
+        self.login_as_buyer()
+
+        search_api_client._get = mock.Mock()
+        search_api_client._get.return_value = self._get_search_results_fixture_data()
+
+        project_searches = data_api_client.find_direct_award_project_searches.return_value
+        project_searches['searches'][0]['searchUrl'] = search_api_url
+
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1')
+        assert res.status_code == 200
+
+        body = res.get_data(as_text=True)
+        doc = html.fromstring(body)
+        assert len(doc.xpath('//a[@href="{}"]'.format(frontend_url))) == 1

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -1,0 +1,90 @@
+from lxml import html
+import mock
+import pytest
+
+from app import data_api_client
+from dmutils.formats import utcdatetimeformat
+from ...helpers import BaseApplicationTest
+
+
+class TestDirectAward(BaseApplicationTest):
+    def setup_method(self, method):
+        super(TestDirectAward, self).setup_method(method)
+
+        self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
+        self._search_api_client = self._search_api_client_patch.start()
+
+        self._search_api_client_presenters_patch = mock.patch('app.main.presenters.search_presenters.search_api_client',
+                                                              autospec=True)
+        self._search_api_client_presenters = self._search_api_client_presenters_patch.start()
+        self._search_api_client_presenters.aggregate_services.return_value = \
+            self._get_fixture_data('g9_aggregations_fixture.json')
+
+        self.g9_search_results = self._get_g9_search_results_fixture_data()
+
+        data_api_client.get_direct_award_project = mock.Mock()
+        data_api_client.get_direct_award_project.return_value = self._get_direct_award_project_fixture()
+
+        data_api_client.find_direct_award_project_searches = mock.Mock()
+        data_api_client.find_direct_award_project_searches.return_value = \
+            self._get_direct_award_project_searches_fixture()
+
+    def teardown_method(self, method):
+        self._search_api_client_patch.stop()
+        self._search_api_client_presenters_patch.stop()
+
+    def test_renders_save_search_button(self):
+        self._search_api_client.search_services.return_value = self.g9_search_results
+
+        res = self.client.get('/g-cloud/search')
+        assert res.status_code == 200
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert len(doc.xpath('//button[@id="save-search" and @formaction="/buyers/direct-award/save-search"]')) == 1
+
+    def test_save_search_redirects_to_login(self):
+        res = self.client.get('/buyers/direct-award/save-search?lot=cloud-software')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/login?next=' \
+                               '%2Fbuyers%2Fdirect-award%2Fsave-search%3Flot%3Dcloud-software'
+
+    def test_save_search_renders_summary_on_page(self):
+        self.login_as_buyer()
+        self._search_api_client.search_services.return_value = self.g9_search_results
+
+        res = self.client.get('/buyers/direct-award/save-search?lot=cloud-software')
+        assert res.status_code == 200
+
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
+        assert '<span class="search-summary-count">1150</span> results found in <em>Cloud software</em>' in summary
+
+    def test_view_project_page_shows_title(self):
+        self.login_as_buyer()
+
+        res = self.client.get('/buyers/direct-award/projects/1')
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        project_name = self._get_direct_award_project_fixture()['project']['name']
+        assert len(doc.xpath('//h1[contains(normalize-space(text()), "Project - {}")]'.format(project_name))) == 1
+
+    @pytest.mark.parametrize('user_id, expected_status_code', ((122, 404), (123, 200)))
+    def test_view_project_checks_user_access_to_project_or_404s(self, user_id, expected_status_code):
+        self.login_as_buyer(user_id=user_id)
+        res = self.client.get('/buyers/direct-award/projects/1')
+        assert res.status_code == expected_status_code
+
+    def test_view_project_shows_active_search_details(self):
+        self.login_as_buyer()
+        self._search_api_client.search_services.return_value = self.g9_search_results
+        self._search_api_client.get_frontend_params_from_search_api_url.return_value = (('q', 'accelerator'), )
+
+        res = self.client.get('/buyers/direct-award/projects/1')
+        assert res.status_code == 200
+
+        body = res.get_data(as_text=True)
+        doc = html.fromstring(body)
+        summary = self.find_search_summary(body)[0]
+        assert '<span class="search-summary-count">1</span> result found containing <em>accelerator</em> in ' \
+               '<em>All categories</em>' in summary
+        assert utcdatetimeformat(self._get_direct_award_project_searches_fixture()['searches'][0]['createdAt']) in body
+        assert len(doc.xpath('//a[@href="/g-cloud/search?q=accelerator"]')) == 1

--- a/tests/main/views/test_g_cloud.py
+++ b/tests/main/views/test_g_cloud.py
@@ -1,8 +1,5 @@
 import mock
-import pytest
 from ...helpers import BaseApplicationTest
-
-from app import data_api_client
 
 
 class TestGCloudIndexResults(BaseApplicationTest):

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -3,8 +3,8 @@ import json
 import mock
 import re
 import pytest
-from ...helpers import BaseApplicationTest
-from ...helpers import data_api_client
+
+from ...helpers import BaseApplicationTest, data_api_client
 
 
 def find_pagination_links(res_data):
@@ -12,11 +12,6 @@ def find_pagination_links(res_data):
         '<li class="[next|previous]+">[^<]+<a\ href="(/g-cloud/search\?[^"]+)',
         res_data,
         re.MULTILINE)
-
-
-def find_search_summary(res_data):
-    return re.findall(
-        r'<span class="search-summary-count">.+</span>[^\n]+', res_data)
 
 
 def find_0_results_suggestion(res_data):
@@ -150,7 +145,7 @@ class TestSearchResults(BaseApplicationTest):
 
         res = self.client.get('/g-cloud/search')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">0</span> results found in <em>All categories</em>' in summary
 
     def test_should_render_summary_for_0_results_in_cloud_software_no_keywords(self):
@@ -158,7 +153,7 @@ class TestSearchResults(BaseApplicationTest):
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">0</span> results found in <em>Cloud software</em>' in summary
 
     def test_should_render_suggestions_for_0_results(self):
@@ -201,7 +196,7 @@ class TestSearchResults(BaseApplicationTest):
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found in <em>Cloud software</em>' in summary
 
     def test_should_render_summary_for_1_result_in_cloud_hosting_no_keywords(self):
@@ -212,7 +207,7 @@ class TestSearchResults(BaseApplicationTest):
 
         res = self.client.get('/g-cloud/search?lot=cloud-hosting')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found' \
             ' in <em>Cloud hosting</em>' in summary
 
@@ -224,7 +219,7 @@ class TestSearchResults(BaseApplicationTest):
 
         res = self.client.get('/g-cloud/search?q=email&lot=cloud-software')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found' \
             ' containing <em>email</em> in' \
             ' <em>Cloud software</em>' in summary
@@ -238,7 +233,7 @@ class TestSearchResults(BaseApplicationTest):
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&phoneSupport=true')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found' \
             ' containing <em>email</em> in' \
             ' <em>Cloud software</em>' \
@@ -253,7 +248,7 @@ class TestSearchResults(BaseApplicationTest):
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&phoneSupport=true&onsiteSupport=yes')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found' \
             ' containing <em>email</em> in' \
             ' <em>Cloud software</em>' in summary
@@ -270,7 +265,7 @@ class TestSearchResults(BaseApplicationTest):
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&resellingType=not_reseller')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found' \
             ' containing <em>email</em> in' \
             ' <em>Cloud software</em>' \
@@ -286,7 +281,7 @@ class TestSearchResults(BaseApplicationTest):
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&resellingType=not_reseller&resellingType=reseller_no_extras')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found' \
             ' containing <em>email</em> in' \
             ' <em>Cloud software</em>' \
@@ -304,7 +299,7 @@ class TestSearchResults(BaseApplicationTest):
             '/g-cloud/search?q=email&lot=cloud-software&phoneSupport=true' +
             '&resellingType=not_reseller&resellingType=reseller_no_extras')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found' \
             ' containing <em>email</em> in' \
             ' <em>Cloud software</em>' in summary
@@ -324,7 +319,7 @@ class TestSearchResults(BaseApplicationTest):
             '&resellingType=not_reseller&resellingType=reseller_no_extras' +
             '&governmentSecurityClearances=dv')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1</span> result found' \
             ' containing <em>email</em> in' \
             ' <em>Cloud software</em>' in summary
@@ -355,7 +350,7 @@ class TestSearchResults(BaseApplicationTest):
         res = self.client.get('/g-cloud/search?q=<div>XSS</div>')
 
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '&lt;div&gt;XSS&lt;/div&gt;' in summary
 
     def test_summary_for_unicode_query_keywords(self):
@@ -366,7 +361,7 @@ class TestSearchResults(BaseApplicationTest):
 
         res = self.client.get(u'/g-cloud/search?q=email+\U0001f47e&lot=cloud-software')
         assert res.status_code == 200
-        summary = find_search_summary(res.get_data(as_text=True))[0]
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert u'<span class="search-summary-count">1</span> result found' \
             u' containing <em>email \U0001f47e</em> in' \
             u' <em>Cloud software</em>' in summary


### PR DESCRIPTION
## Summary
Skeleton direct award pages/alterations to allow testing the flow. This skeleton has not been designed, but implements the basic steps and pages required for functionality. Following stories in Compare and Decide will re-design the pages heavily.

At a high level, this flow will let you run a search against G-Cloud, save those search parameters into a new Direct Award Procurement Project (name still in the air), and view an overview page for that project that links you back to the saved search. The new flow has been implemented under a 'direct_award' Blueprint which will allow us to move this into another app if we need to do so.

This flow will be hidden behind a Feature Flag in staging and production, but be available for use in preview.

**Please don't review the UI itself, which is out of scope for this PR, but do review how the code supporting them has been implemented (i.e. evertything else)**

## Complementary PRs
~~https://github.com/alphagov/digitalmarketplace-api/pull/636~~
https://github.com/alphagov/digitalmarketplace-functional-tests/pull/321
~~https://github.com/alphagov/digitalmarketplace-apiclient/pull/88~~

## Example
![procurement project smaller](https://user-images.githubusercontent.com/2920760/29829059-58ac5810-8cd6-11e7-90f8-1952aac49da1.gif)


## Ticket
https://trello.com/c/Hlq5mzAy/619-save-a-search-and-create-a-project