### PR TITLE
Fixes bug in IE10 where console.time does not exist

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -46,7 +46,7 @@
       "color:#550; background:yellow; font-size: 11pt",
       "color:yellow; background: #550;font-size:11pt"
     );
-    console.time("Modules loaded");
+    if (typeof console.time !== "undefined") console.time("Modules loaded");
   }
 
   // Initialise our modules
@@ -72,6 +72,6 @@
 
   GOVUK.GDM = GDM;
 
-  if (GDM.debug) console.timeEnd("Modules loaded");
+  if (GDM.debug && typeof console.timeEnd !== "undefined") console.timeEnd("Modules loaded");
 
 }).apply(this, [GOVUK||{}, GOVUK.GDM||{}]);


### PR DESCRIPTION
Ticket: https://trello.com/c/ubKd3ztP/75-save-search-and-name-your-procurement-design-and-content

Reference: https://developer.mozilla.org/en-US/docs/Web/API/Console/time

`console.time` and `console.timeEnd` is supported IE11+

Please see comments on commit below:
https://github.com/alphagov/digitalmarketplace-buyer-frontend/commit/d10f98e1c15954e1f40b04cd812c0b297e368be5
