### PR TITLE
709 test save search submission

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -387,7 +387,7 @@ def project_create(framework_framework):
                                form=form,
                                search_summary=search_meta.search_summary,
                                search_api_url=request.form['search_api_url'],
-                               framework_framework=framework_framework)
+                               framework_framework=framework_framework), 400
 
 
 @direct_award.route('/<string:framework_framework>/projects/<int:project_id>', methods=['GET'])

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -377,7 +377,7 @@ def project_create(framework_framework):
         return redirect(url_for('.view_project',
                                 framework_framework=framework_framework,
                                 project_id=project['id']
-                                ))
+                                ), code=303)
     else:
         frameworks_by_slug = framework_helpers.get_frameworks_by_slug(data_api_client)
 


### PR DESCRIPTION
Some new tests for the save search / create project flow, plus some minor changes to use better HTTP statuses.

https://trello.com/c/ubKd3ztP/709-save-search-and-name-your-procurement-design-and-content