### PR TITLE
Remove context sentence and divider above first instruction

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -418,8 +418,7 @@ def view_project(framework_framework, project_id):
         buyer_search_page_url = None
         search_summary_sentence = None
 
-    content_loader.load_messages(framework['slug'], ['descriptions', 'urls'])
-    framework_short_description = content_loader.get_message(framework['slug'], 'descriptions', 'framework_short')
+    content_loader.load_messages(framework['slug'], ['urls'])
     framework_urls = content_loader.get_message(framework['slug'], 'urls')
 
     return render_template('direct-award/view-project.html',
@@ -428,7 +427,6 @@ def view_project(framework_framework, project_id):
                            search=search,
                            buyer_search_page_url=buyer_search_page_url,
                            search_summary_sentence=search_summary_sentence,
-                           framework_short_description=framework_short_description,
                            framework_urls=framework_urls,
                            call_off_contract_url=framework_urls['call_off_contract_url'],
                            customer_benefits_record_form_url=framework_urls['customer_benefits_record_form_url'],

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -40,8 +40,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       {% block before_sections %}{% endblock %}
-      <p class="">Find, compare and buy {{ framework_short_description }}.</p>
-      <ol class="instruction-list steps divider">
+      <ol class="instruction-list steps">
         {% for step in [
           {
             "title": "Prepare your requirements",


### PR DESCRIPTION
## Summary
Slightly tweaked the design for sign-off on the task list page - have been asked to remove the context line about finding/buying cloud services and the divider before the first instruction.

## Before
<img width="700" alt="screen shot 2017-09-12 at 15 07 53" src="https://user-images.githubusercontent.com/2920760/30330213-50484340-97cc-11e7-9dfe-d9c173981ed0.png">

## After
<img width="768" alt="screen shot 2017-09-12 at 15 06 47" src="https://user-images.githubusercontent.com/2920760/30330218-527a29c6-97cc-11e7-94c1-fdb88627ec3a.png">

## Ticket
https://trello.com/c/9YtT8DmX/675-task-list-saved-search-overview-page