### PR TITLE
search page: add aria-live attributes

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -298,6 +298,10 @@ def search_services():
                 "selector": "#js-dm-live-search-summary",
                 "html": render_template("search/_summary.html", **template_args)
             },
+            "summary-accessible-hint": {
+                "selector": "#js-dm-live-search-summary-accessible-hint",
+                "html": render_template("search/_summary_accessible_hint.html", **template_args)
+            },
             "save-form": {
                 "selector": "#js-dm-live-save-search-form",
                 "html": render_template("search/_services_save_search.html", **template_args)

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -271,6 +271,10 @@ def list_opportunities(framework_family):
                 "selector": "#js-dm-live-search-summary",
                 "html": render_template("search/_summary.html", **template_args)
             },
+            "summary-accessible-hint": {
+                "selector": "#js-dm-live-search-summary-accessible-hint",
+                "html": render_template("search/_summary_accessible_hint.html", **template_args)
+            },
         }
 
         return jsonify(live_results_dict)

--- a/app/templates/search/_filters.html
+++ b/app/templates/search/_filters.html
@@ -9,11 +9,12 @@
         with
         label = filter.label,
         options_container_id = filter.slug,
-        options = filter.filters
+        options = filter.filters,
+        aria_controls="search-summary-accessible-hint-wrapper"
       %}
         {% include "toolkit/forms/option-select.html" %}
       {% endwith %}
     {% endfor %}
   </div>
-  <button class="button-save js-hidden js-dm-live-search" type="submit">Filter</button>
+  <button class="button-save js-hidden js-dm-live-search" type="submit" aria-controls="search-summary-accessible-hint-wrapper">Filter</button>
 </div>

--- a/app/templates/search/_filters.html
+++ b/app/templates/search/_filters.html
@@ -1,7 +1,7 @@
 <div class="dm-filters">
   <div class="dm-filter-title">
     <h2 class="apply-filters-title">Apply filters</h2>
-    <a id="dm-clear-all-filters" class="clear-filters-link" href="{{ clear_filters_url }}">Clear filters</a>
+    <a id="dm-clear-all-filters" class="clear-filters-link" href="{{ clear_filters_url }}" role="button">Clear filters</a>
   </div>
   <div>
     {% for filter in filters %}

--- a/app/templates/search/_summary_accessible_hint.html
+++ b/app/templates/search/_summary_accessible_hint.html
@@ -1,0 +1,3 @@
+<div id="js-dm-live-search-summary-accessible-hint">
+  {{ total }} {{ pluralize(total, "result", "results") }} found
+</div>

--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -61,6 +61,18 @@
     </section>
   </form>
   <section class="column-two-thirds" aria-label="Search results">
+    {#
+      the element referenced by an `aria-controls=` seems to need to be persistent -
+      at least I wasn't able to get it to work by just re-using a fragment of the
+      existing search summary text, as it gets removed and replaced wholesale by
+      the javascript when a new set of results is fetched.
+
+      instead, we have this dedicated (and more importantly, persistent) wrapper
+      element, which itself can be the target of `aria-controls=`
+    #}
+    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="all">
+      {% include 'search/_summary_accessible_hint.html' %}
+    </div>
     {% include 'search/_summary.html' %}
     {% include 'search/_results_wrapper.html' %}
   </section>

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -50,6 +50,18 @@
     </section>
   </form>
   <section class="column-two-thirds" aria-label="Search results">
+    {#
+      the element referenced by an `aria-controls=` seems to need to be persistent -
+      at least I wasn't able to get it to work by just re-using a fragment of the
+      existing search summary text, as it gets removed and replaced wholesale by
+      the javascript when a new set of results is fetched.
+
+      instead, we have this dedicated (and more importantly, persistent) wrapper
+      element, which itself can be the target of `aria-controls=`
+    #}
+    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="all">
+      {% include 'search/_summary_accessible_hint.html' %}
+    </div>
     {% include 'search/_summary.html' %}
     {% include 'search/_services_save_search.html' %}
     {% include 'search/_results_wrapper.html' %}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.2.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.2.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1240,9 +1240,13 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             'User research participants (39)': 'a',
         }
 
-        assert '<a id="dm-clear-all-filters" class="clear-filters-link" ' \
-            'href="/digital-outcomes-and-specialists/opportunities?lot=digital-outcomes">Clear filters</a>' \
-            in res.get_data(as_text=True)
+        assert document.xpath(
+            "//a[@id=$i][contains(@class, $c)][normalize-space(string())=normalize-space($t)][@href=$h]",
+            i="dm-clear-all-filters",
+            c="clear-filters-link",
+            t="Clear filters",
+            h="/digital-outcomes-and-specialists/opportunities?lot=digital-outcomes",
+        )
 
         status_inputs = document.xpath("//form[@method='get']//input[@name='status']")
         assert {

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1631,7 +1631,12 @@ class TestCatalogueOfBriefsFilterOnClick(BaseApplicationTest):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities?live-results=true')
         data = json.loads(res.get_data(as_text=True))
 
-        assert set(data.keys()) == {'results', 'summary', 'categories'}
+        assert set(data.keys()) == {
+            'results',
+            'summary',
+            'summary-accessible-hint',
+            'categories',
+        }
 
         for k, v in data.items():
             assert set(v.keys()) == {'selector', 'html'}
@@ -1644,6 +1649,7 @@ class TestCatalogueOfBriefsFilterOnClick(BaseApplicationTest):
                               ('?live-results=true', {"search/_results_wrapper.html",
                                                       "search/_categories_wrapper.html",
                                                       "search/_summary.html",
+                                                      "search/_summary_accessible_hint.html",
                                                       })))
     @mock.patch('app.main.views.marketplace.render_template', autospec=True)
     def test_base_page_renders_search_services(self, render_template_patch, query_string, urls):

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -169,8 +169,16 @@ class TestSearchResults(BaseApplicationTest):
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
         assert res.status_code == 200
