### PR TITLE
Catch missing file extension errors for service documents

### DIFF
--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -181,7 +181,10 @@ class Meta(object):
 
     def _get_document_extension(self, document_url):
         url_object = urlparse(document_url.replace(';', '%3B'))
-        return os.path.splitext(url_object.path)[1].split('.')[1]
+        try:
+            return os.path.splitext(url_object.path)[1].split('.')[1]
+        except IndexError:
+            raise ValueError("Missing file extension for document at URL {}".format(document_url))
 
     def _if_both_keys_or_either(self, service_data, keys=[], values={}):
         def is_not_false(key):

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -4,6 +4,7 @@ from app.main.presenters.service_presenters import (
     Service, Meta,
     chunk_string
 )
+import pytest
 from app import content_loader
 from app.main.helpers import framework_helpers
 
@@ -158,6 +159,16 @@ class TestMeta(object):
             assert documents[idx]['name'] == expected_information[idx]['name']
             assert documents[idx]['url'] == expected_information[idx]['url']
             assert documents[idx]['extension'] == 'pdf'
+
+    def test_get_documents_raises_error_if_no_file_extension(self):
+        bad_document_url = "https://assets.digitalmarketplace.service.gov.uk/documents/123456/noextension"
+        service_missing_file_extension = self.fixture.copy()
+        service_missing_file_extension["pricingDocumentURL"] = bad_document_url
+
+        with pytest.raises(ValueError) as exc:
+            self.meta.get_documents(service_missing_file_extension)
+
+        assert str(exc.value) == "Missing file extension for document at URL {}".format(bad_document_url)
 
     def test_vat_status_is_correct(self):
         # if VAT is not included


### PR DESCRIPTION
Mitigates the error seen in this 2nd line ticket: https://trello.com/c/tvGUsJeL/110-crash-on-preview-bad-g-cloud-service

In theory this error should only happen with bad data on preview or staging - suppliers should be uploading valid file formats (PDF, ODF). We should still fail loudly if this happens, as other stuff will break. But now if a bad filename does somehow sneak in, then we will have a sane error message telling us about it that we can debug.

Possible issue: do we have any concerns logging the full document URL?