### PR TITLE
Remove check for 'services' key in search results

### DIFF
--- a/app/main/presenters/search_results.py
+++ b/app/main/presenters/search_results.py
@@ -5,7 +5,7 @@ class SearchResults(object):
     """Provides access to the search results information"""
 
     def __init__(self, response, lots_by_slug):
-        self.search_results = response.get('documents') or response.get('services')
+        self.search_results = response['documents']
         self._lots = lots_by_slug
         self._annotate()
         self.total = response['meta']['total']
@@ -13,20 +13,20 @@ class SearchResults(object):
             self.page = response['meta']['query']['page']
 
     def _annotate(self):
-        for service in self.search_results:
-            self._replace_lot(service)
-            self._add_highlighting(service)
+        for document in self.search_results:
+            self._replace_lot(document)
+            self._add_highlighting(document)
 
-    def _replace_lot(self, service):
+    def _replace_lot(self, document):
         # replace lot slug with reference to dict containing all the relevant lot data
-        service['lot'] = self._lots.get(service['lot'])
+        document['lot'] = self._lots.get(document['lot'])
 
-    def _add_highlighting(self, service):
-        if 'highlight' in service:
+    def _add_highlighting(self, document):
+        if 'highlight' in document:
             for highlighted_field in ['serviceSummary', 'serviceDescription']:
-                if highlighted_field in service['highlight']:
-                    service[highlighted_field] = Markup(
-                        ''.join(service['highlight'][highlighted_field])
+                if highlighted_field in document['highlight']:
+                    document[highlighted_field] = Markup(
+                        ''.join(document['highlight'][highlighted_field])
                     )
 
 

--- a/tests/fixtures/g9_search_results_fixture.json
+++ b/tests/fixtures/g9_search_results_fixture.json
@@ -11,7 +11,7 @@
     "took":8,
     "total":1150
   },
-  "services":[
+  "documents":[
     {
       "frameworkName":"G-Cloud 9",
       "highlight":{

--- a/tests/fixtures/search_results_fixture.json
+++ b/tests/fixtures/search_results_fixture.json
@@ -7,7 +7,7 @@
     "total": 9,
     "took": 13
   },
-  "services": [
+  "documents": [
     {
       "serviceSummary": "Fastly CDN (Content Delivery Network) speeds up delivery of your website and its content to your users. When your client clicks on your site requesting a piece of information, we want them to feel your speed of delivery. No waiting. We want them to get to your closest point of presence\u2014in milliseconds\u2014to get what they want. Fastly delivers the world's only real-time content delivery network. At Fastly we think slow is unacceptable. Fastly enables a next-generation of businesses to give their users the best online and mobile experience. The patent-pending Fastly Caching Software delivers static, dynamic and streaming content with the lowest recorded time to first byte.",
       "id": "4-G4-0871-001",

--- a/tests/fixtures/search_results_multiple_pages_fixture.json
+++ b/tests/fixtures/search_results_multiple_pages_fixture.json
@@ -8,7 +8,7 @@
     "total": 19981,
     "took": 13
   },
-  "services": [
+  "documents": [
     {
       "frameworkName": "G-Cloud 6",
       "id": "4528242010619904",

--- a/tests/main/presenters/test_search_results.py
+++ b/tests/main/presenters/test_search_results.py
@@ -47,12 +47,6 @@ class TestSearchResults(BaseApplicationTest):
             self._get_framework_fixture_data('g-cloud-6')['frameworks']
         )
 
-    def test_search_results_accepts_top_level_documents_key_in_response_instead_of_services(self):
-        self.fixture['documents'] = self.fixture.pop('services')
-        result = SearchResults(self.fixture, self._lots_by_slug)
-
-        assert result.search_results == self.fixture['documents']
-
     def test_search_results_is_set(self):
         search_results_instance = SearchResults(self.fixture, self._lots_by_slug)
         assert hasattr(search_results_instance, 'search_results')

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -21,7 +21,7 @@ def find_0_results_suggestion(res_data):
 
 def get_0_results_search_response():
     return {
-        "services": [],
+        "documents": [],
         "meta": {
             "query": {},
             "total": 0,
@@ -174,7 +174,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_not_render_suggestions_for_when_results_are_shown(self):
         self._search_api_client.search_services.return_value = {
-            "services": [],
+            "documents": [],
             "meta": {
                 "query": {},
                 "total": 2,
@@ -190,7 +190,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_render_summary_for_1_result_in_cloud_software_no_keywords(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -201,7 +201,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_render_summary_for_1_result_in_cloud_hosting_no_keywords(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -213,7 +213,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_render_summary_for_1_result_in_cloud_software_with_keywords(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -226,7 +226,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_render_summary_with_a_group_of_1_boolean_filter(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -241,7 +241,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_render_summary_with_a_group_of_2_boolean_filters(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -258,7 +258,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_render_summary_with_a_group_of_1_array_filter(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -274,7 +274,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_render_summary_with_a_group_of_2_array_filters(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -291,7 +291,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_render_summary_with_2_groups_of_filters(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -310,7 +310,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_render_summary_with_3_groups_of_filters(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -331,7 +331,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_should_ignore_unknown_arguments(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -343,7 +343,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_query_text_is_escaped(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 
@@ -355,7 +355,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_summary_for_unicode_query_keywords(self):
         return_value = self.search_results_multiple_page
-        return_value["services"] = [return_value["services"][0]]
+        return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
         self._search_api_client.search_services.return_value = return_value
 


### PR DESCRIPTION
The search-api is now only returning 'documents' so we can remove the
check for the 'services' key.

This also fixes a bug when zero search results are returned.

If there are zero results found, the response is an empty list. Using
the `get` method on a dict returns `None` instead of the empty list.
Which broke stuff.