### PR TITLE
Update breadcrumbs to be consistent with other content

### DIFF
--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -12,7 +12,7 @@
       },
       {
           "link": url_for('external.buyer_dashboard'),
-          "label": "Your Account"
+          "label": "Your account"
       },
       {
           "link": url_for('direct_award.saved_search_overview', framework_framework=framework.framework),


### PR DESCRIPTION
## Summary
We're updating breadcrumbs around the buyer account page in the briefs-frontend app and have decided that the correct content for the dual dashboard is 'Your Account'. Some breadcrumbs in the buyer app conflict with this, so let's update them.

As seen in: https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/30

## Ticket
https://trello.com/c/FiR3NLyZ/679-buyer-account-page