### PR TITLE
Allow suppliers to edit submitted application

### DIFF
--- a/app/external/views/external.py
+++ b/app/external/views/external.py
@@ -26,3 +26,13 @@ def info_page_for_starting_a_brief(framework_slug, lot_slug):
 @external.route('/buyers/frameworks/<framework_slug>/requirements/user-research-studios')
 def studios_start_page(framework_slug):
     raise NotImplementedError()
+
+
+@external.route('/suppliers/opportunities/<brief_id>/responses/start')
+def start_brief_response(brief_id):
+    raise NotImplementedError()
+
+
+@external.route('/suppliers/opportunities/<brief_id>/responses/result')
+def brief_response_result(brief_id):
+    raise NotImplementedError()

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -141,19 +141,15 @@
 {% elif brief.status == 'live' %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      <h2 class="summary-item-heading">Apply for this opportunity</h2>
-      <p class="dmspeak">To apply, you must give evidence for all the essential and nice-to-have skills and experience you have.</p>
-    </div>
-  </div>
-  <div class="grid-row">
-    <div class="column-one-third">
-      {% with
-         url = "/suppliers/opportunities/{}/responses/start".format(brief.id),
-         label = "Apply",
-         advice = True
-      %}
-        {% include "toolkit/link-button.html" %}
-      {% endwith %}
+      <form action="{{ '/suppliers/opportunities/{}/responses/start'.format(brief.id) }}" method="get">
+        {%
+          with
+          label="Apply for this opportunity",
+          type="save"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </form>
     </div>
   </div>
 {% endif %}

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -130,7 +130,7 @@
   <div class="grid-row">
     <div class="column-one-third">
         {% with
-           url = "/suppliers/opportunities/{}/responses/result".format(brief.id),
+           url = url_for('external.brief_response_result', brief_id=brief.id),
            text = "View your application",
            bigger = True
         %}
@@ -141,7 +141,7 @@
 {% elif brief.status == 'live' %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      <form action="{{ '/suppliers/opportunities/{}/responses/start'.format(brief.id) }}" method="get">
+      <form action="{{ url_for('external.start_brief_response', brief_id=brief.id) }}" method="get">
         {%
           with
           label="Apply for this opportunity",

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -131,8 +131,7 @@
     <div class="column-one-third">
         {% with
            url = url_for('external.brief_response_result', brief_id=brief.id),
-           text = "View your application",
-           bigger = True
+           text = "View your application"
         %}
           {% include "toolkit/secondary-action-link.html" %}
         {% endwith %}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,6 @@ cssselect==0.9.1
 watchdog==0.8.3
 
 coverage==3.7.1
-pytest-cov==2.2.0
+pytest-cov==2.5.1
 python-coveralls==2.5.0
 hypothesis==3.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 norecursedirs = venv* app/content bower_components node_modules

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -623,17 +623,10 @@ class TestBriefPage(BaseBriefPageTest):
         assert 'Quality assurance analyst' in res.get_data(as_text=True)
 
     def _assert_start_application(self, document, brief_id):
-        message_list = document.xpath("//p[@class='dmspeak']/text()")
-        message = message_list[0] if message_list else None
-
-        assert message == "To apply, you must give evidence for all the essential and nice-to-have " \
-            "skills and experience you have."
-        assert len(document.xpath(
-            '//a[@href="{0}"][contains(normalize-space(text()), normalize-space("{1}"))]'.format(
-                "/suppliers/opportunities/{}/responses/start".format(brief_id),
-                'Apply',
-            )
-        )) == 1
+        assert document.xpath("//form[@method='get']/@action") == [
+            "/suppliers/opportunities/{}/responses/start".format(brief_id)
+        ]
+        assert document.xpath("//input[@class='button-save']/@value") == ['Apply for this opportunity']
 
     def _assert_view_application(self, document, brief_id):
         assert len(document.xpath(


### PR DESCRIPTION
Trello ticket: https://trello.com/c/kQpbazwt/85-allow-suppliers-edit-submitted-application-if-opportunity-is-still-open

Cosmetic changes to the Buyer FE as part of the 'suppliers editing their Brief applications' story (see prototype https://suppliers-edit-application.cloudapps.digital/application/opportunity):
- the blue 'Apply' link button is now a green submit button (with a GET form action to trigger the link - not great but we do something similar in the Briefs FE when a buyer wants to start a new Brief).
- remove paragraph text, as per prototype 

Old version: 
![apply-old](https://user-images.githubusercontent.com/3492540/32333345-93b8cdd0-bfdf-11e7-9694-a6c6b5f5ceab.png)
New version:
![apply-new](https://user-images.githubusercontent.com/3492540/32333359-9995b560-bfdf-11e7-9dc2-d81f28d1113b.png)

Also some tidying:
- convert some of the hardcoded URLs in the same template to be named external routes.
- fix pytest deprecation warnings (adding `[tool:pytest]` to config and upgrading `pytest-cov`) which means test are now green instead of yellow 🎉 

This PR can be merged independently of the rest of the supplier edit flow, however some functional tests will fail (so don't merge yet!).