### PR TITLE
Choose an existing saved search

### DIFF
--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -1,5 +1,5 @@
 from flask_wtf import Form
-from wtforms.validators import Length
+from wtforms.validators import Length, Optional
 from dmutils.forms import StripWhitespaceStringField
 
 
@@ -9,6 +9,7 @@ class CreateProjectForm(Form):
         validators=[
             Length(min=1,
                    max=100,
-                   message="Names must be between 1 and 100 characters")
+                   message="Names must be between 1 and 100 characters"),
+            Optional()
         ]
     )

--- a/app/main/helpers/direct_award_helpers.py
+++ b/app/main/helpers/direct_award_helpers.py
@@ -1,2 +1,31 @@
+from app import data_api_client
+from operator import itemgetter
+
+
 def is_direct_award_project_accessible(project, user_id):
     return any([user['id'] == user_id for user in project['users']])
+
+
+def get_direct_award_projects(user_id, return_type="all", sort_by_key=None):
+    projects = data_api_client.find_direct_award_projects(user_id).get('projects', [])
+
+    res = {
+        "open_projects": [],
+        "closed_projects": [],
+    }
+
+    for project in projects:
+        if project['lockedAt'] is None:
+            res['open_projects'].append(project)
+        else:
+            res['closed_projects'].append(project)
+
+    if return_type == "all":
+        if sort_by_key:
+            res['open_projects'].sort(key=itemgetter(sort_by_key))
+            res['closed_projects'].sort(key=itemgetter(sort_by_key))
+        return res
+    else:
+        if sort_by_key:
+            res[return_type].sort(key=itemgetter(sort_by_key))
+        return res[return_type]

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -90,12 +90,11 @@
         </fieldset>
 
         <br>
-        
-        <fieldset>
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-          <input type="hidden" name="search_api_url" value="{{ search_api_url }}"/>
-          <input type="submit" class="button-save" name="return_to_overview" value="Save and continue">
-        </fieldset>
+
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="hidden" name="search_api_url" value="{{ search_api_url }}"/>
+        <input type="submit" class="button-save" name="return_to_overview" value="Save and continue">
+
       </div>
     </div>
   </form>

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -33,36 +33,69 @@
   </div>
   <form method="post" action="{{ url_for('direct_award.project_create', framework_framework=framework_framework)}}" id="createProjectForm">
     <div class="grid-row">
-      <div class="column-two-thirds dmspeak">
+      <div class="column-two-thirds">
         <div class="panel panel-border-wide">
           {% with content = search_summary_sentence %}
             {% include "toolkit/search-summary.html" %}
           {% endwith %}
         </div>
-        <h2 class="heading-xmedium">Create a new saved search</h2>
-        <p>Name your search. A short description of what you want to buy makes a good name.</p>
-        {% if form.name.errors %}
-        <div class="validation-wrapper">
-            {% endif %}
-            <div class="question" id="{{ form.name.name }}">
+
+        <div class="dmspeak">
+          <h2 class="heading-xmedium">Choose where to save your search</h2>
+        </div>
+        
+        <fieldset>
+          <div class="multiple-choice" data-target="new-search">
+            <input type="radio" name="save_search_selection" value="new_search" 
+              {% if request.form.save_search_selection == 'new_search' or not projects %}checked="checked"{% endif %} 
+              required="required">
+            <label for="save_search_selection">Create a new search</label>
+          </div>
+          <div class="panel panel-border-narrow js-hidden" id="new-search">
+            {% if form.name.errors %}
+            <div class="validation-wrapper">
+              {% endif %}
+              <div class="question" id="{{ form.name.name }}">
                 {{ form.name.label(class="question-heading") }}
+                <p>Name your search. A short description of what you want to buy makes a good name.</p>
                 <p class="hint">
-                    100 characters maximum
+                  100 characters maximum
                 </p>
                 {% if form.name.errors %}
                 <p class="validation-message" id="error-name-textbox">
-                    {% for error in form.name.errors %}{{ error }}{% endfor %}
+                  {% for error in form.name.errors %}{{ error }}{% endfor %}
                 </p>
                 {% endif %}
                 {{ form.name(class="text-box") }}
+              </div>
+              {% if form.name.errors %}
             </div>
-            {% if form.name.errors %}
-        </div>
-        {% endif %}
+              {% endif %}
+          </div>
 
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <input type="hidden" name="search_api_url" value="{{ search_api_url }}"/>
-        <input type="submit" class="button-save" name="return_to_overview" value="Save and continue">
+          {% if projects %}
+
+          <p class="form-block">or</p>
+
+          {% for project in projects %}
+
+          <div class="multiple-choice">
+            <input type="radio" name="save_search_selection" value="{{ project.id }}" {% if request.form.save_search_selection == project.id %}checked="checked"{% endif %}>
+            <label for="save_search_selection">{{ project.name or "No Project Name" }}</label>
+          </div>
+
+          {% endfor %}
+
+          {% endif %}
+        </fieldset>
+
+        <br>
+        
+        <fieldset>
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          <input type="hidden" name="search_api_url" value="{{ search_api_url }}"/>
+          <input type="submit" class="button-save" name="return_to_overview" value="Save and continue">
+        </fieldset>
       </div>
     </div>
   </form>

