### PR TITLE
Remove unused `link-button` functionality in shim

### DIFF
--- a/app/assets/javascripts/_shim-links-with-button-role.js
+++ b/app/assets/javascripts/_shim-links-with-button-role.js
@@ -1,12 +1,12 @@
+// Javascript shim for accessibility incase we use `role="button"` in our front end code. See GOV.UK front end toolkit
+// for further documentation
 (function(GOVUK, GDM) {
 
   GDM.shimLinksWithButtonRole = function() {
 
     if (!GOVUK.shimLinksWithButtonRole) return;
 
-    GOVUK.shimLinksWithButtonRole.init({
-      selector: '[class^=link-button]'
-    });
+    GOVUK.shimLinksWithButtonRole.init();
 
   };
 


### PR DESCRIPTION
We are not using link button components in our applications.
On top of that, the `shimLinkWithButtonRole` has changed due to
version bumping and it no longer even accepts a parameters in it's
init method.

We have decided to keep this functionality in our tookit even though
we have no button roles in our templates at the moment or in the
frontend toolkit. This is because it can be there in case we do
add something in the future without needing to remember about this
accessibility shim which could easily be missed at code review.

alphagov/govuk_frontend_toolkit@e882086#diff-0afd84124334f16359259ae2ca718990

Note, I may not merge this as I am going to look into moving this into the DM toolkit to see if that streamlines our javascript.