### PR TITLE
Centralise app context creation for tests to BaseApplicationTest

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,8 +27,12 @@ class BaseApplicationTest(object):
         self.client = self.app.test_client()
         self.get_user_patch = None
 
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
     def teardown_method(self, method):
         self.teardown_login()
+        self.app_context.pop()
 
     @staticmethod
     def user(id, email_address, supplier_id, supplier_name, name,

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -575,7 +575,7 @@ class TestDirectAwardDownloadResultsView(TestDirectAwardBase):
             self.view.get_project_and_search(self.project_id)
 
     def test_get_file_context(self):
-        with self.app.app_context(), self.app.test_request_context('/'):
+        with self.app.test_request_context('/'):
             file_context = self.view.get_file_context(**self.kwargs)
 
         assert set(file_context.keys()) == {'framework', 'search', 'project', 'questions', 'services', 'filename',
@@ -595,7 +595,7 @@ class TestDirectAwardDownloadResultsView(TestDirectAwardBase):
         """This test will quite closely reproduce the implementation, but is the only way I can think of to tightly
         pin the content and styling that will go into the file to be downloaded. It also validates that the structure
         meets the expectations of the parent class."""
-        with self.app.app_context(), self.app.test_request_context('/'):
+        with self.app.test_request_context('/'):
             file_context = self.view.get_file_context(**self.kwargs)
             file_rows, column_styles = self.view.get_file_data_and_column_styles(file_context)
 
@@ -638,14 +638,11 @@ class TestDirectAwardDownloadResultsView(TestDirectAwardBase):
     def test_file_download(self):
         self.login_as_buyer()
 
-        with self.app.app_context():
-            res = self.client.get('/buyers/direct-award/g-cloud/projects/1/results/download?filetype=csv')
-            assert res.status_code == 200
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1/results/download?filetype=csv')
+        assert res.status_code == 200
 
-        with self.app.app_context():
-            res = self.client.get('/buyers/direct-award/g-cloud/projects/1/results/download?filetype=ods')
-            assert res.status_code == 200
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1/results/download?filetype=ods')
+        assert res.status_code == 200
 
-        with self.app.app_context():
-            res = self.client.get('/buyers/direct-award/g-cloud/projects/1/results/download?filetype=docx')
-            assert res.status_code == 400
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1/results/download?filetype=docx')
+        assert res.status_code == 400

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -72,120 +72,115 @@ class TestHomepageBrowseList(BaseApplicationTest):
     }
 
     def test_dos_links_are_shown(self, data_api_client):
-        with self.app.app_context():
-            data_api_client.find_frameworks.return_value = {
-                "frameworks": [
-                    self.mock_live_dos_1_framework
-                ]
-            }
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                self.mock_live_dos_1_framework
+            ]
+        }
 
-            res = self.client.get("/")
-            document = html.fromstring(res.get_data(as_text=True))
+        res = self.client.get("/")
+        document = html.fromstring(res.get_data(as_text=True))
 
-            assert res.status_code == 200
+        assert res.status_code == 200
 
-            link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
-            assert link_texts[0] == "Find an individual specialist"
-            assert link_texts[-1] == "Buy physical datacentre space"
-            assert "Find specialists to work on digital projects" not in link_texts
+        link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
+        assert link_texts[0] == "Find an individual specialist"
+        assert link_texts[-1] == "Buy physical datacentre space"
+        assert "Find specialists to work on digital projects" not in link_texts
 
     def test_links_are_for_existing_dos_framework_when_a_new_dos_framework_in_standstill_exists(self, data_api_client):
-        with self.app.app_context():
-            mock_standstill_dos_2_framework = self.mock_live_dos_2_framework.copy()
-            mock_standstill_dos_2_framework.update({"status": "standstill"})
+        mock_standstill_dos_2_framework = self.mock_live_dos_2_framework.copy()
+        mock_standstill_dos_2_framework.update({"status": "standstill"})
 
-            data_api_client.find_frameworks.return_value = {
-                "frameworks": [
-                    self.mock_live_dos_1_framework,
-                    mock_standstill_dos_2_framework,
-                ]
-            }
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                self.mock_live_dos_1_framework,
+                mock_standstill_dos_2_framework,
+            ]
+        }
 
