### PR TITLE
Download shortlist

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -451,4 +451,30 @@ def end_search(framework_framework, project_id):
 
 @direct_award.route('/<string:framework_framework>/projects/<int:project_id>/download-shortlist')
 def download_shortlist(framework_framework, project_id):
-    raise NotImplementedError()
+    # Get the requested Direct Award Project.
+    project = data_api_client.get_direct_award_project(project_id=project_id)['project']
+    if not is_direct_award_project_accessible(project, current_user.id):
+        abort(404)
+
+    searches = data_api_client.find_direct_award_project_searches(user_id=current_user.id,
+                                                                  project_id=project['id'])['searches']
+
+    if searches:
+        # A Direct Award project has one 'active' search which is what we will display on this overview page.
+        search = list(filter(lambda x: x['active'], searches))[0]
+
+        # Indexes for our search API are named by the framework slug they relate to.
+        framework_slug = search_api_client.get_index_from_search_api_url(search['searchUrl'])
+        framework = data_api_client.get_framework(framework_slug)['frameworks']
+
+        content_loader.load_messages(framework['slug'], ['descriptions', 'urls'])
+        framework_urls = content_loader.get_message(framework['slug'], 'urls')
+
+    else:
+        abort(404)
+
+    return render_template('direct-award/download-shortlist.html',
+                           framework=framework,
+                           project=project,
+                           framework_urls=framework_urls
+                           )

--- a/app/templates/direct-award/download-shortlist.html
+++ b/app/templates/direct-award/download-shortlist.html
@@ -1,0 +1,72 @@
+{% extends "_base_page.html" %}
+
+{% block page_title %}Download your shortlist - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with
+    items = [
+      {
+          "link": url_for('main.index'),
+          "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for('external.buyer_dashboard'),
+        "label": "Your Account"
+      },
+      {
+        "link": url_for('direct_award.saved_search_overview', framework_framework=framework.framework),
+        "label": "Saved searches"
+      },
+      {
+        "link": url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id),
+        "label": project.name
+      },
+      {
+        "label": "End search"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <header class="page-heading">
+      <h1>
+        Download your shortlist
+      </h1>
+    </header>
+  </div>
+  <div class="column-two-thirds">
+    <div class="marketplace-paragraph">
+      <p>Download your shortlist to help you track and record your decision-making.</p>
+    </div>
+    <div class="explanation-list">
+      <p class="lead">The shortlist file includes:</p>
+      <ul class='list-bullet'>
+        <li>service names, descriptions and pricing information</li>
+        <li>links to detailed service description pages on the Digital Marketplace</li>
+        <li>supplier names and contact details</li>
+      </ul>
+    </div>
+    <div class="marketplace-paragraph">
+      <p>
+        <br>
+        <a href="{{ url_for('direct_award.download_shortlist', framework_framework=framework.framework, project_id=project.id, filetype='odf') }}">Download shortlist (ODF)</a>
+        <br>
+        <a href="{{ url_for('direct_award.download_shortlist', framework_framework=framework.framework, project_id=project.id, filetype='csv') }}">Download shortlist (CSV)</a>
+      </p>
+      <br>
+    </div>
+    <div class="marketplace-paragraph">
+    <h2>After you download your shortlist</h2>
+      <p>Compare services to find the cheapest or best value for money.<br>Read the <a href="{{ framework_urls.buyers_guide_compare_services_url }}">{{ framework.framework|title }} Buyers' Guide</a> for details
+    of how to compare services.</p>
+      <p><a href="{{ url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id) }}">Return to overview</a></p>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
Add intermediate page for downloading a shortlist for a locked direct award project. Further work will be required to add functionality for the links and tests.

## Screenshot
<img width="1111" alt="screen shot 2017-09-06 at 14 34 02" src="https://user-images.githubusercontent.com/2920760/30114686-79042a80-9310-11e7-8ba4-ff9c865b8428.png">


## Ticket
https://trello.com/c/igRhA3Bt/711-shortlist-file-download