### PR TITLE
Pull in frontend-toolkit v24.2.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.2.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.2.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.13.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"


### PR DESCRIPTION
## Summary
Pull in updated toolkit to fix a cross-browser CSS compatibility bug for an element on the search overview page (namely the boxes surrounding 'Search saved on ...'/etc text, which was spanning the width of the table on Safari+IE but was meant to hug the contents only).

Please could one of you (Dilwoar/George) shepherd this through tomorrow if I'm not around.

## Ticket
https://trello.com/c/9YtT8DmX/675-task-list-saved-search-overview-page