--- a/tests/fixtures/direct_award_project_list_fixture.json
+++ b/tests/fixtures/direct_award_project_list_fixture.json
@@ -1,0 +1,164 @@
+{
+  "links": {
+    "self": "http://localhost:5000/direct-award/projects?user-id=32157"
+  },
+  "meta": {
+    "total": 22
+  },
+  "projects": [
+    {
+      "active": true,
+      "createdAt": "2017-08-31T11:49:45.546512Z",
+      "id": 3,
+      "lockedAt": "2017-09-06T16:55:03.244373Z",
+      "name": "Procurement Test - Software"
+    },
+    {
+      "active": false,
+      "createdAt": "2017-09-04T10:29:52.686781Z",
+      "id": 4,
+      "lockedAt": "2017-09-04T10:29:52.686781Z",
+      "name": "Procurement Test - Legal Software"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-04T11:28:27.318985Z",
+      "id": 5,
+      "lockedAt": "2017-09-06T17:03:09.868521Z",
+      "name": "Procurement Test - Test"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-05T13:26:15.692748Z",
+      "id": 6,
+      "lockedAt": "2017-09-06T17:03:20.549849Z",
+      "name": "Procurement Test - Chocolate"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-06T09:46:28.186848Z",
+      "id": 7,
+      "lockedAt": "2017-09-06T16:51:33.010667Z",
+      "name": "Procurement Test - Laptops"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-06T11:24:42.366588Z",
+      "id": 8,
+      "lockedAt": "2017-09-06T17:04:26.039944Z",
+      "name": "Procurement Test - Trainers"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-06T16:41:49.819477Z",
+      "id": 9,
+      "lockedAt": "2017-09-18T14:32:51.142053Z",
+      "name": "Procurement Test 25"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-06T17:04:44.194675Z",
+      "id": 10,
+      "lockedAt": "2017-09-18T14:34:52.685518Z",
+      "name": "Procurement Test 10"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-06T17:13:26.514960Z",
+      "id": 11,
+      "lockedAt": "2017-09-06T17:18:19.035669Z",
+      "name": "Procurement Test 11"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-07T10:42:47.823866Z",
+      "id": 12,
+      "lockedAt": "2017-09-08T14:05:17.113039Z",
+      "name": "Procurement Test 12"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-08T14:06:42.245101Z",
+      "id": 13,
+      "lockedAt": "2017-09-08T14:06:45.597781Z",
+      "name": "Procurement Test 13"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-08T14:07:10.804280Z",
+      "id": 14,
+      "lockedAt": "2017-09-08T14:07:14.716154Z",
+      "name": "Procurement Test 14"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-12T14:53:49.533362Z",
+      "id": 15,
+      "lockedAt": "2017-09-18T14:35:32.716428Z",
+      "name": "Procurement Test 15"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-15T09:32:13.320740Z",
+      "id": 19,
+      "lockedAt": "2017-09-18T14:35:54.266574Z",
+      "name": "Procurement Test 19"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-18T11:24:10.790422Z",
+      "id": 20,
+      "lockedAt": "2017-09-18T14:36:04.709057Z",
+      "name": "Procurement Test 20"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-18T13:27:48.463582Z",
+      "id": 21,
+      "lockedAt": "2017-09-18T14:36:26.493646Z",
+      "name": "Procurement Test 21"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-18T13:52:59.573140Z",
+      "id": 22,
+      "lockedAt": "2017-09-18T14:36:35.996437Z",
+      "name": "Procurement Test 22"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-18T14:08:25.040681Z",
+      "id": 23,
+      "lockedAt": "2017-09-18T14:36:48.956226Z",
+      "name": "Procurement Test 23"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-18T14:15:17.217630Z",
+      "id": 24,
+      "lockedAt": "2017-09-18T14:36:56.265221Z",
+      "name": "Procurement Test 24"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-18T14:40:41.741815Z",
+      "id": 25,
+      "lockedAt": "2017-09-18T14:40:52.903082Z",
+      "name": "Test"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-18T15:33:37.612538Z",
+      "id": 26,
+      "lockedAt": null,
+      "name": "test"
+    },
+    {
+      "active": true,
+      "createdAt": "2017-09-18T15:33:52.215176Z",
+      "id": 27,
+      "lockedAt": null,
+      "name": "test 2"
+    }
+  ]
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -146,6 +146,10 @@ class BaseApplicationTest(object):
             'suppliers_by_prefix_fixture_page_with_next_and_prev.json')
 
     @staticmethod
+    def _get_direct_award_project_list_fixture(**kwargs):
+        return BaseApplicationTest._get_fixture_data('direct_award_project_list_fixture.json')
+
+    @staticmethod
     def _get_direct_award_project_fixture(**kwargs):
         project = BaseApplicationTest._get_fixture_data('direct_award_project_fixture.json')
 


### PR DESCRIPTION
As a G-Cloud buyer
I need to be able to return to work I've already started on a procurement
so that I can progress with my procurement

After clicking save search - the user has the option to add the search to a new procurement or update the search in an existing procurement

Ticket: https://trello.com/c/zt49gYL6/673-choose-an-existing-saved-search

Still to do:
- ~~Write Tests~~

<img width="1207" alt="screen shot 2017-09-18 at 15 20 59" src="https://user-images.githubusercontent.com/4599889/30546803-8305b246-9c85-11e7-9314-c471de1e2f37.png">
