### PR TITLE
Feedback forms tweaks

### DIFF
--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -1,6 +1,5 @@
 import requests
 
-from werkzeug.exceptions import ServiceUnavailable
 from werkzeug.datastructures import MultiDict
 from werkzeug.urls import url_parse
 
@@ -18,9 +17,10 @@ def send_feedback():
 
     result = requests.post(feedback_config['uri'], list(form_data.items(multi=True)))
     if result.status_code != 200:
-        current_app.logger.error(
-            "Feedback form submission error - unexpected response {}.".format(result.status_code))
-        raise ServiceUnavailable('There was a problem submitting your feedback. Please try again later.')
+        current_app.logger.error("Feedback form submission error - unexpected response {} from {}.".format(
+            result.status_code, feedback_config['uri']))
+        current_app.logger.warning("Feedback message was not correctly recorded: {}".format(
+            ' / '.join(request.form.values())))
 
     came_from = url_parse(request.form['uri'])
     # strip netloc and scheme as we should ignore attempts to make us redirect elsewhere

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.2.5",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.3.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.15.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/tests/main/views/test_feedback.py
+++ b/tests/main/views/test_feedback.py
@@ -8,31 +8,31 @@ class TestFeedbackForm(BaseApplicationTest):
     def _post(self):
         return self.client.post('/feedback', data={
             'uri': 'test:some-uri',
-            'what_doing': 'test: what doing text',
-            'what_happened': 'test: what happened text'})
+            'what_doing': 'what doing text',
+            'what_happened': 'what happened text'})
+
+    def _check_success(self, response):
+        # The idea here is that the user will know only success, even if due to some failure we end up logging their
+        # feedback rather than recording it properly.
+        assert response.status_code == 303
+        new_page = self.client.get(response.location)
+        assert "Thank you for your message" in new_page.get_data(as_text=True)
 
     @mock.patch('requests.post')
-    def test_google_gone_gives_503(self, external_requests_post):
-        assert self._post().status_code == 503
+    @mock.patch('flask.Flask.logger')
+    def test_google_gone_logs_problem(self, logger, external_requests_post):
+        external_requests_post.return_value.status_code = 404
+        self._check_success(self._post())
+        logger.warning.assert_called_once_with(
+            'Feedback message was not correctly recorded: test:some-uri / what doing text / what happened text')
 
     @mock.patch('requests.post')
     def test_feedback_submission(self, external_requests_post):
         external_requests_post.return_value.status_code = 200
-        response = self._post()
-
-        assert response.status_code == 303
-        new_page = self.client.get(response.location)
-        assert "Thank you for your message" in new_page.get_data(as_text=True)
+        self._check_success(self._post())
 
     def test_feedback_form_has_csrf(self):
         res = self.client.get("/")
         document = html.fromstring(res.get_data(as_text=True))
 
         assert len(document.cssselect('.report-a-problem-container form input[name="csrf_token"]')) == 1
-
-    @mock.patch('requests.post')
-    def test_feedback_form_fail(self, external_requests_post):
-        external_requests_post.return_value.status_code = 404
-        response = self._post()
-
-        assert response.status_code == 503


### PR DESCRIPTION
Don't die if feedback form submission fails, plus an update to the front-end toolkit to get new wording for feedback forms.