### PR TITLE
Update homepage link to new "Become a supplier" page

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -94,11 +94,10 @@
     {% if current_user.role != 'supplier' %}
       <div class="padding-bottom-small">
         <p>
-          <a href="/suppliers/create" class="top-level-link">
-            Create a supplier account
+          <a href="/suppliers/supply" class="top-level-link">
+            Become a supplier
           </a>
         </p>
-        <p>Get updates about opportunities to sell on the Digital Marketplace.</p>
       </div>
     {% endif %}
 

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -294,7 +294,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         sidebar_link_texts = [str(item).strip() for item in sidebar_links]
 
         assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
-        assert 'Create a supplier account' in sidebar_link_texts
+        assert 'Become a supplier' in sidebar_link_texts
 
     @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
     def test_homepage_sidebar_messages_when_logged_in(self, data_api_client):
@@ -315,7 +315,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         sidebar_link_texts = [str(item).strip() for item in sidebar_links]
 
         assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
-        assert 'Create a supplier account' not in sidebar_link_texts
+        assert 'Become a supplier' not in sidebar_link_texts
 
     # here we've given an valid framework with a valid status but there is no message.yml file to read from
     @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)


### PR DESCRIPTION
For this Trello ticket: https://trello.com/c/kMYuzoge/75-create-the-become-a-supplier-page-2
This should NOT BE MERGED until the page in supplier app actually exists:

 - [x] https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/741

When this is merged then these *two* functional tests PRs should be merged at the same time to keep things green:
 - [ ] https://github.com/alphagov/digitalmarketplace-functional-tests/pull/364
 - [ ] https://github.com/alphagov/digitalmarketplace-functional-tests/pull/365

## New look
![screen shot 2017-09-14 at 18 51 00](https://user-images.githubusercontent.com/6525554/30445472-f268b864-997d-11e7-8eda-6c045ba905e4.png)
