### PR TITLE
Fixes breadcrumbs and content

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -365,7 +365,7 @@ def save_search(framework_framework):
             form.name.errors = ["Names must be between 1 and 100 characters"]
 
         if not save_search_selection and request.method == "POST":
-            save_search_selection_error = "Please choose where to save your search."
+            save_search_selection_error = "Please choose where to save your search"
         else:
             save_search_selection_error = None
 
@@ -374,6 +374,7 @@ def save_search(framework_framework):
                                save_search_selection_error=save_search_selection_error,
                                search_summary_sentence=search_summary.markup(),
                                search_query=url_encode(search_query),
+                               search_url=url_for('main.search_services', **search_query),
                                request=request,
                                projects=projects,
                                framework_framework=framework_framework), 400 if request.method == 'POST' else 200

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -11,6 +11,10 @@
           "label": "Digital Marketplace"
       },
       {
+          "link": search_url,
+          "label": "Search"
+      },
+      {
           "label": "Save your search"
       }
     ]


### PR DESCRIPTION
As a G-Cloud buyer
I need to be able to return to work I've already started on a procurement
so that I can progress with my procurement

After clicking save search - the user has the option to add the search to a new procurement or update the search in an existing procurement

Ticket: https://trello.com/c/zt49gYL6/74-choose-an-existing-saved-search

<img width="670" alt="screen shot 2017-10-11 at 12 27 18" src="https://user-images.githubusercontent.com/4599889/31438193-903ce784-ae7f-11e7-8d10-054a0adcf1b4.png">