-        assert '<a id="dm-clear-all-filters" class="clear-filters-link" ' \
-            'href="/g-cloud/search?lot=cloud-software">Clear filters</a>' in res.get_data(as_text=True)
+
+        document = html.fromstring(res.get_data(as_text=True))
+
+        assert document.xpath(
+            "//a[@id=$i][contains(@class, $c)][normalize-space(string())=normalize-space($t)][@href=$h]",
+            i="dm-clear-all-filters",
+            c="clear-filters-link",
+            t="Clear filters",
+            h="/g-cloud/search?lot=cloud-software",
+        )
 
     def test_should_not_render_suggestions_for_when_results_are_shown(self):
         self._search_api_client.search.return_value = {

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -600,7 +600,13 @@ class TestSearchFilterOnClick(BaseApplicationTest):
         res = self.client.get('/g-cloud/search?live-results=true')
         data = json.loads(res.get_data(as_text=True))
 
-        assert set(data.keys()) == {'results', 'summary', 'categories', 'save-form'}
+        assert set(data.keys()) == {
+            'results',
+            'summary',
+            'summary-accessible-hint',
+            'categories',
+            'save-form',
+        }
 
         for k, v in data.items():
             assert set(v.keys()) == {'selector', 'html'}
@@ -613,6 +619,7 @@ class TestSearchFilterOnClick(BaseApplicationTest):
                               ('?live-results=true', {"search/_results_wrapper.html",
                                                       "search/_categories_wrapper.html",
                                                       "search/_summary.html",
+                                                      "search/_summary_accessible_hint.html",
                                                       "search/_services_save_search.html",
                                                       })))
     @mock.patch('app.main.views.g_cloud.render_template', autospec=True)

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#ea0d37c23827bda76cfdab8517f2e665b441c5dc"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.0.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v27.2.0":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#bec67d8d44fa0f279be32786e7fb75a6e1981629"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#1d44c7098dbcf2d613eec67009e468e0351080f3"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Trello https://trello.com/c/qUViIfu9/172-dynamic-content-on-the-search-pages-which-updates-without-a-page-reload-is-marked-up-using-wai-aria-live-regions

We don't want the whole loaded results section re-read on reloading, instead just a shortened "N results found" summary.

The element referenced by an `aria-controls=` seems to need to be persistent, meaning we probably can't use a fragment of the existing search summary text, as it gets removed & replaced wholesale when a new set of results is fetched.

Instead, we return the shortened summary as its own html fragment under the summary-accessible-hint key in the live results request. This html fragment gets placed inside a dedicated (and more importantly, persistent) `search-summary-accessible-hint-wrapper` element, which itself can be the target of the `aria-controls=`

This PR has fixed the tests to *pass* but hasn't added any new tests for the new functionality. I thought adding new tests would actually be best done in functional tests to ensure the ajax procedure doesn't screw things up.

Depends on https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/401 - ~~~~TODO fix dependency reference before merge.~~~~