### PR TITLE
BUG: Spacing issue on the compare and decide saved search task list page

### DIFF
--- a/app/assets/scss/_search_overview.scss
+++ b/app/assets/scss/_search_overview.scss
@@ -18,7 +18,7 @@ ol.instruction-list-item-top li {
 
 ol.steps {
   @include bold-27;
-  padding-left: 25px;
+  padding-left: 30px;
 
   @include media( $min-width: $site-width + (2 * (27px + $gutter) ) ) {
     padding-left: 0;
@@ -30,11 +30,11 @@ ol.steps {
   .instruction-list-item-top,
   .instruction-list-item-box,
   .instruction-list-item-action {
-    margin-left: 25px;
+    margin-left: 30px;
   }
 
   .step-number {
-    min-width: 25px;
+    min-width: 30px;
     float: left;
   }
 }

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -135,7 +135,7 @@
           }
         ] %}
           <li class="instruction-list-item divider">
-            <h2 class="instruction-list-item-body"><span class="step-number" role="presentation">{{ loop.index }}.</span>&nbsp;{{ step.title }}</h2>
+            <h2 class="instruction-list-item-body"><span class="step-number" role="presentation">{{ loop.index }}.</span>{{ step.title }}</h2>
             {% for item in step.content %}
               {% if item.type == 'text' %}
                 <p class="instruction-list-item-top{% for class in item.class %} {{ class }}{% endfor %}">{{ item.text|safe }}</p>


### PR DESCRIPTION
The space between the numeral and the title seems to vary on different items.

1 and 7 look ok, the others look too close together.

Ticket: https://trello.com/c/LHDlR93V/123-bug-spacing-issue-on-the-compare-and-decide-saved-search-task-list-page

Before:
![screen_shot_2017-10-20_at_10 09 44](https://user-images.githubusercontent.com/4599889/31939372-07f8c89c-b8b2-11e7-85dd-f359bde01ef7.png)

After:
![screen shot 2017-10-24 at 11 53 10](https://user-images.githubusercontent.com/4599889/31939382-14d71cd0-b8b2-11e7-87b3-ade3ddf710a8.png)
