### PR TITLE
Support Briefs/BriefResponses with new award statuses

### DIFF
--- a/app/main/forms/brief_forms.py
+++ b/app/main/forms/brief_forms.py
@@ -41,7 +41,14 @@ class BriefSearchForm(Form):
         if not self.validate():
             raise ValueError("Invalid form")
 
-        statuses = self.status.data or tuple(id for id, label in self.status.choices)
+        # Treat 'awarded' briefs as closed for filtering purposes, but don't show as a status filter option on the form.
+        if self.status.data:
+            statuses = self.status.data.copy()
+        else:
+            statuses = [id for id, label in self.status.choices]
+        if 'closed' in statuses:
+            statuses.append('awarded')
+
         lots = self.lot.data or tuple(id for id, label in self.lot.choices)
 
         return self._data_api_client.find_briefs(

--- a/app/main/forms/brief_forms.py
+++ b/app/main/forms/brief_forms.py
@@ -45,11 +45,11 @@ class BriefSearchForm(Form):
         if self.status.data:
             statuses = self.status.data.copy()
         else:
-            statuses = [id for id, label in self.status.choices]
+            statuses = [id_ for id_, label in self.status.choices]
         if 'closed' in statuses:
             statuses.append('awarded')
 
-        lots = self.lot.data or tuple(id for id, label in self.lot.choices)
+        lots = self.lot.data or tuple(id_ for id_, label in self.lot.choices)
 
         return self._data_api_client.find_briefs(
             status=",".join(statuses),

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from datetime import datetime
-
 from flask_login import current_user
 from flask import abort, current_app, render_template, request
-import flask_featureflags as feature
 
 from dmapiclient import APIError
 from dmcontent.content_loader import ContentNotFoundError
@@ -17,6 +14,8 @@ from ..helpers.framework_helpers import get_latest_live_framework, get_framework
 from ..forms.brief_forms import BriefSearchForm
 
 from app import data_api_client, content_loader
+
+COMPLETED_BRIEF_RESPONSE_STATUSES = ['submitted', 'pending-awarded', 'awarded']
 
 
 @main.route('/')
@@ -106,7 +105,9 @@ def get_brief_by_id(framework_framework, brief_id):
 
     try:
         has_supplier_responded_to_brief = (
-            current_user.supplier_id in [response['supplierId'] for response in completed_brief_responses]
+            current_user.supplier_id in [
+                res['supplierId'] for res in brief_responses if res["status"] in COMPLETED_BRIEF_RESPONSE_STATUSES
+            ]
         )
     except AttributeError:
         has_supplier_responded_to_brief = False

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -15,6 +15,7 @@ from ..forms.brief_forms import BriefSearchForm
 
 from app import data_api_client, content_loader
 
+ALL_BRIEF_RESPONSE_STATUSES = ['draft', 'submitted', 'pending-awarded', 'awarded']
 COMPLETED_BRIEF_RESPONSE_STATUSES = ['submitted', 'pending-awarded', 'awarded']
 PUBLISHED_BRIEF_STATUSES = ['live', 'withdrawn', 'closed', 'awarded']
 
@@ -77,7 +78,7 @@ def get_brief_by_id(framework_framework, brief_id):
     brief = briefs.get('briefs')
     brief_responses = data_api_client.find_brief_responses(
         brief_id=brief_id,
-        status='draft,submitted,pending-awarded,awarded'
+        status=",".join(ALL_BRIEF_RESPONSE_STATUSES)
     ).get('briefResponses')
 
     started_brief_responses = [response for response in brief_responses if response['status'] == 'draft']

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -16,6 +16,7 @@ from ..forms.brief_forms import BriefSearchForm
 from app import data_api_client, content_loader
 
 COMPLETED_BRIEF_RESPONSE_STATUSES = ['submitted', 'pending-awarded', 'awarded']
+PUBLISHED_BRIEF_STATUSES = ['live', 'withdrawn', 'closed', 'awarded']
 
 
 @main.route('/')
@@ -76,11 +77,13 @@ def get_brief_by_id(framework_framework, brief_id):
     brief = briefs.get('briefs')
     brief_responses = data_api_client.find_brief_responses(
         brief_id=brief_id,
-        status='draft,submitted'
+        status='draft,submitted,pending-awarded,awarded'
     ).get('briefResponses')
 
     started_brief_responses = [response for response in brief_responses if response['status'] == 'draft']
-    completed_brief_responses = [response for response in brief_responses if response['status'] == 'submitted']
+    completed_brief_responses = [
+        response for response in brief_responses if response['status'] in COMPLETED_BRIEF_RESPONSE_STATUSES
+    ]
 
     # Counts for application statistics
     started_sme_responses_count = len([
@@ -100,7 +103,7 @@ def get_brief_by_id(framework_framework, brief_id):
         if response['supplierOrganisationSize'] == 'large'
     ])
 
-    if brief['status'] not in ['live', 'closed', 'withdrawn'] or brief['frameworkFramework'] != framework_framework:
+    if brief['status'] not in PUBLISHED_BRIEF_STATUSES or brief['frameworkFramework'] != framework_framework:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
 
     try:

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -23,7 +23,7 @@
 
 {% block main_content %}
 
-{% if brief.status == 'closed' %}
+{% if brief.status in ['closed', 'awarded'] %}
 <div class="grid-row">
   <div class="column-one-whole">
     {%

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -25,7 +25,7 @@
     </ul>
 
     <ul class="search-result-metadata">
-        {% if brief.data.status == 'closed' %}
+        {% if brief.data.status in ['closed', 'awarded'] %}
             <li class="search-result-metadata-item">
                 Closed
             </li>

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -101,6 +101,86 @@
       "title":"Another requirement",
       "updatedAt":"2016-02-16T14:04:22.617017Z",
       "workingArrangements":"Work"
+    },
+    {
+      "applicationsClosedAt":"2016-03-24T00:00:00.000000Z",
+      "backgroundInformation":"Here is the first requirements summary.",
+      "clarificationQuestions":[],
+      "clarificationQuestionsAreClosed":true,
+      "clarificationQuestionsClosedAt":"2016-03-17T00:00:00.000000Z",
+      "clarificationQuestionsPublishedBy": "2016-03-20T00:00:00.000000Z",
+      "createdAt":"2016-03-09T15:23:48.328413Z",
+      "culturalWeighting": 30,
+      "essentialRequirements": [
+        "Proven experience in recruiting niche business users"
+      ],
+      "evaluationType": [
+        "Interview"
+      ],
+      "frameworkFramework":"digital-outcomes-and-specialists",
+      "frameworkName":"Digital Outcomes and Specialists",
+      "frameworkSlug":"digital-outcomes-and-specialists",
+      "frameworkStatus":"live",
+      "id":14,
+      "links":{
+        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists",
+        "self":"http://localhost:5000/briefs/17"
+      },
+      "location":"International (outside the UK)",
+      "lot":"user-research-participants",
+      "lotName":"User research participants",
+      "lotSlug":"user-research-participants",
+      "niceToHaveRequirements": [],
+      "numberOfSuppliers": 5,
+      "organisation":"GDS",
+      "priceWeighting": 20,
+      "publishedAt":"2016-03-09T16:02:51.591567Z",
+      "researchDates": "1 year contract with option to extend for one additional year commencing approx mid/end June",
+      "status":"closed",
+      "summary": "Find out those user needs!",
+      "technicalWeighting": 50,
+      "title":"I need All Research Participants",
+      "updatedAt":"2016-03-09T15:56:32.487141Z"
+    },
+    {
+      "applicationsClosedAt":"2016-03-24T00:00:00.000000Z",
+      "backgroundInformation":"Here is the first requirements summary.",
+      "clarificationQuestions":[],
+      "clarificationQuestionsAreClosed":true,
+      "clarificationQuestionsClosedAt":"2016-03-17T00:00:00.000000Z",
+      "clarificationQuestionsPublishedBy": "2016-03-20T00:00:00.000000Z",
+      "createdAt":"2016-03-09T15:23:48.328413Z",
+      "culturalWeighting": 30,
+      "essentialRequirements": [
+        "Proven experience in recruiting niche business users"
+      ],
+      "evaluationType": [
+        "Interview"
+      ],
+      "frameworkFramework":"digital-outcomes-and-specialists",
+      "frameworkName":"Digital Outcomes and Specialists",
+      "frameworkSlug":"digital-outcomes-and-specialists",
+      "frameworkStatus":"live",
+      "id":15,
+      "links":{
+        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists",
+        "self":"http://localhost:5000/briefs/17"
+      },
+      "location":"International (outside the UK)",
+      "lot":"user-research-participants",
+      "lotName":"User research participants",
+      "lotSlug":"user-research-participants",
+      "niceToHaveRequirements": [],
+      "numberOfSuppliers": 5,
+      "organisation":"GDS",
+      "priceWeighting": 20,
+      "publishedAt":"2016-03-09T16:02:51.591567Z",
+      "researchDates": "1 year contract with option to extend for one additional year commencing approx mid/end June",
+      "status":"awarded",
+      "summary": "Find out those user needs!",
+      "technicalWeighting": 50,
+      "title":"I need More Research Participants",
+      "updatedAt":"2016-03-09T15:56:32.487141Z"
     }
   ],
   "links":{

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -583,6 +583,33 @@ class TestBriefPage(BaseBriefPageTest):
         assert len(apply_links) == 0
         assert '15 December 2016' in document.xpath('//p[@class="banner-message"]')[0].text_content()
 
+    def test_cannot_apply_to_awarded_brief(self):
+        self.brief['briefs']['status'] = "awarded"
+        self._data_api_client.find_brief_responses.return_value = {
+            "briefResponses": [
+                {
+                    "awardDetails": {"awardedContractStartDate": "2017-08-21", "awardedContractValue": "20000.00"},
+                    "id": 14276,
+                    "briefId": 1,
+                    "createdAt": "2016-12-02T11:09:28.054129Z",
+                    "status": "awarded",
+                    "submittedAt": "2016-12-05T11:09:28.054129Z",
+                    "supplierId": 123456,
+                    "supplierName": "Another, Better, Company Limited",
+                    "supplierOrganisationSize": "large"
+                }
+            ]
+        }
+        self.brief['briefs']['awardedBriefResponseId'] = 14276
+
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+
+        apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/start"]'.format(brief_id))
+        assert len(apply_links) == 0
+
     def test_dos_brief_specialist_role_displays_label(self):
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
@@ -710,6 +737,44 @@ class TestBriefPage(BaseBriefPageTest):
         }
 
         self.brief['briefs']['awardedBriefResponseId'] = 14276
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+
+        self._assert_view_application(document, brief_id)
+
+    def test_supplier_applied_view_application_for_opportunity_awarded_to_other_supplier(self):
+        self.login_as_supplier()
+
+        self._data_api_client.find_brief_responses.return_value = {
+            "briefResponses": [
+                {
+                    "awardDetails": {"awardedContractStartDate": "2017-08-21", "awardedContractValue": "20000.00"},
+                    "id": 14276,
+                    "briefId": 1,
+                    "createdAt": "2016-12-02T11:09:28.054129Z",
+                    "status": "awarded",
+                    "submittedAt": "2016-12-05T11:09:28.054129Z",
+                    "supplierId": 123456,
+                    "supplierName": "Another, Better, Company Limited",
+                    "supplierOrganisationSize": "large"
+                },
+                {
+                    "id": 14277,
+                    "briefId": 1,
+                    "createdAt": "2016-12-02T11:09:28.054129Z",
+                    "status": "submitted",
+                    "submittedAt": "2016-12-05T11:09:28.054129Z",
+                    "supplierId": 1234,
+                    "supplierName": "Example Company Limited",
+                    "supplierOrganisationSize": "small"
+                }
+            ]
+        }
+        self.brief['briefs']['status'] = 'awarded'
+        self.brief['briefs']['awardedBriefResponseId'] = 14276
+
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert res.status_code == 200

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -661,6 +661,62 @@ class TestBriefPage(BaseBriefPageTest):
 
         self._assert_view_application(document, brief_id)
 
+    def test_supplier_applied_view_application_for_opportunity_awarded_to_logged_in_supplier(self):
+        self.login_as_supplier()
+        self.brief['briefs']['status'] = 'awarded'
+
+        self._data_api_client.find_brief_responses.return_value = {
+            "briefResponses": [
+                {
+                    "awardDetails": {"awardedContractStartDate": "2017-08-21", "awardedContractValue": "20000.00"},
+                    "id": 14276,
+                    "briefId": 1,
+                    "createdAt": "2016-12-02T11:09:28.054129Z",
+                    "status": "awarded",
+                    "submittedAt": "2016-12-05T11:09:28.054129Z",
+                    "supplierId": 1234,
+                    "supplierName": "Example Company Limited",
+                    "supplierOrganisationSize": "small"
+                }
+            ]
+        }
+
+        self.brief['briefs']['awardedBriefResponseId'] = 14276
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+
+        self._assert_view_application(document, brief_id)
+
+    def test_supplier_applied_view_application_for_opportunity_pending_awarded_to_logged_in_supplier(self):
+        self.login_as_supplier()
+        self.brief['briefs']['status'] = 'closed'
+
+        self._data_api_client.find_brief_responses.return_value = {
+            "briefResponses": [
+                {
+                    "awardDetails": {"pending": True},
+                    "id": 14276,
+                    "briefId": 1,
+                    "createdAt": "2016-12-02T11:09:28.054129Z",
+                    "status": "pending-awarded",
+                    "submittedAt": "2016-12-05T11:09:28.054129Z",
+                    "supplierId": 1234,
+                    "supplierName": "Example Company Limited",
+                    "supplierOrganisationSize": "small"
+                }
+            ]
+        }
+
+        self.brief['briefs']['awardedBriefResponseId'] = 14276
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+
+        self._assert_view_application(document, brief_id)
+
 
 class TestBriefPageQandASectionViewQandASessionDetails(BaseBriefPageTest):
 

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1120,6 +1120,15 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         filter_button = document.xpath('//button[@class="button-save" and normalize-space(text())="Filter"]')
         assert len(filter_button) == 1
 
+    def test_closed_and_awarded_briefs_displayed_with_word_closed(self):
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities')
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+        details_of_opportunities = document.xpath('//li[@class="search-result-metadata-item"]/text()')
+        closed_instances = [item.strip() for item in details_of_opportunities if "Closed" in item.strip()]
+        assert len(closed_instances) == 2
+
 
 @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
 class TestGCloudHomepageLinks(BaseApplicationTest):

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1120,14 +1120,31 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         filter_button = document.xpath('//button[@class="button-save" and normalize-space(text())="Filter"]')
         assert len(filter_button) == 1
 
-    def test_closed_and_awarded_briefs_displayed_with_word_closed(self):
+    def test_opportunity_status_and_published_date(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')
         assert res.status_code == 200
 
         document = html.fromstring(res.get_data(as_text=True))
-        details_of_opportunities = document.xpath('//li[@class="search-result-metadata-item"]/text()')
-        closed_instances = [item.strip() for item in details_of_opportunities if "Closed" in item.strip()]
-        assert len(closed_instances) == 2
+
+        live_opportunity_published_at = document.xpath(
+            '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'
+        )[-2].text_content().strip()
+        assert live_opportunity_published_at == "Published: Wednesday 9 March 2016"
+
+        live_opportunity_closing_at = document.xpath(
+            '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'
+        )[-1].text_content().strip()
+        assert live_opportunity_closing_at == "Closing: Thursday 24 March 2016"
+
+        closed_opportunity_status = document.xpath(
+            '//div[@class="search-result"][3]//li[@class="search-result-metadata-item"]'
+        )[-1].text_content().strip()
+        assert closed_opportunity_status == "Closed"
+
+        awarded_opportunity_status = document.xpath(
+            '//div[@class="search-result"][4]//li[@class="search-result-metadata-item"]'
+        )[-1].text_content().strip()
+        assert awarded_opportunity_status == "Closed"
 
 
 @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -928,7 +928,9 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             "page": 1,
             "human": True,
         }
-        assert set(self._data_api_client.find_briefs.call_args[1]["status"].split(",")) == {"live", "closed"}
+        assert set(self._data_api_client.find_briefs.call_args[1]["status"].split(",")) == {
+            "live", "closed", "awarded"
+        }
         assert set(self._data_api_client.find_briefs.call_args[1]["lot"].split(",")) == {
             "lot-one",
             "lot-three",
@@ -1032,7 +1034,9 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             "page": 1,
             "human": True,
         }
-        assert set(self._data_api_client.find_briefs.call_args[1]["status"].split(",")) == {"live", "closed"}
+        assert set(self._data_api_client.find_briefs.call_args[1]["status"].split(",")) == {
+            "live", "closed", "awarded"
+        }
         assert set(self._data_api_client.find_briefs.call_args[1]["lot"].split(",")) == {
             "lot-one",
             "lot-three",


### PR DESCRIPTION
Before the award journey is released, we need to ensure the new `awarded` status on Brief and `awarded`/`pending-awarded` statuses on BriefResponse don't break any existing functionality.

This is part of the awards mega-story https://trello.com/c/kGVfzXuH/749-3-collect-award-status-on-buyer-dashboard

Note: most of these commits originally lived on the `show_award_details` branch https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/577. This branch still displays the 'closed' banner message on the opportunity page, instead of the new 'awarded' banner. 

Changes required for adding a new Brief or BriefResponse status:
- add new Brief status to `BriefSearchForm` (used by `marketplace.list_opportunities`) For now we treat 'awarded' status as 'closed' for the search form.
- on the search results template, determine what to display for the new status ('awarded' treated as 'closed' for now)
- on the opportunity view (`marketplace.get_brief_by_id`) include new BriefResponse status when fetching from the data API, and the new Brief status when collecting supplier stats.
- on the opportunity template, determine what banner (if any) to display for the new status. For now we treat 'awarded' status as 'closed'; this will change on the `show_award_details` branch.
- determine whether a supplier can still apply to the brief (for awarded briefs, they cannot)
- determine whether suppliers can still view their application to the brief (for awarded briefs, they can, even if the brief was awarded to someone else)
- consider adding a new test fixture for the new status