### PR TITLE
Download search results

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,7 @@ def create_app(config_name):
                     content_loader.load_manifest(framework_data['slug'], 'services', 'search_filters')
                 # we need to be able to display old services, even on expired frameworks
                 content_loader.load_manifest(framework_data['slug'], 'services', 'display_service')
+                content_loader.load_manifest(framework_data['slug'], 'services', 'download_results')
             elif framework_data['framework'] == 'digital-outcomes-and-specialists':
                 content_loader.load_manifest(framework_data['slug'], 'briefs', 'display_brief')
 

--- a/app/main/helpers/search_save_helpers.py
+++ b/app/main/helpers/search_save_helpers.py
@@ -13,7 +13,7 @@ from .search_helpers import ungroup_request_filters
 
 
 class SearchMeta(object):
-    def __init__(self, search_api_url, frameworks_by_slug):
+    def __init__(self, search_api_url, frameworks_by_slug, include_markup=False):
         # Get core data
         self.framework_slug = search_api_client.get_index_from_search_api_url(search_api_url)
         framework = frameworks_by_slug[self.framework_slug]
@@ -38,5 +38,6 @@ class SearchMeta(object):
             search_api_response['meta']['total'],
             clean_request_query_params.copy(),
             filters.values(),
-            lots_by_slug
+            lots_by_slug,
+            include_markup=include_markup
         )

--- a/app/main/helpers/shared_helpers.py
+++ b/app/main/helpers/shared_helpers.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+from itertools import chain
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
 
@@ -27,3 +29,21 @@ def construct_url_from_base_and_params(base_url, query_params):
 
     # Reconstruct the full URL with inline params from our six-item iterable
     return urlunparse(parsed_url)
+
+
+def get_fields_from_manifest(content_manifest):
+    """Takes a content manifest and returns a tuple of all the key names that hold data."""
+    fields_nested = [section.get_field_names() for section in content_manifest.sections]
+
+    return tuple(chain.from_iterable(fields_nested))
+
+
+def get_questions_from_manifest_by_id(content_manifest):
+    """Returns an OrderedDict of all questions in a content manifest, {question.id: question, ...}"""
+    questions = OrderedDict()
+
+    for section in content_manifest.sections:
+        for question in section.questions:
+            questions[question.id] = question
+
+    return questions

--- a/app/templates/direct-award/results.html
+++ b/app/templates/direct-award/results.html
@@ -55,9 +55,9 @@
     <div class="marketplace-paragraph">
       <p>
         <br>
-        <a href="{{ url_for('direct_award.download_shortlist', framework_framework=framework.framework, project_id=project.id, filetype='odf') }}">Download search results spreadsheet (ODF)</a>
+        <a href="{{ url_for('direct_award.download_results', framework_framework=framework.framework, project_id=project.id, filetype='ods') }}">Download search results spreadsheet (ODS)</a>
         <br>
-        <a href="{{ url_for('direct_award.download_shortlist', framework_framework=framework.framework, project_id=project.id, filetype='csv') }}">Download search results spreadsheet (CSV)</a>
+        <a href="{{ url_for('direct_award.download_results', framework_framework=framework.framework, project_id=project.id, filetype='csv') }}">Download search results spreadsheet (CSV)</a>
       </p>
       <br>
     </div>

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -78,8 +78,8 @@
             "title": "Download your search results",
             "content": [
               {"type": "text", "text": ''.join(["Download a spreadsheet of your search results.<br>You can use the spreadsheet to help you review or <a href=\"", framework_urls.buyers_guide_compare_services_url|e, "\" target=\"_blank\" rel=\"external noopener noreferrer\">compare services</a>."])|safe},
-              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not search.searchedAt else {"type": "action", "label": "Download search results", "href": url_for('direct_award.download_shortlist', framework_framework=framework.framework, project_id=project.id)} if not project.downloadedAt else {"type": "box", "style": "complete", "label": "Search results downloaded"},
-              {"type": "text", "text": ''.join(["<a href=\"", url_for('direct_award.download_shortlist', framework_framework=framework.framework, project_id=project.id)|e, "\">Download your results again.</a>"])|safe} if project.downloadedAt else {}
+              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not search.searchedAt else {"type": "action", "label": "Download search results", "href": url_for('direct_award.search_results', framework_framework=framework.framework, project_id=project.id)} if not project.downloadedAt else {"type": "box", "style": "complete", "label": "Search results downloaded"},
+              {"type": "text", "text": ''.join(["<a href=\"", url_for('direct_award.search_results', framework_framework=framework.framework, project_id=project.id)|e, "\">Download your results again.</a>"])|safe} if project.downloadedAt else {}
             ]
           },
           {

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.2.5",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.13.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.15.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   }
 }

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,8 @@
 Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
+lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.8.0#egg=digitalmarketplace-utils==28.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.3.0#egg=digitalmarketplace-apiclient==10.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.6.0#egg=digitalmarketplace-apiclient==10.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ pytest==2.9.1
 flake8==2.6.2
 flake8-putty==0.4.0
 mock==2.0.0
-lxml==3.8.0
 cssselect==0.9.1
 watchdog==0.8.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,11 @@
 Flask==0.10.1
 Flask-Login==0.2.11
 Flask-WTF==0.12
+lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.2#egg=digitalmarketplace-utils==27.2.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@28.8.0#egg=digitalmarketplace-utils==28.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.3.0#egg=digitalmarketplace-apiclient==10.3.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.6.0#egg=digitalmarketplace-apiclient==10.6.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.22.0
@@ -34,6 +35,7 @@ Markdown==2.6.7
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
+odfpy==1.3.3
 pycparser==2.18
 PyJWT==1.5.2
 python-dateutil==2.6.1

--- a/tests/fixtures/direct_award_project_services_fixture.json
+++ b/tests/fixtures/direct_award_project_services_fixture.json
@@ -1,0 +1,29 @@
+{
+  "links": {
+    "self": "http://localhost:5000/direct-award/projects/1/services"
+  },
+  "meta": {
+    "total": 1
+  },
+  "services": [
+    {
+      "data": {
+        "serviceName": "Service name",
+        "serviceDescription": "This is a really interesting and appropriate service description.",
+        "priceMin": "1.00",
+        "priceMax": "10.00",
+        "priceInterval": "hour",
+        "priceUnit": "virtual machine"
+      },
+      "id": "123456789",
+      "supplier": {
+        "contact": {
+          "email": "test@fixture.com",
+          "name": "Supplier contact name",
+          "phone": "01234 000 000"
+        },
+        "name": "Supplier name"
+      }
+    }
+  ]
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -154,22 +154,29 @@ class BaseApplicationTest(object):
         project = BaseApplicationTest._get_fixture_data('direct_award_project_fixture.json')
 
         for key, value in kwargs.items():
-            if key in project:
+            if key in project['project']:
                 project['project'][key] = value
             else:
-                raise ValueError('Key "{}" does not exist in the Direct Award project fixture.')
+                raise ValueError('Key "{}" does not exist in the Direct Award project fixture.'.format(key))
 
         return project
 
     @staticmethod
     def _get_direct_award_lock_project_fixture():
-        fixture = BaseApplicationTest._get_fixture_data('direct_award_project_fixture.json')
-        fixture['project']['lockedAt'] = "2017-09-08T00:00:00.000000Z"
-        return fixture
+        return BaseApplicationTest._get_direct_award_project_fixture(lockedAt="2017-09-08T00:00:00.000000Z")
 
     @staticmethod
-    def _get_direct_award_project_searches_fixture():
-        return BaseApplicationTest._get_fixture_data('direct_award_project_searches_fixture.json')
+    def _get_direct_award_project_searches_fixture(only_active=False):
+        searches = BaseApplicationTest._get_fixture_data('direct_award_project_searches_fixture.json')
+
+        if only_active:
+            searches = {'searches': [search for search in searches['searches'] if search['active']]}
+
+        return searches
+
+    @staticmethod
+    def _get_direct_award_project_services_fixture():
+        return BaseApplicationTest._get_fixture_data('direct_award_project_services_fixture.json')
 
     @staticmethod
     def _strip_whitespace(whitespace_in_this):


### PR DESCRIPTION
## Summary
When a G-Cloud buyer has ended their search and locked in their result set, we want them to be able to download a list of the services that match their specifications so they can start to compare those services offline. This PR adds that endpoint and supports CSV and ODS filetypes.

We pull in an updated version of utils, which now contains a generic `DownloadFileView` that can be  (and has been) subclassed in the buyer-frontend to generate the data required for these files.

We also update the SearchMeta class to prevent HTML tags being embedded in the search summary, as we want to present this in the downloaded file.

The URL for the search results download preface page has been changed to allow a better structure. We have `/projects/x/results` for the preface page, and `/projects/x/results/download` for the download endpoint.

## Example file downloads
https://drive.google.com/open?id=0Bwv8xRW8JeF7QXplWm1kQWRldFE (csv)
https://drive.google.com/open?id=0Bwv8xRW8JeF7ZExyNVN0WVhkTEU (ods)

## Blocked by
* [x] Must write tests for DownloadResultsView
* [x] Re-run `freeze-requirements` after the utils PR goes in

## Depends upon
https://github.com/alphagov/digitalmarketplace-api/pull/656
~~https://github.com/alphagov/digitalmarketplace-apiclient/pull/98~~
https://github.com/alphagov/digitalmarketplace-utils/pull/332
~~https://github.com/alphagov/digitalmarketplace-frameworks/pull/473~~

## Other associated PRs
https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/32

## Ticket
https://trello.com/c/igRhA3Bt/711-shortlist-file-download