### PR TITLE
Show appropriate banners for cancelled and unsuccessful briefs

### DIFF
--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -56,7 +56,11 @@
       with
       type = "temporary-message",
       heading = "This opportunity was cancelled",
-      message = "You can't apply for this opportunity now. The buyer may publish an " + "updated version"|nbsp + " on the " + "Digital Marketplace"|nbsp
+      message = (
+        "The buyer cancelled this opportunity, for example because they no longer have the budget."
+        + "<br />"|safe
+        + "They may publish an updated version later."
+      )
     %}
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -49,6 +49,19 @@
     {% endwith %}
   </div>
 </div>
+{% elif brief.status == 'cancelled' %}
+<div class="grid-row">
+  <div class="column-one-whole">
+    {%
+      with
+      type = "temporary-message",
+      heading = "This opportunity was cancelled",
+      message = "You can't apply for this opportunity now. The buyer may publish an " + "updated version"|nbsp + " on the " + "Digital Marketplace"|nbsp
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  </div>
+</div>
 {% elif brief.status == 'awarded' %}
 <div class="grid-row">
   <div class="column-one-whole">

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -23,7 +23,7 @@
 
 {% block main_content %}
 
-{% if brief.status in ['closed', 'cancelled', 'unsuccessful'] %}
+{% if brief.status == 'closed' %}
 <div class="grid-row">
   <div class="column-one-whole">
     {%
@@ -43,7 +43,7 @@
       with
       type = "temporary-message",
       heading = "This opportunity was withdrawn on " + "{}".format(brief.withdrawnAt|dateformat)|nbsp,
-      message = "You can't apply for this opportunity now. The buyer may publish an " + "updated version"|nbsp + " on the " + "Digital Marketplace"|nbsp
+      message = "You can't apply for this opportunity now. The buyer may publish an " + "updated version"|nbsp + " on the " + "Digital Marketplace."|nbsp
     %}
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}
@@ -74,7 +74,7 @@
       type = "temporary-message",
       heading = "No suitable suppliers applied",
       message = (
-        "example"
+        "The buyer didn't award this contract because no suppliers met their requirements"
         + "<br />"|safe
         + "They may publish an updated version later."
       )

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -52,15 +52,15 @@
 {% elif brief.status == 'cancelled' %}
 <div class="grid-row">
   <div class="column-one-whole">
+    {% set brief_cancelled_message %}
+      The buyer cancelled this opportunity, for example because they no longer have the budget.<br />
+      They may publish an updated version later.
+    {% endset %}
     {%
       with
       type = "temporary-message",
       heading = "This opportunity was cancelled",
-      message = (
-        "The buyer cancelled this opportunity, for example because they no longer have the budget."
-        + "<br />"|safe
-        + "They may publish an updated version later."
-      )
+      message = brief_cancelled_message
     %}
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}
@@ -69,15 +69,15 @@
 {% elif brief.status == 'unsuccessful' %}
 <div class="grid-row">
   <div class="column-one-whole">
+    {% set brief_unsuccessful_message %}
+    The buyer didn't award this contract because no suppliers met their requirements<br />
+    They may publish an updated version later.
+    {% endset %}
     {%
       with
       type = "temporary-message",
       heading = "No suitable suppliers applied",
-      message = (
-        "The buyer didn't award this contract because no suppliers met their requirements"
-        + "<br />"|safe
-        + "They may publish an updated version later."
-      )
+      message = brief_unsuccessful_message
     %}
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}
@@ -86,21 +86,20 @@
 {% elif brief.status == 'awarded' %}
 <div class="grid-row">
   <div class="column-one-whole">
