### PR TITLE
Add milliseconds to application log time format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:2.0.2
+FROM digitalmarketplace/base-frontend:2.0.5

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.8.0#egg=digitalmarketplace-utils==28.8.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,16 +7,16 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@28.8.0#egg=digitalmarketplace-utils==28.8.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@10.7.0#egg=digitalmarketplace-apiclient==10.7.0
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.22.0
+asn1crypto==0.23.0
 backoff==1.0.7
 boto3==1.4.4
 botocore==1.5.95
-cffi==1.10.0
+cffi==1.11.2
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
@@ -37,13 +37,13 @@ monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.3
 pycparser==2.18
-PyJWT==1.5.2
+PyJWT==1.5.3
 python-dateutil==2.6.1
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
 requests==2.7.0
-s3transfer==0.1.10
+s3transfer==0.1.11
 six==1.9.0
 unicodecsv==0.14.1
 Werkzeug==0.12.2


### PR DESCRIPTION
Upgrades dmutils and base Docker image to add milliseconds to app logs shipped to CloudWatch.

This allows us to maintain the order of the log messages written by an application instance in Kibana.