### PR TITLE
Accept `documents` as well as `services` in SearchResults

### DIFF
--- a/app/main/presenters/search_results.py
+++ b/app/main/presenters/search_results.py
@@ -5,7 +5,7 @@ class SearchResults(object):
     """Provides access to the search results information"""
 
     def __init__(self, response, lots_by_slug):
-        self.search_results = response['services']
+        self.search_results = response.get('documents') or response.get('services')
         self._lots = lots_by_slug
         self._annotate()
         self.total = response['meta']['total']

--- a/tests/main/presenters/test_search_results.py
+++ b/tests/main/presenters/test_search_results.py
@@ -49,9 +49,9 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_search_results_accepts_top_level_documents_key_in_response_instead_of_services(self):
         self.fixture['documents'] = self.fixture.pop('services')
+        result = SearchResults(self.fixture, self._lots_by_slug)
 
-        search_results_instance = SearchResults(self.fixture, self._lots_by_slug)
-        assert hasattr(search_results_instance, 'search_results')
+        assert result.search_results == self.fixture['documents']
 
     def test_search_results_is_set(self):
         search_results_instance = SearchResults(self.fixture, self._lots_by_slug)

--- a/tests/main/presenters/test_search_results.py
+++ b/tests/main/presenters/test_search_results.py
@@ -47,6 +47,12 @@ class TestSearchResults(BaseApplicationTest):
             self._get_framework_fixture_data('g-cloud-6')['frameworks']
         )
 
+    def test_search_results_accepts_top_level_documents_key_in_response_instead_of_services(self):
+        self.fixture['documents'] = self.fixture.pop('services')
+
+        search_results_instance = SearchResults(self.fixture, self._lots_by_slug)
+        assert hasattr(search_results_instance, 'search_results')
+
     def test_search_results_is_set(self):
         search_results_instance = SearchResults(self.fixture, self._lots_by_slug)
         assert hasattr(search_results_instance, 'search_results')


### PR DESCRIPTION
In an upcoming change to the search-api ([see this PR](https://github.com/alphagov/digitalmarketplace-search-api/pull/124/))
we're going to be returning data structure with a top level `documents`
key instead of `services`. To allow this PR to go out without breaking
the buyer frontend, we need to be able to accept both keys for a while.