### PR TITLE
Remove context push, not required when not accessing db.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,12 +27,8 @@ class BaseApplicationTest(object):
         self.client = self.app.test_client()
         self.get_user_patch = None
 
-        self.app_context = self.app.app_context()
-        self.app_context.push()
-
     def teardown_method(self, method):
         self.teardown_login()
-        self.app_context.pop()
 
     @staticmethod
     def user(id, email_address, supplier_id, supplier_name, name,


### PR DESCRIPTION
The context push here isn't required as we're not accessing the database.