### PR TITLE
Improve styling for search summary

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -1,8 +1,6 @@
 @import "search/_search-summary.scss";
 
 .search-summary {
-  padding: 0 0 $gutter-half;
-
   em {
     font-style: normal;
     font-weight: bold;
@@ -10,10 +8,8 @@
 }
 
 .button-save-wrapper {
-  border-top: 1px solid $border-colour;
   border-bottom: 1px solid $border-colour;
-  padding-top: 20px;
-  margin: 0px 0px 20px;
+  margin: 0px 0px $gutter-half;
 
   .save-summary-text {
     @include core-16;
@@ -26,6 +22,7 @@
   .save-button {
     .button-save {
       @include core-16;
+      margin-bottom: $gutter-half;
       width: 100%;
     }
   }
@@ -95,7 +92,7 @@
   .dm-filters {
 
     .dm-filter-title {
-      margin-bottom: 10px;
+      margin-bottom: $gutter-one-third;
 
       .apply-filters-title {
         display: inline-block;

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "jquery": "1.11.2",
     "hogan": "3.0.2",
     "jquery-details": "https://github.com/mathiasbynens/jquery-details/archive/v0.1.0.tar.gz",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v26.1.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v26.1.1",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#9.3.2",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"


### PR DESCRIPTION
Related PR: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/392

Originally I planned to just add a border to the summary results for the opportunities page but then realised that the search results summary needed more consideration.

This commit:
• removes a border-top from the save search
• increases the font-size for search results summary and suggestion
• increases font sizes for mobile

Before:
<img width="1012" alt="screen shot 2017-12-11 at 12 13 10" src="https://user-images.githubusercontent.com/3798032/33830602-bb8bca82-de6c-11e7-8c7c-c4b07d6ec568.png">

<img width="1004" alt="screen shot 2017-12-11 at 12 12 36" src="https://user-images.githubusercontent.com/3798032/33830608-c0206cba-de6c-11e7-9e73-5f2455b6a336.png">

<img width="371" alt="screen shot 2017-12-11 at 12 15 47" src="https://user-images.githubusercontent.com/3798032/33830701-1a85f814-de6d-11e7-8b22-06a08cecddc4.png">


After:

<img width="1005" alt="screen shot 2017-12-11 at 11 59 46" src="https://user-images.githubusercontent.com/3798032/33830618-c8cb998e-de6c-11e7-892c-a0be32a99c0a.png">

<img width="1015" alt="screen shot 2017-12-11 at 12 00 03" src="https://user-images.githubusercontent.com/3798032/33830627-cdc4890a-de6c-11e7-938a-8860d98463fb.png">

<img width="385" alt="screen shot 2017-12-11 at 11 28 29" src="https://user-images.githubusercontent.com/3798032/33830697-15d01a84-de6d-11e7-8851-d24c41a51d2e.png">


