### PR TITLE
Update apiclient for direct award download

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.8.0#egg=digitalmarketplace-utils==28.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.6.0#egg=digitalmarketplace-apiclient==10.6.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@28.8.0#egg=digitalmarketplace-utils==28.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.6.0#egg=digitalmarketplace-apiclient==10.6.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.22.0


### PR DESCRIPTION
## Summary
Direct Award downloads need apiclient 10.7.0

## Ticket
https://trello.com/c/igRhA3Bt/711-shortlist-file-download