### PR TITLE
Change wording for application stats from "started" to "incomplete"

### DIFF
--- a/app/templates/_brief_applications_stats.html
+++ b/app/templates/_brief_applications_stats.html
@@ -2,7 +2,7 @@
 
 {{ statistics.big_stat(
      started_responses_stats["total"],
-     pluralize(started_responses_stats["total"], "Started application", "Started applications"),
+     pluralize(started_responses_stats["total"], "Incomplete application", "Incomplete applications"),
      "%d SME, %d large" | format(started_responses_stats['sme_count'], started_responses_stats['large_count']) if started_responses_stats['total'] else None,
      id="started-applications"
    )

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -392,7 +392,7 @@ class TestBriefPage(BaseBriefPageTest):
         completed_responses_section = document.xpath('//div[@id="completed-applications"]')[0]
 
         assert started_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '3'
-        assert started_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Started applications"
+        assert started_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Incomplete applications"
         assert started_responses_section.xpath('div[@class="statistic-description"]/text()')[0] == "3 SME, 0 large"
 
         assert completed_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '5'
@@ -432,7 +432,7 @@ class TestBriefPage(BaseBriefPageTest):
         completed_responses_section = document.xpath('//div[@id="completed-applications"]')[0]
 
         assert started_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '1'
-        assert started_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Started application"
+        assert started_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Incomplete application"
         assert started_responses_section.xpath('div[@class="statistic-description"]/text()')[0] == "1 SME, 0 large"
 
         assert completed_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '1'
@@ -451,7 +451,7 @@ class TestBriefPage(BaseBriefPageTest):
 
         assert started_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '0'
         assert completed_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '0'
-        assert started_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Started applications"
+        assert started_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Incomplete applications"
         assert completed_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Completed applications"
         assert len(started_responses_section.xpath('div[@class="statistic-description"]/text()')) == 0
         assert len(completed_responses_section.xpath('div[@class="statistic-description"]/text()')) == 0


### PR DESCRIPTION
This was done to avoid confusion, following feedback from the
users. Users found former wording confusing, they thought that
completed applications should be included in started applications
count, as they have been started as well. To avoid such confusion
content decided to use binary oppositions completed/incomplete


Trello ticket: https://trello.com/c/n0sExgc5/811-update-content-for-application-stats

Code changed to match the content:
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/577/commits/fe71d56457bf717647572aa47492f6bbe110de74