+    {% set brief_awarded_message %}
+      Start date: {}<br />
+      Value: &pound;{:,.2f}<br/>
+      Company size: {}
+    {% endset %}
     {%
       with
       type = "temporary-message",
       heading = "Awarded to {}".format(winning_response.supplierName),
-      message = (
-        "Start date: {}"
-        + "<br />"|safe
-        + "Value: " + "&pound;"|safe + "{:,.2f}"
-        + "<br/>"|safe
-        + "Company size: {}"
-      ).format((
-        winning_response.awardDetails.awardedContractStartDate + "T00:00:00.000000Z")|dateformat,
-        winning_response.awardDetails.awardedContractValue|float,
-        winning_supplier_size
-      ).replace(".00", "")
+      message = brief_awarded_message.format((
+            winning_response.awardDetails.awardedContractStartDate + "T00:00:00.000000Z")|dateformat,
+            winning_response.awardDetails.awardedContractValue|float,
+            winning_supplier_size
+          ).replace(".00", "")
     %}
       {% include "toolkit/notification-banner.html" %}
     {% endwith %}

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -66,6 +66,23 @@
     {% endwith %}
   </div>
 </div>
+{% elif brief.status == 'unsuccessful' %}
+<div class="grid-row">
+  <div class="column-one-whole">
+    {%
+      with
+      type = "temporary-message",
+      heading = "No suitable suppliers applied",
+      message = (
+        "example"
+        + "<br />"|safe
+        + "They may publish an updated version later."
+      )
+    %}
+      {% include "toolkit/notification-banner.html" %}
+    {% endwith %}
+  </div>
+</div>
 {% elif brief.status == 'awarded' %}
 <div class="grid-row">
   <div class="column-one-whole">

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -976,6 +976,18 @@ class TestAwardedBriefPage(BaseBriefPageTest):
 
         assert 'Company size: SME' in awarded_banner.xpath('p/text()')[2]
 
+class TestCancelledBriefPage(BaseBriefPageTest):
+    def setup_method(self, method):
+        super(TestCancelledBriefPage, self).setup_method(method)
+        self.brief['briefs']['status'] = "cancelled"
+
+    def test_cancelled_banner_shown_on_cancelled_brief_page(self):
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(self.brief_id))
+        document = html.fromstring(res.get_data(as_text=True))
+        cancelled_banner = document.xpath('//div[@class="banner-temporary-message-without-action"]')[0]
+
+        assert 'This opportunity was cancelled' in cancelled_banner.xpath('h2/text()')[0]
+
 
 class TestWithdrawnSpecificBriefPage(BaseBriefPageTest):
     def setup_method(self, method):

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -988,6 +988,15 @@ class TestCancelledBriefPage(BaseBriefPageTest):
 
         assert 'This opportunity was cancelled' in cancelled_banner.xpath('h2/text()')[0]
 
+    def test_explanation_message_shown_on_cancelled_banner(self):
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(self.brief_id))
+        document = html.fromstring(res.get_data(as_text=True))
+        cancelled_banner = document.xpath('//div[@class="banner-temporary-message-without-action"]')[0]
+        message_part_1 = 'The buyer cancelled this opportunity, for example because they no longer have the budget.'
+        message_part_2 = 'They may publish an updated version later.'
+        assert message_part_1 in cancelled_banner.xpath('p/text()')[0]
+        assert message_part_2 in cancelled_banner.xpath('p/text()')[1]
+
 
 class TestWithdrawnSpecificBriefPage(BaseBriefPageTest):
     def setup_method(self, method):

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -937,7 +937,7 @@ class TestBriefPageQandASectionAskAQuestion(BaseBriefPageTest):
 class TestAwardedBriefPage(BaseBriefPageTest):
     def setup_method(self, method):
         super(TestAwardedBriefPage, self).setup_method(method)
-        self.brief['briefs']['status'] = "awarded"
+        self.brief['briefs']['status'] = 'awarded'
         self.brief['briefs']['awardedBriefResponseId'] = 14276
 
     def test_award_banner_with_winning_supplier_shown_on_awarded_brief_page(self):
@@ -979,7 +979,7 @@ class TestAwardedBriefPage(BaseBriefPageTest):
 class TestCancelledBriefPage(BaseBriefPageTest):
     def setup_method(self, method):
         super(TestCancelledBriefPage, self).setup_method(method)
-        self.brief['briefs']['status'] = "cancelled"
+        self.brief['briefs']['status'] = 'cancelled'
 
     def test_cancelled_banner_shown_on_cancelled_brief_page(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(self.brief_id))
