### PR TITLE
Fix broken category sub category section on filtering

### DIFF
--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -288,8 +288,18 @@ def _annotate_categories_with_selection(lot_slug, category_filters, request, url
             content_manifest, framework, aggregations, keys_to_remove, parent_category=category['value'])
 
         if selected_descendants:
-            # If a parentCategory has been sent as a url query param, de-select all other parent categories.
-            if request.values.get('parentCategory', category['value']) != category['value']:
+            # If a parentCategory has been sent as a url query param, and it's this category...
+            # (Note: `get` fallback is for if there are selected descendants but no parent category is set, which is
+            # not expected, but could happen if constructing URLs by hand.)
+            if request.values.get('parentCategory', category['value']) == category['value']:
+                # ... then ensure this choice survives as a hidden field for the filters form
+                parent_category_filter = dict()
+                parent_category_filter['name'] = 'parentCategory'
+                parent_category_filter['value'] = category['value']
+                selected_category_filters.append(parent_category_filter)
+
+            else:
+                # ... but otherwise, don't include this category's children in the tree
                 selected_descendants = []
 
         if directly_selected or selected_descendants:

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -230,8 +230,8 @@ def search_services():
                                                                          request, content_manifest)
 
     # Filter form should also filter by lot, and by category, when any of those are selected.
-    # (But if a sub-category is selected, there is no need to filter by the parent category as,
-    # well, so we can just take one hidden field per key - sub-cat will be last.)
+    # (If a sub-category is selected, we also need the parent category id, so that the correct part
+    # of the category tree is displayed when the sub-category appears under multiple parents.)
     filter_form_hidden_fields_by_name = {f['name']: f for f in selected_category_tree_filters[1:]}
 
     current_lot = lots_by_slug.get(current_lot_slug)

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -256,7 +256,7 @@ class TestSearchFilters(BaseApplicationTest):
         with self.app.test_request_context(url):
             selection = build_lots_and_categories_link_tree(framework, lots, category_filter_group, flask.request,
                                                             g9_builder)
-            assert len(selection) == 4  # all -> software -> option2 -> option2.2
+            assert len(selection) == 5  # all -> software -> option2 -> option2.2; option2 as a parent category filter
 
             tree_root = selection[0]
             # check that only siblings of the selected sub-category are shown, and other categories
@@ -268,6 +268,9 @@ class TestSearchFilters(BaseApplicationTest):
             assert category_filters[0]['selected']
             sub_category_filters = category_filters[0]['children']
             assert len(sub_category_filters) == 2
