### PR TITLE
Backwards compatibility for new Brief statuses

### DIFF
--- a/app/main/forms/brief_forms.py
+++ b/app/main/forms/brief_forms.py
@@ -3,7 +3,7 @@ from wtforms import IntegerField, SelectMultipleField
 from wtforms.validators import NumberRange
 
 
-CLOSED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
+BRIEF_AWARD_STATUSES = ['awarded', 'cancelled', 'unsuccessful']
 
 
 class BriefSearchForm(Form):
@@ -50,12 +50,12 @@ class BriefSearchForm(Form):
         else:
             statuses = [id_ for id_, label in self.status.choices]
         if 'closed' in statuses:
-            statuses.extend(CLOSED_BRIEF_STATUSES)
+            statuses.extend(BRIEF_AWARD_STATUSES)
 
         lots = self.lot.data or tuple(id_ for id_, label in self.lot.choices)
 
         return self._data_api_client.find_briefs(
-            status=",".join(set(statuses)),
+            status=",".join(statuses),
             lot=",".join(lots),
             framework=self._framework_slug,
             page=self.page.data,

--- a/app/main/forms/brief_forms.py
+++ b/app/main/forms/brief_forms.py
@@ -3,6 +3,9 @@ from wtforms import IntegerField, SelectMultipleField
 from wtforms.validators import NumberRange
 
 
+CLOSED_BRIEF_STATUSES = ['closed', 'awarded', 'cancelled', 'unsuccessful']
+
+
 class BriefSearchForm(Form):
     page = IntegerField(default=1, validators=(NumberRange(min=1),))
     status = SelectMultipleField("Status", choices=(
@@ -47,12 +50,12 @@ class BriefSearchForm(Form):
         else:
             statuses = [id_ for id_, label in self.status.choices]
         if 'closed' in statuses:
-            statuses.append('awarded')
+            statuses.extend(CLOSED_BRIEF_STATUSES)
 
         lots = self.lot.data or tuple(id_ for id_, label in self.lot.choices)
 
         return self._data_api_client.find_briefs(
-            status=",".join(statuses),
+            status=",".join(set(statuses)),
             lot=",".join(lots),
             framework=self._framework_slug,
             page=self.page.data,

--- a/app/main/helpers/brief_helpers.py
+++ b/app/main/helpers/brief_helpers.py
@@ -1,7 +1,7 @@
 SME, LARGE = ['micro', 'small', 'medium'], ['large']
 COMPLETED_BRIEF_RESPONSE_STATUSES = ['submitted', 'pending-awarded', 'awarded']
 ALL_BRIEF_RESPONSE_STATUSES = ['draft', 'submitted', 'pending-awarded', 'awarded']
-PUBLISHED_BRIEF_STATUSES = ['live', 'withdrawn', 'closed', 'awarded']
+PUBLISHED_BRIEF_STATUSES = ['live', 'withdrawn', 'closed', 'awarded', 'cancelled', 'unsuccessful']
 
 
 def _count_brief_responses_by_size(brief_responses, size):

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -23,7 +23,7 @@
 
 {% block main_content %}
 
-{% if brief.status == 'closed' %}
+{% if brief.status in ['closed', 'cancelled', 'unsuccessful'] %}
 <div class="grid-row">
   <div class="column-one-whole">
     {%

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -25,7 +25,7 @@
     </ul>
 
     <ul class="search-result-metadata">
-        {% if brief.data.status in ['closed', 'awarded'] %}
+        {% if brief.data.status in ['closed', 'awarded', 'cancelled', 'unsuccessful'] %}
             <li class="search-result-metadata-item">
                 Closed
             </li>

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -181,6 +181,86 @@
       "technicalWeighting": 50,
       "title":"I need More Research Participants",
       "updatedAt":"2016-03-09T15:56:32.487141Z"
+    },
+    {
+      "applicationsClosedAt":"2016-03-24T00:00:00.000000Z",
+      "backgroundInformation":"Here is an unsuccessful requirements summary, i.e. no suitable suppliers applied.",
+      "clarificationQuestions":[],
+      "clarificationQuestionsAreClosed":true,
+      "clarificationQuestionsClosedAt":"2016-03-17T00:00:00.000000Z",
+      "clarificationQuestionsPublishedBy": "2016-03-20T00:00:00.000000Z",
+      "createdAt":"2016-03-09T15:23:48.328413Z",
+      "culturalWeighting": 30,
+      "essentialRequirements": [
+        "Proven experience in recruiting niche business users"
+      ],
+      "evaluationType": [
+        "Interview"
+      ],
+      "frameworkFramework":"digital-outcomes-and-specialists",
+      "frameworkName":"Digital Outcomes and Specialists",
+      "frameworkSlug":"digital-outcomes-and-specialists",
+      "frameworkStatus":"live",
+      "id":16,
+      "links":{
+        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists",
+        "self":"http://localhost:5000/briefs/17"
+      },
+      "location":"International (outside the UK)",
+      "lot":"user-research-participants",
+      "lotName":"User research participants",
+      "lotSlug":"user-research-participants",
+      "niceToHaveRequirements": [],
+      "numberOfSuppliers": 5,
+      "organisation":"GDS",
+      "priceWeighting": 20,
+      "publishedAt":"2016-03-09T16:02:51.591567Z",
+      "researchDates": "1 year contract with option to extend for one additional year commencing approx mid/end June",
+      "status":"unsuccessful",
+      "summary": "Find out those user needs!",
+      "technicalWeighting": 50,
+      "title":"I need More Research Participants",
+      "updatedAt":"2016-03-09T15:56:32.487141Z"
+    },
+    {
+      "applicationsClosedAt":"2016-03-24T00:00:00.000000Z",
+      "backgroundInformation":"A cancelled brief summary, i.e. the brief was cancelled after the closing date.",
+      "clarificationQuestions":[],
+      "clarificationQuestionsAreClosed":true,
+      "clarificationQuestionsClosedAt":"2016-03-17T00:00:00.000000Z",
+      "clarificationQuestionsPublishedBy": "2016-03-20T00:00:00.000000Z",
+      "createdAt":"2016-03-09T15:23:48.328413Z",
+      "culturalWeighting": 30,
+      "essentialRequirements": [
+        "Proven experience in recruiting niche business users"
+      ],
+      "evaluationType": [
+        "Interview"
+      ],
+      "frameworkFramework":"digital-outcomes-and-specialists",
+      "frameworkName":"Digital Outcomes and Specialists",
+      "frameworkSlug":"digital-outcomes-and-specialists",
+      "frameworkStatus":"live",
+      "id":17,
+      "links":{
+        "framework":"http://localhost:5000/frameworks/digital-outcomes-and-specialists",
+        "self":"http://localhost:5000/briefs/17"
+      },
+      "location":"Scotland",
+      "lot":"user-research-participants",
+      "lotName":"User research participants",
+      "lotSlug":"user-research-participants",
+      "niceToHaveRequirements": [],
+      "numberOfSuppliers": 5,
+      "organisation":"GDS",
+      "priceWeighting": 20,
+      "publishedAt":"2016-03-09T16:02:51.591567Z",
+      "researchDates": "1 year contract with option to extend for one additional year commencing approx mid/end June",
+      "status":"cancelled",
+      "summary": "Find out those user needs!",
+      "technicalWeighting": 50,
+      "title":"I need More Research Participants",
+      "updatedAt":"2016-03-09T15:56:32.487141Z"
     }
   ],
   "links":{
@@ -190,6 +270,6 @@
     "next":"http://localhost:5000/briefs?status=live%2Cclosed&framework=digital-outcomes-and-specialists&page=3"
   },
   "meta":{
-    "total":2
+    "total":6
   }
 }

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -571,8 +571,9 @@ class TestBriefPage(BaseBriefPageTest):
 
         self._assert_start_application(document, brief_id)
 
-    def test_cannot_apply_to_closed_brief(self):
-        self.brief['briefs']['status'] = "closed"
+    @pytest.mark.parametrize('status', ['closed', 'unsuccessful', 'cancelled'])
+    def test_cannot_apply_to_closed_cancelled_or_unsuccessful_brief(self, status):
+        self.brief['briefs']['status'] = status
         self.brief['briefs']['applicationsClosedAt'] = "2016-12-15T11:08:28.054129Z"
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
@@ -678,9 +679,10 @@ class TestBriefPage(BaseBriefPageTest):
 
         self._assert_view_application(document, brief_id)
 
-    def test_supplier_applied_view_application_for_closed_opportunity(self):
+    @pytest.mark.parametrize('status', ['closed', 'unsuccessful', 'cancelled'])
+    def test_supplier_applied_view_application_for_closed_unsuccessful_or_cancelled_opportunity(self, status):
         self.login_as_supplier()
-        self.brief['briefs']['status'] = "closed"
+        self.brief['briefs']['status'] = status
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert res.status_code == 200
@@ -1093,7 +1095,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             "human": True,
         }
         assert set(self._data_api_client.find_briefs.call_args[1]["status"].split(",")) == {
-            "live", "closed", "awarded"
+            "live", "closed", "awarded", "unsuccessful", "cancelled"
         }
         assert set(self._data_api_client.find_briefs.call_args[1]["lot"].split(",")) == {
             "lot-one",
@@ -1199,7 +1201,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             "human": True,
         }
         assert set(self._data_api_client.find_briefs.call_args[1]["status"].split(",")) == {
-            "live", "closed", "awarded"
+            "live", "closed", "awarded", "unsuccessful", "cancelled"
         }
         assert set(self._data_api_client.find_briefs.call_args[1]["lot"].split(",")) == {
             "lot-one",

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1122,7 +1122,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert not any(element.get("checked") for element in status_inputs)
 
         ss_elem = document.xpath("//p[@class='search-summary']")[0]
-        assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "2 opportunities"
+        assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "6 opportunities"
 
         specialist_role_labels = document.xpath("//div[@class='search-result']/ul[2]/li[2]/text()")
         assert len(specialist_role_labels) == 1  # only one brief has a specialist role so only one label should exist
@@ -1182,7 +1182,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             normalize_qs(parsed_prev_url.query)
 
         ss_elem = document.xpath("//p[@class='search-summary']")[0]
-        assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "2 results"
+        assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "6 results"
 
     def test_catalogue_of_briefs_page_filtered_all_options_selected(self):
         original_url = "/digital-outcomes-and-specialists/opportunities?status=live&lot=lot-one&lot=lot-three"\
@@ -1242,7 +1242,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert normalize_qs(parsed_original_url.query) == normalize_qs(parsed_next_url.query)
 
         ss_elem = document.xpath("//p[@class='search-summary']")[0]
-        assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "2 results"
+        assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "6 results"
 
     def test_catalogue_of_briefs_404_if_invalid_status(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities?status=pining-for-fjords')
@@ -1311,6 +1311,16 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             '//div[@class="search-result"][4]//li[@class="search-result-metadata-item"]'
         )[-1].text_content().strip()
         assert awarded_opportunity_status == "Closed"
+
+        cancelled_opportunity_status = document.xpath(
+            '//div[@class="search-result"][5]//li[@class="search-result-metadata-item"]'
+        )[-1].text_content().strip()
+        assert cancelled_opportunity_status == "Closed"
+
+        unsuccessful_opportunity_status = document.xpath(
+            '//div[@class="search-result"][6]//li[@class="search-result-metadata-item"]'
+        )[-1].text_content().strip()
+        assert unsuccessful_opportunity_status == "Closed"
 
 
 @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)


### PR DESCRIPTION
Second of 5 backwards compatibility PRs to handle the two new Brief statuses, `cancelled` and `unsuccessful`.

1. Admin FE https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/293
2. Buyer FE 
3. Scripts https://github.com/alphagov/digitalmarketplace-scripts/pull/144
4. Brief Responses FE https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/5
5. Briefs FE https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/17

See #582 for the equivalent changes for the awarded status.

- Adds new `cancelled` and `unsuccessful` statuses to existing Brief status lists
- Update templates for search results and public Brief page (treat both new statuses as 'closed' for now)
- Update tests and test fixtures