### PR TITLE
Localised datetime format for saved search dashboard

### DIFF
--- a/app/templates/direct-award/index.html
+++ b/app/templates/direct-award/index.html
@@ -42,7 +42,7 @@
     ) %}
       {% call summary.row() %}
         {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_framework=framework.framework, project_id=item.id)) }}
-        {{ summary.text(item.createdAt | utcdatetimeformat ) }}
+        {{ summary.text(item.createdAt | datetimeformat ) }}
       {% endcall %}
     {% endcall %}
 
@@ -57,7 +57,7 @@
     ) %}
       {% call summary.row() %}
         {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_framework=framework.framework, project_id=item.id)) }}
-        {{ summary.text(item.lockedAt | utcdatetimeformat ) }}
+        {{ summary.text(item.lockedAt | datetimeformat ) }}
       {% endcall %}
     {% endcall %}
 

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -61,7 +61,7 @@
             ] if not search_summary_sentence else [
               {"type": "text", "class": ["search-summary"], "text": search_summary_sentence},
               {"type": "text", "text": ''.join(["<a href=\"", buyer_search_page_url|e, "\">View results</a>"])|safe},
-              {"type": "box", "style": "complete", "label": ''.join(["Search saved on ", search.createdAt|datetimeformat()])}
+              {"type": "box", "style": "complete", "label": ''.join(["Search saved on ", search.createdAt|datetimeformat])}
             ]
           },
           {


### PR DESCRIPTION
https://trello.com/c/BBgL8WtW/57-timestamp-shows-gmt-but-right-now-its-gmt1
Show 'BST' on the list of projects (to be consistent with the individual project page).

A separate bug ticket has been raised to address the fact that the date itself refers to the project create date, not the most recent saved search for that project (whoops) https://trello.com/c/A6ItggQH/273-direct-award-search-saved-at-datestamp-doesnt-match-project-list-saved-at