+
+            assert [f for f in selection if f.get('name') == 'parentCategory'] == [
+                {'name': 'parentCategory', 'value': 'option 2'}]
 
     def test_filter_groups_have_correct_default_state(self):
         request = self._get_request_for_params({

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -206,72 +206,6 @@ class TestSearchFilters(BaseApplicationTest):
         assert search_filters[0]['filters'][1]['name'] == 'booleanExample2'
         assert search_filters[0]['filters'][1]['checked'] is False
 
-    @mock.patch('app.main.presenters.search_presenters.search_api_client', autospec=True)
-    def test_show_lots_and_categories_selection(self, search_api_client):
-        search_api_client.aggregate_services.return_value = _get_g9_aggregations_fixture_data()
-
-        framework = self._get_framework_fixture_data('g-cloud-9')['frameworks']
-        lots = framework['lots']
-
-        category_filter_group = filters_for_lot('cloud-software', g9_builder)['categories-example']
-        # in this test, the key 'category' key is 'checkboxTreeExample'
-
-        # first test with a top-level category selected
-        url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&filterExample=option+1" \
-              "&checkboxTreeExample=option+1&page=2"
-        with self.app.test_request_context(url):
-            selection = build_lots_and_categories_link_tree(framework, lots, category_filter_group, flask.request,
-                                                            g9_builder)
-            assert len(selection) == 3  # all -> software -> option1
-
-            tree_root = selection[0]
-            assert tree_root.get('label') == 'All categories'
-
-            lot_filters = tree_root['children']
-            selected_lot = next(f for f in lot_filters if f['selected'])
-            assert selected_lot.get('label') == 'Cloud software'
-            # there should be a link to the lot without a category, as a category has been selected within it
-            assert 'lot=cloud-software' in selected_lot['link']
-            assert 'checkboxTreeExample' not in selected_lot['link']
-
-            # check that we have links in place to a search with the relevant category filter applied,
-            # except to the currently-selected category
-            category_filters = selected_lot['children']
-            assert 'link' not in category_filters[0]
-            assert not category_filters[0].get('children')
-            assert 'checkboxTreeExample=option+2' in category_filters[1]['link']
-            sub_category_filters = category_filters[1]['children']
-            assert 'checkboxTreeExample=option+2.1' in sub_category_filters[0]['link']
-            assert 'checkboxTreeExample=option+2.2' in sub_category_filters[1]['link']
-
-            # ...and also that each link preserves only the values of filters that are valid for the target...
-            for f in itertools.chain(category_filters, sub_category_filters):
-                if f.get('link'):
-                    assert 'filterExample=option+1' in f['link']
-                    assert 'otherfilter=somevalue' not in f['link']
-                    assert 'page=' not in f['link']
-
-        # now test with a sub-category selected
-        url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&checkboxTreeExample=option+2.2"
-        with self.app.test_request_context(url):
-            selection = build_lots_and_categories_link_tree(framework, lots, category_filter_group, flask.request,
-                                                            g9_builder)
-            assert len(selection) == 5  # all -> software -> option2 -> option2.2; option2 as a parent category filter
-
-            tree_root = selection[0]
-            # check that only siblings of the selected sub-category are shown, and other categories
-            # have been removed
-            lot_filters = tree_root['children']
-            selected_lot = next(f for f in lot_filters if f['selected'])
-            category_filters = selected_lot['children']
-            assert len(category_filters) == 1
-            assert category_filters[0]['selected']
-            sub_category_filters = category_filters[0]['children']
-            assert len(sub_category_filters) == 2
-
-            assert [f for f in selection if f.get('name') == 'parentCategory'] == [
-                {'name': 'parentCategory', 'value': 'option 2'}]
-
     def test_filter_groups_have_correct_default_state(self):
         request = self._get_request_for_params({
             'q': 'email',
@@ -364,3 +298,70 @@ class TestSearchFilters(BaseApplicationTest):
         assert 'Booleans example' not in filter_group_labels
         assert 'Checkboxes example' in filter_group_labels
         assert 'Radios example' in filter_group_labels
+
+
+@mock.patch('app.main.presenters.search_presenters.search_api_client', autospec=True,
+            **{'aggregate_services.return_value': _get_g9_aggregations_fixture_data()})
+class TestLotsAndCategoriesSelection(BaseApplicationTest):
+    def setup_method(self, method):
+        super().setup_method(method)
+
+        self.framework = self._get_framework_fixture_data('g-cloud-9')['frameworks']
+        self.category_filter_group = filters_for_lot('cloud-software', g9_builder)['categories-example']
+        # in these tests, the key 'category' key is 'checkboxTreeExample'
+
+    def test_top_level_category_selection(self, search_api_client):
+        url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&filterExample=option+1" \
+              "&checkboxTreeExample=option+1&page=2"
+        with self.app.test_request_context(url):
+            selection = build_lots_and_categories_link_tree(self.framework, self.framework['lots'],
+                                                            self.category_filter_group, flask.request, g9_builder)
+            assert len(selection) == 3  # all -> software -> option1
+
+            tree_root = selection[0]
+            assert tree_root.get('label') == 'All categories'
+
+            lot_filters = tree_root['children']
+            selected_lot = next(f for f in lot_filters if f['selected'])
+            assert selected_lot.get('label') == 'Cloud software'
+            # there should be a link to the lot without a category, as a category has been selected within it
+            assert 'lot=cloud-software' in selected_lot['link']
+            assert 'checkboxTreeExample' not in selected_lot['link']
+
+            # check that we have links in place to a search with the relevant category filter applied,
+            # except to the currently-selected category
+            category_filters = selected_lot['children']
+            assert 'link' not in category_filters[0]
+            assert not category_filters[0].get('children')
+            assert 'checkboxTreeExample=option+2' in category_filters[1]['link']
+            sub_category_filters = category_filters[1]['children']
+            assert 'checkboxTreeExample=option+2.1' in sub_category_filters[0]['link']
+            assert 'checkboxTreeExample=option+2.2' in sub_category_filters[1]['link']
+
+            # ...and also that each link preserves only the values of filters that are valid for the target...
+            for f in itertools.chain(category_filters, sub_category_filters):
+                if f.get('link'):
+                    assert 'filterExample=option+1' in f['link']
+                    assert 'otherfilter=somevalue' not in f['link']
+                    assert 'page=' not in f['link']
+
+    def test_sub_category_selection(self, search_api_client):
+        url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&checkboxTreeExample=option+2.2"
+        with self.app.test_request_context(url):
+            selection = build_lots_and_categories_link_tree(self.framework, self.framework['lots'],
+                                                            self.category_filter_group, flask.request, g9_builder)
+            assert len(selection) == 5  # all -> software -> option2 -> option2.2; option2 as a parent category filter
+
+            tree_root = selection[0]
+            # check that only siblings of the selected sub-category are shown, and other categories
+            # have been removed
+            lot_filters = tree_root['children']
+            selected_lot = next(f for f in lot_filters if f['selected'])
+            category_filters = selected_lot['children']
+            assert len(category_filters) == 1
+            assert category_filters[0]['selected']
+            sub_category_filters = category_filters[0]['children']
+            assert len(sub_category_filters) == 2
+
+            assert [f for f in selection if f.get('name') == 'parentCategory'] == [
+                {'name': 'parentCategory', 'value': 'option 2'}]

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -566,7 +566,7 @@ class TestSearchResults(BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         hidden_inputs = document.xpath('//form[@id="js-dm-live-search-form"]//input[@type="hidden"]')
-        kv_pairs = { input_el.get('name'): input_el.get('value') for input_el in hidden_inputs }
+        kv_pairs = {input_el.get('name'): input_el.get('value') for input_el in hidden_inputs}
 
         assert kv_pairs == {
             'lot': 'cloud-software',

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -556,6 +556,24 @@ class TestSearchResults(BaseApplicationTest):
         assert len(training) == 1
         assert len(training[0].xpath('a')) == 0
 
+    def test_filter_form_given_category_selection(self):
+        self._search_api_client.search_services.return_value = self.g9_search_results
+
+        res = self.client.get('/g-cloud/search?parentCategory=electronic+document+and+records+management+%28edrm%29&'
+                              'lot=cloud-software&serviceCategories=content+management+system+%28cms%29')
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        hidden_inputs = document.xpath('//form[@id="js-dm-live-search-form"]//input[@type="hidden"]')
+        kv_pairs = { input_el.get('name'): input_el.get('value') for input_el in hidden_inputs }
+
+        assert kv_pairs == {
+            'lot': 'cloud-software',
+            'serviceCategories': 'content management system (cms)',
+            'parentCategory': 'electronic document and records management (edrm)'
+        }
+
 
 class TestSearchFilterOnClick(BaseApplicationTest):
     def setup_method(self, method):


### PR DESCRIPTION
Categories tree 'selected filters' must include parent category. This ensures the parent category (implied) selection survives when a filter is selected - we get a hidden field in the filters form.

https://trello.com/c/QPkflfgt/122-broken-category-sub-category-section-on-filtering-issue-exists-on-production