### PR TITLE
Add opportunity data download to the opportunity list page

### DIFF
--- a/app/assets/javascripts/analytics/_events.js
+++ b/app/assets/javascripts/analytics/_events.js
@@ -92,12 +92,13 @@
   GOVUK.GDM.analytics.events = {
     'supplierListDownload': function (e) {
       var linkClick = new LinkClick(e);
-
-      if ((linkClick.category() === 'download') && (linkClick.fileType() === 'csv')) {
-        GOVUK.analytics.trackEvent('download', 'csv', {
-          'label': downloadLinkLabel(linkClick),
-          'transport': 'beacon'
-        });
+      if (downloadLinkLabel(linkClick)) {
+        if ((linkClick.category() === 'download') && (linkClick.fileType() === 'csv')) {
+          GOVUK.analytics.trackEvent('download', 'csv', {
+            'label': downloadLinkLabel(linkClick),
+            'transport': 'beacon'
+          });
+        }
       }
     },
     trackEvent: function (e) {

--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -122,7 +122,9 @@ em.search-result-highlighted-text {
     display: block;
   }
 }
-
+.search-page-filters {
+  padding-bottom: 15px;
+}
 .search-result-important-metadata {
   li {
     @include bold-19;

--- a/app/templates/search/_opportunity_data.html
+++ b/app/templates/search/_opportunity_data.html
@@ -1,0 +1,5 @@
+<h2 class='opportunity-data-header'>Opportunity data</h2>
+<p class='opportunity-data-description'>Download data about closed opportunities including who won and how much the contract was worth or if the contract was never awarded and why.<p>
+<a class='opportunity-data-link' href="https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists-2/communications/data/test.csv">
+  You can download new data every week.
+</a>

--- a/app/templates/search/_opportunity_data.html
+++ b/app/templates/search/_opportunity_data.html
@@ -1,5 +1,21 @@
-<h2 class='opportunity-data-header'>Opportunity data</h2>
-<p class='opportunity-data-description'>Download data about closed opportunities including who won and how much the contract was worth or if the contract was never awarded and why.<p>
-<a class='opportunity-data-link' href="https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists-2/communications/data/test.csv">
-  You can download new data every week.
-</a>
+<div class="dmspeak">
+  <h2 class="heading-small" id="opportunity-data-header">Opportunity data</h2>
+  <p id="opportunity-data-description">Download data about closed opportunities including award status. This will be updated daily.<p>
+</div>
+{%
+  with
+  items = [
+      {
+          "title": "Download data",
+          "link": "https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists-2/communications/data/opportunity-data.csv",
+          "file_type": "CSV",
+          "download": "True",
+          "analytics": "trackEvent",
+          "analytics_category": "opportunity-data-csv",
+          "analytics_action": "download CSV",
+          "analytics_label": "Opportunity Data CSV"
+      }
+    ]
+%}
+    {% include "toolkit/documents.html" %}
+{% endwith %}

--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -29,16 +29,21 @@
     </div>
 
     <div class="grid-row search-results-page">
-        <section class="column-one-third search-page-filters" aria-label="Search filters">
-            <form action="" method="get">
-                {% include 'search/_filters.html' %}
-            </form>
+      <div class="column-one-third">
+        <section class="search-page-filters" aria-label="Search filters">
+          <form action="" method="get">
+            {% include 'search/_filters.html' %}
+          </form>
         </section>
-        <section class="column-two-thirds" aria-label="Opportunities found">
-            {% include 'search/_briefs_summary.html' %}
-            {% include 'search/_briefs_results.html' %}
-            {% include 'search/_briefs_pagination.html' %}
+        <section class="search-page-opportunity-data" aria-label="Download opportunity data">
+          {% include 'search/_opportunity_data.html' %}
         </section>
+      </div>
+      <section class="column-two-thirds" aria-label="Opportunities found">
+        {% include 'search/_briefs_summary.html' %}
+        {% include 'search/_briefs_results.html' %}
+        {% include 'search/_briefs_pagination.html' %}
+      </section>
     </div>
 
 {% endblock %}

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -109,6 +109,19 @@ describe("GOVUK.Analytics", function () {
       }]);
     });
 
+    it('sends an event requested via html attributes on example of Oportunity Data download', function() {
+      $(document.body).append('<a id="opportunity-data" data-analytics="trackEvent" data-analytics-category="opportunity-data-csv" data-analytics-action="download CSV" data-analytics-label="Opportunity Data CSV" href="https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists-2/communications/data/opportunity-data.csv">Download data</a>');
+      GOVUK.GDM.analytics.events.init();
+      $('#opportunity-data').click();
+      expect(window.ga.calls.first().args).toEqual(['send', {
+        'hitType': 'event',
+        'eventCategory': "opportunity-data-csv",
+        'eventAction': "download CSV",
+        'eventLabel': "Opportunity Data CSV",
+        'transport': 'beacon'
+      }]);
+    });
+
     it('sends the right event when a list of user research labs download link is clicked', function() {
       spyOn(GOVUK.GDM.analytics.location, "pathname")
         .and

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1303,7 +1303,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        header = document.xpath("//h2[@class='opportunity-data-header']")[0].text
+        header = document.xpath("//h2[@id='opportunity-data-header']")[0].text
 
         assert "Opportunity data" in header
 
@@ -1312,32 +1312,29 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        description = document.xpath("//p[@class='opportunity-data-description']")[0].text
-        expected_description = (
-        "Download data about closed opportunities including who won"
-        + " and how much the contract was worth or if the contract was never awarded and why."
-        )
+        description = document.xpath("//p[@id='opportunity-data-description']")[0].text
+        expected_desc = "Download data about closed opportunities including award status. This will be updated daily."
 
-        assert expected_description in description
+        assert expected_desc in description
 
     def test_opportunity_data_link_text_visible_on_catalogue_page(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        link_text = document.xpath("//a[@class='opportunity-data-link']")[0].text
+        link_text = document.xpath("//a[@class='document-link-with-icon']")[0].text_content()
 
-        assert "You can download new data every week." in link_text
+        assert "Download data" in link_text
 
     def test_opportunity_data_file_url_correct_on_catalogue_page(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        link = document.xpath("//a[@class='opportunity-data-link']")[0].values()
+        link = document.xpath("//a[@class='document-link-with-icon']")[0].values()
         expected_link = (
             "https://assets.digitalmarketplace.service.gov.uk"
-            + "/digital-outcomes-and-specialists-2/communications/data/test.csv"
+            + "/digital-outcomes-and-specialists-2/communications/data/opportunity-data.csv"
         )
 
         assert expected_link in link

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1298,6 +1298,50 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         ss_elem = document.xpath("//p[@class='search-summary']")[0]
         assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "6 results"
 
+    def test_opportunity_data_header_visible_on_catalogue_page(self):
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities')
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+
+        header = document.xpath("//h2[@class='opportunity-data-header']")[0].text
+
+        assert "Opportunity data" in header
+
+    def test_opportunity_data_description_visible_on_catalogue_page(self):
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities')
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+
+        description = document.xpath("//p[@class='opportunity-data-description']")[0].text
+        expected_description = (
+        "Download data about closed opportunities including who won"
+        + " and how much the contract was worth or if the contract was never awarded and why."
+        )
+
+        assert expected_description in description
+
+    def test_opportunity_data_link_text_visible_on_catalogue_page(self):
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities')
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+
+        link_text = document.xpath("//a[@class='opportunity-data-link']")[0].text
+
+        assert "You can download new data every week." in link_text
+
+    def test_opportunity_data_file_url_correct_on_catalogue_page(self):
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities')
+        assert res.status_code == 200
+        document = html.fromstring(res.get_data(as_text=True))
+
+        link = document.xpath("//a[@class='opportunity-data-link']")[0].values()
+        expected_link = (
+            "https://assets.digitalmarketplace.service.gov.uk"
+            + "/digital-outcomes-and-specialists-2/communications/data/test.csv"
+        )
+
+        assert expected_link in link
+
     def test_catalogue_of_briefs_404_if_invalid_status(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities?status=pining-for-fjords')
         assert res.status_code == 404


### PR DESCRIPTION
- Add 'Opportunity Data' section to opportunities list page under the filtering section
- Style it using existing front-end patterns
- Add an G-Analytics event to track the downloads

Trello ticket: https://trello.com/c/CN4daMQA/23-add-opportunity-data-download-to-the-opportunity-list-page
![screen shot 2017-10-12 at 10 48 01](https://user-images.githubusercontent.com/20957548/31490193-05e53afc-af3b-11e7-9648-44fdb5c47b34.png)
