### PR TITLE
Update search result download links

### DIFF
--- a/app/templates/direct-award/results.html
+++ b/app/templates/direct-award/results.html
@@ -53,13 +53,26 @@
       </ul>
     </div>
     <div class="marketplace-paragraph">
-      <p>
-        <br>
-        <a href="{{ url_for('direct_award.download_results', framework_framework=framework.framework, project_id=project.id, filetype='ods') }}">Download search results spreadsheet (ODS)</a>
-        <br>
-        <a href="{{ url_for('direct_award.download_results', framework_framework=framework.framework, project_id=project.id, filetype='csv') }}">Download search results spreadsheet (CSV)</a>
-      </p>
       <br>
+      {%
+      with
+      items = [
+          {
+              "title": "Download search results as a spreadsheet",
+              "link": url_for('direct_award.download_shortlist', framework_framework=framework.framework, project_id=project.id, filetype='odf'),
+              "file_type": "ODS",
+              "download": "True"
+          },
+          {
+              "title": "Download search results as comma-separated values",
+              "link": url_for('direct_award.download_shortlist', framework_framework=framework.framework, project_id=project.id, filetype='csv'),
+              "file_type": "CSV",
+              "download": "True"
+          }
+      ]
+      %}
+          {% include "toolkit/documents.html" %}
+      {% endwith %}
     </div>
     <div class="marketplace-paragraph">
     <h2>After you download your shortlist</h2>


### PR DESCRIPTION
## Summary
Our links on the download search results page are not consistent with document download links elsewhere on the site. This brings them in line and removes the `(ODF/CSV)` suffix which is now brought before the link name. I've also slightly tweaked the content on what I think might work well, but @karlchillmaid to decide. @JeremyHHY FYI, these are our file download links.

## Before
<img width="795" alt="screen shot 2017-09-22 at 21 35 01" src="https://user-images.githubusercontent.com/2920760/30763401-ec4e8d26-9fdd-11e7-90cd-aa47c5d11277.png">

## After
<img width="829" alt="screen shot 2017-09-22 at 21 32 35" src="https://user-images.githubusercontent.com/2920760/30763389-db338a8c-9fdd-11e7-8f52-0d66aa0de195.png">
