### PR TITLE
736 bug styling on dos opportunities page

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -1,7 +1,28 @@
-@import "govuk-elements";
+// GOVUK Front-end toolkit styles, including dependencies for govuk-elements
+// Settings (variables)
+@import "colours";                                // Colour variables
+@import "font_stack";                             // Font family variables
+@import "measurements";                           // Widths and gutter variables
+
+// Mixins
+@import "conditionals";                           // Media query mixin
+@import "device-pixels";                          // Retina image mixin
+@import "grid_layout";                            // Basic grid layout mixin
+@import "typography";                             // Core bold and heading mixins
+@import "shims";                                  // Inline block mixin, clearfix placeholder
+
+// Mixins to generate components (chunks of UI)
+@import "design-patterns/alpha-beta";             // Only required if using _phase-banner.scss
+@import "design-patterns/buttons";                // Only required if using _buttons.scss
+
+// Functions
+@import "url-helpers";
 
 // Path to assets for use with file-url()
 $path: "/static/images/";
+
+// Other govuk-elements "partials"
+@import "elements/_forms.scss";
 
 // Digital Marketplace front end toolkit components
 @import "forms/word-counter";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -28,6 +28,8 @@ $path: "/static/images/";
 @import "forms/word-counter";
 @import "forms/list-entry";
 
+// Note we DO NOT load the govuk-elements _reset.scss, only our own custom one, which is different
+
 /* Classes shared between multiple apps */
 @import "toolkit/shared_scss/_reset.scss";
 @import "toolkit/shared_scss/_lists.scss";

--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <div class="grid-row">
+    <div class="grid-row search-results-page">
         <section class="column-one-third search-page-filters" aria-label="Search filters">
             <form action="" method="get">
                 {% include 'search/_filters.html' %}

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -43,7 +43,7 @@
 <header class="page-heading">
         <h1>Search results</h1>
 </header>
-<div id="js-dm-live-search-wrapper" class="grid-row">
+<div id="js-dm-live-search-wrapper" class="grid-row search-results-page">
   <form action="{{ url_for('.search_services') }}" method="get" id="js-dm-live-search-form">
     <section class="column-one-third search-page-filters" aria-label="Search filters">
           {% include 'search/_services_filters.html' %}

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.2.3",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.2.4",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.13.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"


### PR DESCRIPTION
Use a class name common across both G-Cloud and DOS searches for style - fixes record count size.

No longer import all of gov-uk elements - fixes heading size by ensuring that we no longer load the govuk-elements `_reset.scss` stylesheet. (Note that we do still load our own _reset.scss file, which is a bit different!)

https://trello.com/c/DG6GGfib/736-bug-styling-on-dos-opportunities-page
