### PR TITLE
Prevent access to supplier pages if no services on framework

### DIFF
--- a/tests/fixtures/supplier_fixture.json
+++ b/tests/fixtures/supplier_fixture.json
@@ -32,6 +32,7 @@
       "UK Ministry of Defence",
       "Astula Ltd",
       "Bedrock Communications Ltd"
-    ]
+    ],
+    "service_counts": {"G-Cloud 9": 1}
   }
 }

--- a/tests/fixtures/supplier_fixture_with_minium_data.json
+++ b/tests/fixtures/supplier_fixture_with_minium_data.json
@@ -17,6 +17,7 @@
     ],
     "dunsNumber": "333333333",
     "eSourcingId": "333333",
-    "clients": []
+    "clients": [],
+    "service_counts": {"G-Cloud 9": 1}
   }
 }

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -19,6 +19,9 @@ class TestSuppliersPage(BaseApplicationTest):
         self._data_api_client.find_suppliers.return_value = self.suppliers_by_prefix
         self._data_api_client.get_supplier.return_value = self.supplier
 
+        gcloud9_framework = self._get_framework_fixture_data('g-cloud-9')['frameworks']
+        self._data_api_client.find_frameworks.return_value = {'frameworks': [gcloud9_framework]}
+
     def teardown_method(self, method):
         self._data_api_client_patch.stop()
 
@@ -240,3 +243,11 @@ class TestSuppliersPage(BaseApplicationTest):
     def test_should_not_show_web_address(self):
         res = self.client.get('/g-cloud/supplier/92191')
         assert 'www.examplecompany.biz' not in res.get_data(as_text=True)
+
+    def test_should_not_show_supplier_without_services_on_framework(self):
+        supplier_data = self.supplier.copy()
+        supplier_data['suppliers']['service_counts']['G-Cloud 9'] = 0
+        self._data_api_client.get_supplier.return_value = supplier_data
+
+        res = self.client.get('/g-cloud/supplier/92191')
+        assert res.status_code == 404


### PR DESCRIPTION
## Summary
It's possible to get to a supplier page via `/g-cloud/suppliers/<supplier_id>` even if the supplier is not on the G-Cloud framework. This will prevent accessing supplier pages from the supplier A-Z if said supplier doesn't have any services live on G-Cloud.

I've hardcoded the framework name 'g-cloud' because the URL already hardcodes it, and it's not necessarily a simple thing to make the URL take any known framework.

## Ticket
https://trello.com/c/a78tWZAC/19-vulnerability-in-g-cloud-supplier-a-z