### PR TITLE
Change from flake8-putty to per-file-ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,13 +3,12 @@
 # D203: 1 blank line required before class docstring
 # F401: 'identifier' imported but unused
 # E402: module level import not at top of file
-# C901: too complex
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules,bower_components,app/content
 ignore = D203,W503
 max-complexity = 12
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
-    app/__init__.py, app/main/__init__.py, app/status/__init__.py : +E402
-    app/main/views/*.py : +C901
+per-file-ignores =
+    **/__init__.py : F401
+    app/main/__init__.py : E402
+    app/status/__init__.py : E402

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -16,6 +16,7 @@ def require_login():
         flash(LOGIN_REQUIRED_MESSAGE, 'error')
         return current_app.login_manager.unauthorized()
 
+
 from . import errors
 from .views import (
     crown_hosting,

--- a/app/main/presenters/search_summary.py
+++ b/app/main/presenters/search_summary.py
@@ -181,7 +181,7 @@ class SummaryRules(object):
         if hasattr(self, 'filter_rules_ids'):
             try:
                 index = self.filter_rules_ids.index(filter)
-            except:
+            except (AttributeError, TypeError, ValueError):
                 return None
             return self._rules['filterRules'][index]['preposition']
 

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -359,10 +359,7 @@ def save_search(framework_framework):
     form = CreateProjectForm()
     name = form.name.data
 
-    try:
-        save_search_selection = request.form['save_search_selection']
-    except:
-        save_search_selection = None
+    save_search_selection = request.form.get('save_search_selection', None)
 
     name_is_invalid = save_search_selection == "new_search" and not name
 

--- a/config.py
+++ b/config.py
@@ -152,6 +152,7 @@ class Production(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-08')
     FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = enabled_since('2017-10-26')
 
+
 configs = {
     'development': Development,
     'test': Test,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@
 
 #Required for testing
 pytest==3.2.3
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 mock==2.0.0
 cssselect==0.9.1
 watchdog==0.8.3

--- a/tests/main/helpers/test_search_helpers.py
+++ b/tests/main/helpers/test_search_helpers.py
@@ -182,7 +182,6 @@ class TestBuildSearchQueryHelpers(BaseApplicationTest):
             'question1': 'true',
             'question2': 'true',
             'question3': ['option1', 'option2'],
-            'page': 'false',
             'q': 'email',
             'lot': 'saas',
             'page': 9,


### PR DESCRIPTION
## Summary
Add flake8 per-file-ignores, in place of flake8-putty, so that we can support newer Python3 syntax like eg f-strings and type annotations.

Flake8 report:
```
/Users/samuelwilliams/git/digitalmarketplace-buyer-frontend/venv/bin/flake8 .
./app/main/views/__init__.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/crown_hosting.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/digital_services_framework.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/feedback.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/g_cloud.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/login.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/marketplace.py:0:1: X100 Superfluous per-file-ignores for C901
./app/main/views/suppliers.py:0:1: X100 Superfluous per-file-ignores for C901
./tests/main/helpers/test_search_helpers.py:185:13: F601 dictionary key 'page' repeated with different values
./tests/main/helpers/test_search_helpers.py:188:13: F601 dictionary key 'page' repeated with different values
make: *** [test-flake8] Error 1
```