### PR TITLE
Pull in apiclient 9.0.0

### DIFF
--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -170,7 +170,8 @@ def get_filter_value_from_question_option(option):
     return (option.get('value') or option.get('label', '')).lower().replace(',', '')
 
 
-def build_search_query(request_args, lot_filters, content_builder, lots_by_slug, for_aggregation=False):
+def build_search_query(framework, request_args, lot_filters, content_builder, lots_by_slug,
+                       for_aggregation=False):
     """Match request args with known filters.
 
     Removes any unknown query parameters, and will only keep `page`, `q`
@@ -190,7 +191,10 @@ def build_search_query(request_args, lot_filters, content_builder, lots_by_slug,
     if 'q' in query:
         query['q'] = replace_g5_search_dots(query['q'])
 
-    return group_request_filters(query, content_builder)
+    params = group_request_filters(query, content_builder)
+    params.update({'index': framework['slug']})
+
+    return params
 
 
 def query_args_for_pagination(args):

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -130,7 +130,8 @@ def _get_aggregations_for_lot_with_filters(lot, content_manifest, framework, req
     aggregate_request_args['lot'] = lot
 
     aggregate_api_response = search_api_client.aggregate_services(aggregations=aggregate_on_fields,
-                                                                  **build_search_query(aggregate_request_args,
+                                                                  **build_search_query(framework,
+                                                                                       aggregate_request_args,
                                                                                        filters.values(),
                                                                                        content_manifest,
                                                                                        lots_by_slug,

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -179,7 +179,7 @@ def search_services():
         abort(404)
 
     search_api_response = search_api_client.search_services(
-        **build_search_query(request.args, filters.values(), content_manifest, lots_by_slug)
+        **build_search_query(framework, request.args, filters.values(), content_manifest, lots_by_slug)
     )
     search_results_obj = SearchResults(search_api_response, lots_by_slug)
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.0.0#egg=digitalmarketplace-apiclient==9.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.12
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@8.10.1#egg=digitalmarketplace-apiclient==8.10.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@9.0.0#egg=digitalmarketplace-apiclient==9.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.22.0

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -4,6 +4,7 @@ import mock
 import re
 import pytest
 from ...helpers import BaseApplicationTest
+from ...helpers import data_api_client
 
 
 def find_pagination_links(res_data):
@@ -449,12 +450,15 @@ class TestSearchResults(BaseApplicationTest):
         assert self._search_api_client_presenters.aggregate_services.call_count == call_count
 
     def test_search_results_sends_aggregation_request_without_page_filter(self):
-        self._search_api_client.search_services.return_value = self.g9_search_results
+        data_api_client.find_frameworks.return_value = {'frameworks': [self._get_framework_fixture_data('g-cloud-9')
+                                                                       ['frameworks']]}
+        self._search_api_client.search_services.return_value = self.search_results
 
         res = self.client.get('/g-cloud/search?page=2')
         assert res.status_code == 200
 
         self._search_api_client_presenters.aggregate_services.assert_called_with(
+            index='g-cloud-9',
             lot='cloud-support',
             aggregations={'serviceCategories', 'lot'}
         )


### PR DESCRIPTION
## Summary
Pull in apiclient 9.0.0 which removes the default value for `index` in the search API Client. Fix code and tests to provide this parameter as the latest live framework slug, which will be aliases to the current index.

## Ticket
Work required for https://trello.com/c/Hlq5mzAy/619-save-a-search-and-create-a-project