### PR TITLE
Notification banner fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v24.5.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v25.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#8.15.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"


### PR DESCRIPTION
Fixes bug where the notification banner template was unintentionally using the `content` context variable in the opportunity page (see https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/388 - this PR will fail until that is merged).

The breaking change will affect the Briefs FE only (separate PR to come shortly).