-            res = self.client.get("/")
-            document = html.fromstring(res.get_data(as_text=True))
+        res = self.client.get("/")
+        document = html.fromstring(res.get_data(as_text=True))
 
-            assert res.status_code == 200
+        assert res.status_code == 200
 
-            link_locations = [item.values()[1] for item in document.cssselect('.browse-list-item a')]
+        link_locations = [item.values()[1] for item in document.cssselect('.browse-list-item a')]
 
-            lots = ['digital-specialists', 'digital-outcomes', 'user-research-participants', 'user-research-studios']
-            dos_base_path = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/{}'
+        lots = ['digital-specialists', 'digital-outcomes', 'user-research-participants', 'user-research-studios']
+        dos_base_path = '/buyers/frameworks/digital-outcomes-and-specialists/requirements/{}'
 
-            for index, lot_slug in enumerate(lots):
-                assert link_locations[index] == dos_base_path.format(lot_slug)
+        for index, lot_slug in enumerate(lots):
+            assert link_locations[index] == dos_base_path.format(lot_slug)
 
     def test_links_are_for_the_newest_live_dos_framework_when_multiple_live_dos_frameworks_exist(self, data_api_client):
-        with self.app.app_context():
-            data_api_client.find_frameworks.return_value = {
-                "frameworks": [
-                    self.mock_live_dos_1_framework,
-                    self.mock_live_dos_2_framework,
-                ]
-            }
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                self.mock_live_dos_1_framework,
+                self.mock_live_dos_2_framework,
+            ]
+        }
 
-            res = self.client.get("/")
-            document = html.fromstring(res.get_data(as_text=True))
+        res = self.client.get("/")
+        document = html.fromstring(res.get_data(as_text=True))
 
-            assert res.status_code == 200
+        assert res.status_code == 200
 
-            link_locations = [item.values()[1] for item in document.cssselect('.browse-list-item a')]
+        link_locations = [item.values()[1] for item in document.cssselect('.browse-list-item a')]
 
-            lots = ['digital-specialists', 'digital-outcomes', 'user-research-participants', 'user-research-studios']
-            dos2_base_path = '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/{}'
+        lots = ['digital-specialists', 'digital-outcomes', 'user-research-participants', 'user-research-studios']
+        dos2_base_path = '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/{}'
 
-            for index, lot_slug in enumerate(lots):
-                assert link_locations[index] == dos2_base_path.format(lot_slug)
+        for index, lot_slug in enumerate(lots):
+            assert link_locations[index] == dos2_base_path.format(lot_slug)
 
     def test_links_are_for_live_dos_framework_when_expired_dos_framework_exists(self, data_api_client):
-        with self.app.app_context():
-            mock_expired_dos_1_framework = self.mock_live_dos_1_framework.copy()
-            mock_expired_dos_1_framework.update({"status": "expired"})
+        mock_expired_dos_1_framework = self.mock_live_dos_1_framework.copy()
+        mock_expired_dos_1_framework.update({"status": "expired"})
 
-            data_api_client.find_frameworks.return_value = {
-                "frameworks": [
-                    mock_expired_dos_1_framework,
-                    self.mock_live_dos_2_framework,
-                ]
-            }
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                mock_expired_dos_1_framework,
+                self.mock_live_dos_2_framework,
+            ]
+        }
 
-            res = self.client.get("/")
-            document = html.fromstring(res.get_data(as_text=True))
+        res = self.client.get("/")
+        document = html.fromstring(res.get_data(as_text=True))
 
-            assert res.status_code == 200
+        assert res.status_code == 200
 
-            link_locations = [item.values()[1] for item in document.cssselect('.browse-list-item a')]
+        link_locations = [item.values()[1] for item in document.cssselect('.browse-list-item a')]
 
-            lots = ['digital-specialists', 'digital-outcomes', 'user-research-participants', 'user-research-studios']
-            dos2_base_path = '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/{}'
+        lots = ['digital-specialists', 'digital-outcomes', 'user-research-participants', 'user-research-studios']
+        dos2_base_path = '/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/{}'
 
