### PR TITLE
722 refactor save search

### DIFF
--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -7,7 +7,12 @@ from flask import url_for
 
 
 def get_lot_from_request(request, all_lots):
-    lot = request.args.get('lot', None)
+    # TODO prefer get_lot_from_args - get rid of this
+    return get_lot_from_args(request.args, all_lots)
+
+
+def get_lot_from_args(args, all_lots):
+    lot = args.get('lot', None)
     return lot if (not lot or lot in all_lots) else None
 
 

--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -6,11 +6,6 @@ from werkzeug.urls import Href
 from flask import url_for
 
 
-def get_lot_from_request(request, all_lots):
-    # TODO prefer get_lot_from_args - get rid of this
-    return get_lot_from_args(request.args, all_lots)
-
-
 def get_lot_from_args(args, all_lots):
     lot = args.get('lot', None)
     return lot if (not lot or lot in all_lots) else None

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -7,7 +7,7 @@ from werkzeug.urls import Href
 from ..helpers.framework_helpers import get_lots_by_slug
 from ..helpers.search_helpers import (
     get_filters_from_request,
-    get_lot_from_request,
+    get_lot_from_args,
     get_filter_value_from_question_option,
     build_search_query,
     clean_request_args
@@ -189,7 +189,7 @@ def build_lots_and_categories_link_tree(framework, lots, category_filter_group, 
     :param content_manifest: a ContentManifest instance for G-Cloud search_filters.
     :return: list of selected category and lot filters, starting with the 'all categories' root node node
     """
-    current_lot_slug = get_lot_from_request(request, [lot['slug'] for lot in lots])
+    current_lot_slug = get_lot_from_args(request.args, [lot['slug'] for lot in lots])
 
     # Links in the tree should preserve all the filters, except those relating to this tree (i.e. lot
     # and category).

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -22,7 +22,7 @@ from ..helpers.search_helpers import (
     get_keywords_from_request, pagination,
     get_page_from_request, query_args_for_pagination,
     get_lot_from_args,
-    get_lot_from_request, build_search_query,
+    build_search_query,
     clean_request_args, get_request_url_without_any_filters,
 )
 from ..helpers import framework_helpers
@@ -169,7 +169,7 @@ def search_services():
 
     lots_by_slug = framework_helpers.get_lots_by_slug(framework)
 
-    current_lot_slug = get_lot_from_request(request, lots_by_slug)
+    current_lot_slug = get_lot_from_args(request.args, lots_by_slug)
 
     # the bulk of the possible filter parameters are defined through the content loader. they're all boolean and the
     # search api uses the same "question" labels as the content for its attributes, so we can really use those labels

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -31,7 +31,7 @@
       </header>
     </div>
   </div>
-  <form method="post" action="{{ url_for('direct_award.project_create', framework_framework=framework_framework)}}" id="createProjectForm">
+  <form method="post" action="" id="createProjectForm">
     <div class="grid-row">
       <div class="column-two-thirds">
         <div class="panel panel-border-wide">
@@ -92,7 +92,7 @@
         <br>
 
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <input type="hidden" name="search_api_url" value="{{ search_api_url }}"/>
+        <input type="hidden" name="search_query" value="{{ search_query }}"/>
         <input type="submit" class="button-save" name="return_to_overview" value="Save and continue">
 
       </div>

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -46,10 +46,10 @@
         
         <fieldset>
           <div class="multiple-choice" data-target="new-search">
-            <input type="radio" name="save_search_selection" value="new_search" 
+            <input type="radio" name="save_search_selection" value="new_search" id="project-new"
               {% if request.form.save_search_selection == 'new_search' or not projects %}checked="checked"{% endif %} 
               required="required">
-            <label for="save_search_selection">Create a new search</label>
+            <label for="project-new">Create a new search</label>
           </div>
           <div class="panel panel-border-narrow js-hidden" id="new-search">
             {% if form.name.errors %}
@@ -80,8 +80,8 @@
           {% for project in projects %}
 
           <div class="multiple-choice">
-            <input type="radio" name="save_search_selection" value="{{ project.id }}" {% if request.form.save_search_selection == project.id %}checked="checked"{% endif %}>
-            <label for="save_search_selection">{{ project.name or "No Project Name" }}</label>
+            <input type="radio" name="save_search_selection" value="{{ project.id }}" id="project-{{ project.id }}"{% if request.form.save_search_selection == project.id %}checked="checked"{% endif %}>
+            <label for="project-{{ project.id }}">{{ project.name or "No Project Name" }}</label>
           </div>
 
           {% endfor %}

--- a/app/templates/search/_services_save_search.html
+++ b/app/templates/search/_services_save_search.html
@@ -1,0 +1,17 @@
+<div id="js-dm-live-save-search-form">
+  {% if 'DIRECT_AWARD_PROJECTS' is active_feature %}
+    <form action="{{ url_for('direct_award.save_search', framework_framework=framework_family) }}">
+      <input type="hidden" name="search_query" value="{{ search_query_url }}">
+      <div class="button-save-wrapper">
+        <div class="save-summary-text">
+          Save details of your search and download a shortlist of services
+        </div>
+        <div class="save-button">
+          <button id="save-search" class="button-save" role="button" type="submit">
+            Save search
+          </button>
+        </div>
+      </div>
+    </form>
+  {% endif %}
+</div>

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -48,22 +48,12 @@
     <section class="column-one-third search-page-filters" aria-label="Search filters">
           {% include 'search/_services_filters.html' %}
     </section>
-    <section class="column-two-thirds" aria-label="Search results">
-      {% include 'search/_services_summary.html' %}
-      {% if 'DIRECT_AWARD_PROJECTS' is active_feature %}
-        <div class="button-save-wrapper">
-          <div class="save-summary-text">
-            Save details of your search and download a shortlist of services
-          </div>
-          <div class="save-button">
-            <button id="save-search" class="button-save" role="button" type="submit" formaction="{{ url_for('direct_award.save_search', framework_framework=framework_family) }}">
-              Save search
-            </button>
-          </div>
-        </div>
-      {% endif %}
-      {% include 'search/_services_results_wrapper.html' %}
-    </section>
   </form>
+  <section class="column-two-thirds" aria-label="Search results">
+    {% include 'search/_services_summary.html' %}
+    {% include 'search/_services_save_search.html' %}
+    {% include 'search/_services_results_wrapper.html' %}
+  </section>
+
 </div>
 {% endblock %}

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -592,7 +592,7 @@ class TestSearchFilterOnClick(BaseApplicationTest):
         res = self.client.get('/g-cloud/search?live-results=true')
         data = json.loads(res.get_data(as_text=True))
 
-        assert set(data.keys()) == {'results', 'summary', 'categories'}
+        assert set(data.keys()) == {'results', 'summary', 'categories', 'save-form'}
 
         for k, v in data.items():
             assert set(v.keys()) == {'selector', 'html'}
@@ -604,7 +604,9 @@ class TestSearchFilterOnClick(BaseApplicationTest):
                              (('', {'search/services.html'}),
                               ('?live-results=true', {"search/_services_results_wrapper.html",
                                                       "search/_services_categories_wrapper.html",
-                                                      "search/_services_summary.html"})))
+                                                      "search/_services_summary.html",
+                                                      "search/_services_save_search.html",
+                                                      })))
     @mock.patch('app.main.views.g_cloud.render_template', autospec=True)
     def test_base_page_renders_search_services(self, render_template_patch, query_string, urls):
         render_template_patch.return_value = '<p>some html</p>'


### PR DESCRIPTION
* Refactor save search form to avoid exposing Search API URLs;
* fix problem with the initial Save Search button in IE8, which does not support the form-action attribute;
* fix label elements on save search page.

The first of these should have no functional impact; the other two are bug-fixes.

As well as now using a frontend-side (i.e. buyer app) URL (chunk) to represent the search on the 'save search' page, the other refactoring of interest is that the 'create project' view has been combined into the 'save search' view. It already did more than just create projects, and the two views needed to have quite a large chunk of code in common anyway.

https://trello.com/c/ubKd3ztP/709-save-search-and-name-your-procurement-design-and-content
https://trello.com/c/jjVWnK1e/722-security-fixes-for-save-search-feature
