### PR TITLE
Extends filterSelected event to allow multiple frameworks

### DIFF
--- a/app/assets/javascripts/analytics/_virtualPageViews.js
+++ b/app/assets/javascripts/analytics/_virtualPageViews.js
@@ -36,20 +36,22 @@
 
   };
 
-  VirtualPageViews.prototype.trackFilterAnalytics = function( group, key, value ) {
-
-    var filter_path = '/' + group + '/' + key + '/' + value;
-    var url = '/g-cloud/filters' + filter_path;
-    this.sendVirtualPageView( url, 'Filter' + filter_path.replace(/[/]/g, " - ") );
-
+  VirtualPageViews.prototype.trackFilterAnalytics = function( framework, lot, group, key, value ) {
+    var url = '/' + framework + '/' + lot + '/filters' + '/' + group + '/' + key + '/' + value;
+    var pageTitle = 'Filter' + url.replace('/filters/', '/').replace(/[/]/g, " - ");
+    this.sendVirtualPageView(url, pageTitle);
   };
 
   VirtualPageViews.prototype.filterSelected = function(){
     if(this.checked) {
+      var framework = $(this).closest('.options-container').attr('data-framework');
+      framework = framework ? framework : 'no-framework-given';
+      var lot = $(this).closest('.options-container').attr('data-current-lot');
+      lot = lot ? lot : 'no-lot-selected';
       var group = $(this).closest('.options-container').attr('id');
       var key = $(this).attr('name');
       var value = $(this).attr('value');
-      GOVUK.GDM.analytics.virtualPageViews.trackFilterAnalytics(group, key, value);
+      GOVUK.GDM.analytics.virtualPageViews.trackFilterAnalytics(framework, lot, group, key, value);
     }
   };
 

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v25.1.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v26.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.3.2",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -197,7 +197,7 @@ describe("GOVUK.Analytics", function () {
     var filterTemplate = 
         '<form id="js-dm-live-search-form">' + 
             '<div class="dm-filters">' +
-              '<div class="options-container" id="example-filters-group">' +
+              '<div class="options-container" id="example-filters-group" data-framework="g-cloud" data-current-lot="test-lot">' +
                 '<div class="js-auto-height-inner">' +
                   '<label for="filter-option-1">' +
                     '<input name="filter-option-1" value="filter-option-1-value" id="filter-option-1" type="checkbox" aria-controls="">' +
@@ -248,8 +248,8 @@ describe("GOVUK.Analytics", function () {
       window.GOVUK.GDM.analytics.virtualPageViews.init();
       $('#filter-option-1').click();
       expect(window.ga.calls.first().args[2]).toEqual({
-        page: "/g-cloud/filters/example-filters-group/filter-option-1/filter-option-1-value/vpv", 
-        title: "Filter - example-filters-group - filter-option-1 - filter-option-1-value"
+        page: "/g-cloud/test-lot/filters/example-filters-group/filter-option-1/filter-option-1-value/vpv", 
+        title: "Filter - g-cloud - test-lot - example-filters-group - filter-option-1 - filter-option-1-value"
       });
     });
 


### PR DESCRIPTION
Extends filterSelected event to allow multiple frameworks

This work was done to meet the acceptance criteria:
`It should send the page view to Google Analytics in the following format: /{framework family}/{lot}/filters/{group}/{key}/{value}/vpv`

Ticket: https://trello.com/c/g0h1Ibq6/137-how-to-measure-impact-of-adding-filters-to-dos-opportunities-page