-            for index, lot_slug in enumerate(lots):
-                assert link_locations[index] == dos2_base_path.format(lot_slug)
+        for index, lot_slug in enumerate(lots):
+            assert link_locations[index] == dos2_base_path.format(lot_slug)
 
     def test_non_dos_links_are_shown_if_no_live_dos_framework(self, data_api_client):
-        with self.app.app_context():
-            mock_expired_dos_1_framework = self.mock_live_dos_1_framework.copy()
-            mock_expired_dos_1_framework.update({"status": "expired"})
-            mock_expired_dos_2_framework = self.mock_live_dos_2_framework.copy()
-            mock_expired_dos_2_framework.update({"status": "expired"})
-            mock_g_cloud_9_framework = self.mock_live_g_cloud_9_framework.copy()
+        mock_expired_dos_1_framework = self.mock_live_dos_1_framework.copy()
+        mock_expired_dos_1_framework.update({"status": "expired"})
+        mock_expired_dos_2_framework = self.mock_live_dos_2_framework.copy()
+        mock_expired_dos_2_framework.update({"status": "expired"})
+        mock_g_cloud_9_framework = self.mock_live_g_cloud_9_framework.copy()
 
-            data_api_client.find_frameworks.return_value = {
-                "frameworks": [
-                    mock_expired_dos_1_framework,
-                    mock_expired_dos_2_framework,
-                    mock_g_cloud_9_framework,
-                ]
-            }
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [
+                mock_expired_dos_1_framework,
+                mock_expired_dos_2_framework,
+                mock_g_cloud_9_framework,
+            ]
+        }
 
-            res = self.client.get("/")
-            document = html.fromstring(res.get_data(as_text=True))
+        res = self.client.get("/")
+        document = html.fromstring(res.get_data(as_text=True))
 
-            assert res.status_code == 200
+        assert res.status_code == 200
 
-            link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
-            assert link_texts[0] == "Find cloud hosting, software and support"
-            assert link_texts[1] == "Buy physical datacentre space"
-            assert len(link_texts) == 2
+        link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
+        assert link_texts[0] == "Find cloud hosting, software and support"
+        assert link_texts[1] == "Buy physical datacentre space"
+        assert len(link_texts) == 2
 
 
 class TestHomepageSidebarMessage(BaseApplicationTest):
@@ -1432,17 +1427,16 @@ class TestGCloudHomepageLinks(BaseApplicationTest):
                              (('g-cloud-8', 'Find cloud technology and support'),
                               ('g-cloud-9', 'Find cloud hosting, software and support')))
     def test_g_cloud_homepage_content_is_correct(self, data_api_client, framework_slug, gcloud_content):
-        with self.app.app_context():
-            data_api_client.find_frameworks.return_value = {
-                "frameworks": [self.mock_live_g_cloud_framework.copy()]
-            }
-            data_api_client.find_frameworks.return_value['frameworks'][0].update({'slug': framework_slug})
+        data_api_client.find_frameworks.return_value = {
+            "frameworks": [self.mock_live_g_cloud_framework.copy()]
+        }
+        data_api_client.find_frameworks.return_value['frameworks'][0].update({'slug': framework_slug})
 
-            res = self.client.get("/")
-            document = html.fromstring(res.get_data(as_text=True))
+        res = self.client.get("/")
+        document = html.fromstring(res.get_data(as_text=True))
 
-            assert res.status_code == 200
+        assert res.status_code == 200
 
-            link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
-            assert link_texts[-2] == gcloud_content
-            assert link_texts[-1] == 'Buy physical datacentre space'
+        link_texts = [item.text_content().strip() for item in document.cssselect('.browse-list-item a')]
+        assert link_texts[-2] == gcloud_content
+        assert link_texts[-1] == 'Buy physical datacentre space'


### PR DESCRIPTION
## Summary
Our tests sporadically create app contexts for individual tests as/when needed. We can centralise this by giving each test its own app context, removing the need to create it inside each test.