### PR TITLE
Redirect saved search IDs

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -51,6 +51,21 @@ TOO_MANY_RESULTS_MESSAGE = Markup("""
     You have too many results. Choose a category or add filters to refine your search.""")
 
 
+# TODO: Temporary redirect for direct_award internal IDs. Remove after external IDs have been out for a week - SW.
+@direct_award.before_request
+def redirect_internal_ids():
+    if 'project_id' in request.view_args:
+        project_id = request.view_args['project_id']
+
+        project = data_api_client.get_direct_award_project(project_id=project_id)['project']
+        if project and is_direct_award_project_accessible(project, current_user.id):
+            if project_id != project['id']:
+                view_args = request.view_args.copy()
+                view_args['project_id'] = project['id']
+
+                return redirect(url_for(request.endpoint, **view_args))
+
+
 @main.route('/g-cloud')
 def index_g_cloud():
     # if there are multiple live g-cloud frameworks, assume they all have the same lots

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -645,3 +645,28 @@ class TestDirectAwardDownloadResultsView(TestDirectAwardBase):
 
         res = self.client.get('/buyers/direct-award/g-cloud/projects/1/results/download?filetype=docx')
         assert res.status_code == 400
+
+
+class TestDirectAwardRedirect(TestDirectAwardBase):
+    def test_no_redirect_if_id_from_api_matches_original_id_from_url(self):
+        data_api_client.get_direct_award_project.return_value = self._get_direct_award_project_fixture(id=1)
+        data_api_client.find_direct_award_project_searches.return_value = \
+            self._get_direct_award_project_searches_fixture()
+
+        self.login_as_buyer()
+
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1')
+        assert res.status_code == 200
+
+    def test_redirect_if_id_from_api_doesnt_match_original_id_from_url(self):
+        data_api_client.get_direct_award_project.return_value = self._get_direct_award_project_fixture(
+            id=123456789012345
+        )
+        data_api_client.find_direct_award_project_searches.return_value = \
+            self._get_direct_award_project_searches_fixture()
+
+        self.login_as_buyer()
+
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1')
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/buyers/direct-award/g-cloud/projects/123456789012345'


### PR DESCRIPTION
## Summary
We are generating random external IDs for Direct Award projects/saved searches, so we need a transitional function to redirect buyer URLs if the ID returned by the API doesn't match the ID provided in the URL.

## Associated PRs
https://github.com/alphagov/digitalmarketplace-api/pull/690

## Ticket
https://trello.com/c/GEziXqcE/34-security-change-direct-award-projects-to-use-randomly-generated-ids-rather-than-sequential