### PR TITLE
Use month rather than minute in download filename

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -593,7 +593,7 @@ class DownloadResultsView(SimpleDownloadFileView):
         price_question = list(filter(lambda x: type(x) == Pricing, manifest_questions.values()))
 
         locked_at = datetime.strptime(project['lockedAt'], DATETIME_FORMAT)
-        filename = '{}-{}-results'.format(locked_at.strftime('%Y-%M-%d'), inflection.parameterize(project['name']))
+        filename = '{}-{}-results'.format(locked_at.strftime('%Y-%m-%d'), inflection.parameterize(project['name']))
         locked_at = utcdatetimeformat(locked_at)
 
         services = self.data_api_client.get_direct_award_project_services_iter(project_id=project['id'],

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -586,7 +586,7 @@ class TestDirectAwardDownloadResultsView(TestDirectAwardBase):
         assert file_context['project'] == data_api_client.get_direct_award_project.return_value['project']
         assert set(q.id for q in file_context['questions'].values()) == {'serviceName', 'serviceDescription', 'price'}
         assert len(file_context['services']) == 1
-        assert file_context['filename'] == '2017-00-08-my-procurement-project-results'
+        assert file_context['filename'] == '2017-09-08-my-procurement-project-results'
         assert file_context['sheetname'] == "Search results"
         assert file_context['locked_at'] == 'Friday 8 September 2017 at 12:00am GMT'
         assert file_context['search_summary'] == Markup('1 result found in All categories')


### PR DESCRIPTION
The existing test implies that having "Year-Minute-Day" is the desired behaviour, but it feels like "Year-Month-Day" will make more sense to our buyers when they download their saved search results.

When formatting times in Python `%M` is minutes, `%m` is the month - see https://docs.python.org/3/library/time.html for more details.