@@ -996,6 +996,19 @@ class TestCancelledBriefPage(BaseBriefPageTest):
         message_part_2 = 'They may publish an updated version later.'
         assert message_part_1 in cancelled_banner.xpath('p/text()')[0]
         assert message_part_2 in cancelled_banner.xpath('p/text()')[1]
+
+
+class TestUnsuccessfulBriefPage(BaseBriefPageTest):
+    def setup_method(self, method):
+        super(TestUnsuccessfulBriefPage, self).setup_method(method)
+        self.brief['briefs']['status'] = 'unsuccessful'
+
+    def test_unsuccessful_banner_shown_on_unsuccessful_brief_page(self):
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(self.brief_id))
+        document = html.fromstring(res.get_data(as_text=True))
+        unsuccessful_banner = document.xpath('//div[@class="banner-temporary-message-without-action"]')[0]
+
+        assert 'No suitable suppliers applied' in unsuccessful_banner.xpath('h2/text()')[0]
 
 
 class TestWithdrawnSpecificBriefPage(BaseBriefPageTest):

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -581,7 +581,6 @@ class TestBriefPage(BaseBriefPageTest):
 
         apply_links = document.xpath('//a[@href="/suppliers/opportunities/{}/responses/start"]'.format(brief_id))
         assert len(apply_links) == 0
-        assert '15 December 2016' in document.xpath('//p[@class="banner-message"]')[0].text_content()
 
     def test_cannot_apply_to_awarded_brief(self):
         self.brief['briefs']['status'] = "awarded"
@@ -976,6 +975,7 @@ class TestAwardedBriefPage(BaseBriefPageTest):
 
         assert 'Company size: SME' in awarded_banner.xpath('p/text()')[2]
 
+
 class TestCancelledBriefPage(BaseBriefPageTest):
     def setup_method(self, method):
         super(TestCancelledBriefPage, self).setup_method(method)
@@ -1009,6 +1009,15 @@ class TestUnsuccessfulBriefPage(BaseBriefPageTest):
         unsuccessful_banner = document.xpath('//div[@class="banner-temporary-message-without-action"]')[0]
 
         assert 'No suitable suppliers applied' in unsuccessful_banner.xpath('h2/text()')[0]
+
+    def test_explanation_message_shown_on_unsuccessful_banner(self):
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(self.brief_id))
+        document = html.fromstring(res.get_data(as_text=True))
+        cancelled_banner = document.xpath('//div[@class="banner-temporary-message-without-action"]')[0]
+        message_part_1 = "The buyer didn't award this contract because no suppliers met their requirements"
+        message_part_2 = "They may publish an updated version later."
+        assert message_part_1 in cancelled_banner.xpath('p/text()')[0]
+        assert message_part_2 in cancelled_banner.xpath('p/text()')[1]
 
 
 class TestWithdrawnSpecificBriefPage(BaseBriefPageTest):

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -380,6 +380,17 @@ class TestBriefPage(BaseBriefPageTest):
         assert page_heading.xpath('h1/text()')[0] == self.brief['briefs']['title']
         assert page_heading.xpath('p[@class="context"]/text()')[0] == self.brief['briefs']['organisation']
 
+    @pytest.mark.parametrize('status', ['closed', 'unsuccessful', 'cancelled', 'awarded'])
+    def test_only_one_banner_at_once_brief_page(self, status):
+        self.brief['briefs']['status'] = status
+        if self.brief['briefs']['status'] == 'awarded':
+            self.brief['briefs']['awardedBriefResponseId'] = 14276
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(self.brief_id))
+        document = html.fromstring(res.get_data(as_text=True))
+        number_of_banners = len(document.xpath('//div[@class="banner-temporary-message-without-action"]'))
+
+        assert number_of_banners == 1
+
     def test_dos_brief_displays_application_stats(self):
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))


### PR DESCRIPTION
Trello ticket: https://trello.com/c/sqfpwtPW/797-1-show-award-status-when-buyer-has-cancelled-procurement