### PR TITLE
Remove temporary create user redirect

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -18,7 +18,10 @@ def require_login():
 
 from . import errors
 from .views import (
-    crown_hosting, digital_services_framework, g_cloud,
-    login, marketplace, suppliers,
+    crown_hosting,
+    digital_services_framework,
     feedback,
+    g_cloud,
+    marketplace,
+    suppliers,
 )

--- a/app/main/views/login.py
+++ b/app/main/views/login.py
@@ -1,9 +1,0 @@
-from flask import redirect
-from .. import main
-
-
-# Any invites sent before the new user-frontend becomes active will be linking to this route. We need to maintain it
-# for seven days after the user-frontend goes live.
-@main.route('/create-user/<string:encoded_token>', methods=['GET'])
-def create_user(encoded_token):
-    return redirect('/user/create/{}'.format(encoded_token), 301)

--- a/tests/main/views/test_login.py
+++ b/tests/main/views/test_login.py
@@ -1,8 +1,0 @@
-from ...helpers import BaseApplicationTest
-
-
-class TestCreateUser(BaseApplicationTest):
-    def test_should_redirect_to_the_user_frontend_app(self):
-        res = self.client.get('/create-user/1234567890')
-        assert res.status_code == 301
-        assert res.location == 'http://localhost/user/create/1234567890'


### PR DESCRIPTION
This functionality is now found at a new URL in the user FE. This
route was just a temporary redirect for people who may have been
using the original links in their emails (which were valid for
a week). Now this time has passed, we no longer need to maintain
this redirect.