### PR TITLE
Simplify search summary & display on task list

### DIFF
--- a/app/main/helpers/search_save_helpers.py
+++ b/app/main/helpers/search_save_helpers.py
@@ -38,6 +38,5 @@ class SearchMeta(object):
             search_api_response['meta']['total'],
             clean_request_query_params.copy(),
             filters.values(),
-            lots_by_slug,
-            include_markup=include_markup
+            lots_by_slug
         )

--- a/app/main/presenters/search_summary.py
+++ b/app/main/presenters/search_summary.py
@@ -32,9 +32,7 @@ class SearchSummary(object):
             formatted_conjunction = " {} ".format(final_conjunction)
             return formatted_conjunction.join([u', '.join(start), end])
 
-    def __init__(self, results_total, request_args, filter_groups, lots_by_slug, include_markup=True):
-        self.include_markup = include_markup
-
+    def __init__(self, results_total, request_args, filter_groups, lots_by_slug):
         self._lots_by_slug = lots_by_slug
         self._set_initial_sentence(results_total, request_args)
 
@@ -53,8 +51,7 @@ class SearchSummary(object):
                     SummaryFragment(
                         group_id=group_id,
                         filters=filters,
-                        rules=group_rules,
-                        include_markup=self.include_markup)
+                        rules=group_rules)
                 )
 
     def _set_initial_sentence(self, results_total, request_args):
@@ -94,12 +91,10 @@ class SearchSummary(object):
             parts.append(SearchSummary.write_list_as_sentence(
                 fragment_strings, u"and"))
 
-        marked_up_text = Markup(u" ".join(parts))
+        return Markup(u" ".join(parts))
 
-        if not self.include_markup:
-            marked_up_text = document_fromstring(marked_up_text).text_content()
-
-        return marked_up_text
+    def text_content(self):
+        return document_fromstring(self.markup()).text_content()
 
     def get_starting_sentence(self):
         return u"{}{}{} {}".format(
@@ -198,8 +193,7 @@ class SummaryFragment(object):
     POST_TAG = u'</em>'
     FINAL_CONJUNCTION = u'and'
 
-    def __init__(self, group_id, filters, rules, include_markup=True):
-
+    def __init__(self, group_id, filters, rules):
         self.id = group_id
         self.rules = rules
         self.form = 'singular'

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -606,7 +606,7 @@ class DownloadResultsView(SimpleDownloadFileView):
 
             all_services.append(service)
 
-        search_meta = SearchMeta(search['searchUrl'], frameworks_by_slug, include_markup=False)
+        search_meta = SearchMeta(search['searchUrl'], frameworks_by_slug)
 
         file_context = {
             'framework': frameworks_by_slug[framework_slug]['name'],
@@ -617,7 +617,7 @@ class DownloadResultsView(SimpleDownloadFileView):
             'filename': filename,
             "sheetname": "Search results",
             'locked_at': locked_at,
-            'search_summary': search_meta.search_summary.markup(),
+            'search_summary': search_meta.search_summary.text_content(),
         }
 
         return file_context


### PR DESCRIPTION
Moves 'no-markup' version of the search summary to a separate method.

 - fixes a bug where we were getting no markup in the search summary on the Task List (project view) screen by mistake;
 - easier to be sure you're getting the right formatting - either call markup method, or the new text_content method instead.

https://trello.com/c/9YtT8DmX/85-task-list-saved-search-overview-page