### PR TITLE
Add page for /404 that has only absolute links

### DIFF
--- a/app/main/errors.py
+++ b/app/main/errors.py
@@ -1,8 +1,9 @@
 # coding=utf-8
-
 from flask import render_template
-from . import main
+
 from dmapiclient import APIError
+
+from . import main
 
 
 @main.app_errorhandler(APIError)

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -1,5 +1,6 @@
 from flask_wtf import Form
 from wtforms.validators import Length, Optional
+
 from dmutils.forms import StripWhitespaceStringField
 
 

--- a/app/main/helpers/__init__.py
+++ b/app/main/helpers/__init__.py
@@ -1,5 +1,5 @@
-import hashlib
 import base64
+import hashlib
 
 
 def hash_email(email):

--- a/app/main/helpers/direct_award_helpers.py
+++ b/app/main/helpers/direct_award_helpers.py
@@ -1,5 +1,6 @@
-from app import data_api_client
 from operator import itemgetter
+
+from app import data_api_client
 
 
 def is_direct_award_project_accessible(project, user_id):

--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -1,9 +1,9 @@
-import re
 from math import ceil
+import re
 
+from flask import url_for
 from werkzeug.datastructures import MultiDict
 from werkzeug.urls import Href
-from flask import url_for
 
 
 def get_valid_lot_from_args_or_none(args, all_lots):

--- a/app/main/helpers/search_save_helpers.py
+++ b/app/main/helpers/search_save_helpers.py
@@ -1,15 +1,13 @@
-from werkzeug.datastructures import MultiDict
 from flask import url_for
-
-from app.main.helpers.framework_helpers import get_lots_by_slug
-
-from app.main.presenters.search_presenters import filters_for_lot
-from app.main.presenters.search_summary import SearchSummary
-from app.main.helpers.search_helpers import clean_request_args
-from ..helpers.shared_helpers import construct_url_from_base_and_params
+from werkzeug.datastructures import MultiDict
 
 from app import search_api_client, content_loader
+from app.main.helpers.framework_helpers import get_lots_by_slug
+from app.main.helpers.search_helpers import clean_request_args
+from app.main.presenters.search_presenters import filters_for_lot
+from app.main.presenters.search_summary import SearchSummary
 from .search_helpers import ungroup_request_filters
+from ..helpers.shared_helpers import construct_url_from_base_and_params
 
 
 class SearchMeta(object):

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 from werkzeug.datastructures import MultiDict
 
+from app import search_api_client
 from ..helpers.framework_helpers import get_lots_by_slug
 from ..helpers.search_helpers import (
     get_filters_from_request,
@@ -11,8 +12,6 @@ from ..helpers.search_helpers import (
     clean_request_args
 )
 from ..presenters.search_results import AggregationResults
-
-from app import search_api_client
 
 
 def sections_for_lot(lot, builder, all_lots=[]):

--- a/app/main/presenters/search_summary.py
+++ b/app/main/presenters/search_summary.py
@@ -1,9 +1,9 @@
-from lxml.html import document_fromstring
+from collections import defaultdict
 import os
 import yaml
-from collections import defaultdict
 
 from flask import Markup, escape
+from lxml.html import document_fromstring
 
 
 class SearchSummary(object):

--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -1,17 +1,10 @@
 import os
 import re
+from urllib.parse import unquote, urlparse
 
 from app import content_loader
 from dmcontent.errors import ContentNotFoundError
 from dmcontent.formats import format_service_price
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
-try:
-    from urllib import unquote
-except ImportError:
-    from urllib.parse import unquote
 
 
 def chunk_string(string, chunk_length):

--- a/app/main/views/crown_hosting.py
+++ b/app/main/views/crown_hosting.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from flask import render_template, redirect
 from ...main import main
 

--- a/app/main/views/crown_hosting.py
+++ b/app/main/views/crown_hosting.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask import render_template, redirect
+
 from ...main import main
 
 

--- a/app/main/views/digital_services_framework.py
+++ b/app/main/views/digital_services_framework.py
@@ -1,4 +1,5 @@
 from flask import abort
+
 from ...main import main
 
 

--- a/app/main/views/feedback.py
+++ b/app/main/views/feedback.py
@@ -1,9 +1,8 @@
 import requests
 
+from flask import current_app, request, redirect, flash, Markup
 from werkzeug.datastructures import MultiDict
 from werkzeug.urls import url_parse
-
-from flask import current_app, request, redirect, flash, Markup
 
 from .. import main
 

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import datetime
 from flask import abort, render_template, request, redirect, current_app, url_for, flash, Markup
 from flask_login import current_user

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -1,19 +1,34 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
+import inflection
+from operator import itemgetter
+
 from flask import abort, render_template, request, redirect, current_app, url_for, flash, Markup
 from flask_login import current_user
-import inflection
 from werkzeug.urls import Href, url_encode, url_decode
 
+from dmapiclient import HTTPError
 from dmcontent.formats import format_service_price
 from dmcontent.questions import Pricing
-
-from dmutils.ods import A as AnchorElement
 from dmutils.formats import dateformat, DATETIME_FORMAT, datetimeformat
 from dmutils.filters import capitalize_first
+from dmutils.ods import A as AnchorElement
 from dmutils.views import SimpleDownloadFileView
-from dmapiclient import HTTPError
 
+from app import search_api_client, data_api_client, content_loader
+from ..exceptions import AuthException
+from ..forms.direct_award_forms import CreateProjectForm
+from ..helpers.search_helpers import (
+    get_keywords_from_request, pagination,
+    get_page_from_request, query_args_for_pagination,
+    get_valid_lot_from_args_or_none,
+    build_search_query,
+    clean_request_args, get_request_url_without_any_filters,
+)
+from ..helpers import framework_helpers
+from ..helpers.direct_award_helpers import is_direct_award_project_accessible, get_direct_award_projects
+from ..helpers.search_save_helpers import SearchMeta
+from ..helpers.shared_helpers import get_fields_from_manifest, get_questions_from_manifest_by_id
 from ...main import main, direct_award
 from ..presenters.search_presenters import (
     filters_for_lot,
@@ -23,23 +38,6 @@ from ..presenters.search_presenters import (
 from ..presenters.search_results import SearchResults
 from ..presenters.search_summary import SearchSummary
 from ..presenters.service_presenters import Service
-from ..helpers.search_helpers import (
-    get_keywords_from_request, pagination,
-    get_page_from_request, query_args_for_pagination,
-    get_valid_lot_from_args_or_none,
-    build_search_query,
-    clean_request_args, get_request_url_without_any_filters,
-)
-from ..helpers import framework_helpers
-from ..helpers.search_save_helpers import SearchMeta
-from ..helpers.shared_helpers import get_fields_from_manifest, get_questions_from_manifest_by_id
-from ..forms.direct_award_forms import CreateProjectForm
-from operator import itemgetter
-
-from ..helpers.direct_award_helpers import is_direct_award_project_accessible, get_direct_award_projects
-
-from ..exceptions import AuthException
-from app import search_api_client, data_api_client, content_loader
 
 
 END_SEARCH_LIMIT = 100  # TODO: This should be done in the API.

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from urllib.parse import urljoin
 
 from flask_login import current_user

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -4,7 +4,6 @@ from urllib.parse import urljoin
 from flask_login import current_user
 from flask import abort, current_app, render_template, request, url_for
 from lxml import html
-
 from werkzeug.urls import Href
 from werkzeug.datastructures import MultiDict
 
@@ -12,22 +11,21 @@ from dmapiclient import APIError
 from dmcontent.content_loader import ContentNotFoundError
 from dmutils.filters import capitalize_first
 
-from ...main import main
-from ..helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference
+from app import search_api_client, data_api_client, content_loader
 from ..helpers.brief_helpers import (
     count_brief_responses_by_size_and_status, format_winning_supplier_size,
     COMPLETED_BRIEF_RESPONSE_STATUSES, ALL_BRIEF_RESPONSE_STATUSES, PUBLISHED_BRIEF_STATUSES
 )
+from ..helpers.framework_helpers import get_latest_live_framework, get_framework_description, get_lots_by_slug
 from ..helpers.search_helpers import (
     pagination, get_page_from_request, query_args_for_pagination, get_valid_lot_from_args_or_none, build_search_query,
     clean_request_args, get_request_url_without_any_filters,
 )
+from ..helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference
+from ...main import main
 from ..presenters.search_presenters import filters_for_lot, set_filter_states, build_lots_and_categories_link_tree
 from ..presenters.search_results import SearchResults
 from ..presenters.search_summary import SearchSummary
-from ..helpers.framework_helpers import get_latest_live_framework, get_framework_description, get_lots_by_slug
-
-from app import search_api_client, data_api_client, content_loader
 
 
 @main.route('/')

--- a/app/main/views/suppliers.py
+++ b/app/main/views/suppliers.py
@@ -1,12 +1,15 @@
 # coding=utf-8
+import re
 from string import ascii_uppercase
-from app.main import main
+
 from flask import render_template, request, abort
-from app import data_api_client
+
 from dmapiclient import APIError
+
+from app import data_api_client
+from app.main import main
 from ..helpers.shared_helpers import parse_link
 from ..helpers.framework_helpers import get_framework_description
-import re
 
 
 def process_prefix(prefix=None, format='view'):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,8 @@
 from flask import Blueprint
-from dmutils.user import User
 from flask_login import login_user
+
+from dmutils.user import User
+
 
 login_for_tests = Blueprint('login_for_tests', __name__)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 import json
 import re

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,15 +1,15 @@
-import os
-import json
-import re
-import mock
-
-from app import create_app, data_api_client
-from tests import login_for_tests
 from datetime import datetime, timedelta
-from mock import patch
+import os
+import re
+
+import json
+import mock
 from werkzeug.http import parse_cookie
 
 from dmutils.formats import DATETIME_FORMAT
+
+from app import create_app, data_api_client
+from tests import login_for_tests
 
 
 class BaseApplicationTest(object):
@@ -214,11 +214,11 @@ class BaseApplicationTest(object):
             self.get_user_patch.stop()
 
     def login_as_supplier(self):
-        with patch('app.data_api_client') as login_api_client:
+        with mock.patch('app.data_api_client') as login_api_client:
             login_api_client.authenticate_user.return_value = self.user(
                 123, "email@email.com", 1234, u'Supplier NĀme', u'Năme')
 
-            self.get_user_patch = patch.object(
+            self.get_user_patch = mock.patch.object(
                 data_api_client,
                 'get_user',
                 return_value=self.user(123, "email@email.com", 1234, u'Supplier NĀme', u'Năme')
@@ -229,11 +229,11 @@ class BaseApplicationTest(object):
             assert response.status_code == 200
 
     def login_as_buyer(self, user_id=123):
-        with patch('app.data_api_client') as login_api_client:
+        with mock.patch('app.data_api_client') as login_api_client:
             login_api_client.authenticate_user.return_value = self.user(
                 user_id, "buyer@email.com", None, None, 'Ā Buyer', role='buyer')
 
-            self.get_user_patch = patch.object(
+            self.get_user_patch = mock.patch.object(
                 data_api_client,
                 'get_user',
                 return_value=self.user(user_id, "buyer@email.com", None, None, 'Buyer', role='buyer')
@@ -244,11 +244,11 @@ class BaseApplicationTest(object):
             assert response.status_code == 200
 
     def login_as_admin(self):
-        with patch('app.main.views.login.data_api_client') as login_api_client:
+        with mock.patch('app.main.views.login.data_api_client') as login_api_client:
             login_api_client.authenticate_user.return_value = self.user(
                 123, "admin@email.com", None, None, 'Name', role='admin')
 
-            self.get_user_patch = patch.object(
+            self.get_user_patch = mock.patch.object(
                 data_api_client,
                 'get_user',
                 return_value=self.user(123, "admin@email.com", None, None, 'Some Admin', role='admin')

--- a/tests/main/helpers/test_framework_helpers.py
+++ b/tests/main/helpers/test_framework_helpers.py
@@ -1,5 +1,5 @@
-from app.main.helpers import framework_helpers
 from app import data_api_client
+from app.main.helpers import framework_helpers
 
 from ...helpers import BaseApplicationTest
 

--- a/tests/main/helpers/test_search_helpers.py
+++ b/tests/main/helpers/test_search_helpers.py
@@ -2,8 +2,8 @@ import mock
 import pytest
 from werkzeug.datastructures import MultiDict
 
-from ...helpers import BaseApplicationTest
 from app.main.helpers import search_helpers, framework_helpers
+from ...helpers import BaseApplicationTest
 
 
 def test_should_hide_both_next_and_prev_if_no_services():

--- a/tests/main/helpers/test_shared_helpers.py
+++ b/tests/main/helpers/test_shared_helpers.py
@@ -1,4 +1,5 @@
 import pytest
+
 from app.main.helpers.shared_helpers import construct_url_from_base_and_params
 
 

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -1,18 +1,19 @@
-import os
-import json
 import itertools
+import json
+import os
+
+import flask
 import mock
-from dmcontent.content_loader import ContentLoader
 from werkzeug.datastructures import MultiDict
 from werkzeug.urls import Href
-import flask
+
+from dmcontent.content_loader import ContentLoader
 
 from app.main.presenters.search_presenters import (
     filters_for_lot,
     set_filter_states,
     build_lots_and_categories_link_tree,
 )
-
 from ...helpers import BaseApplicationTest
 
 content_loader = ContentLoader('tests/fixtures/content')

--- a/tests/main/presenters/test_search_results.py
+++ b/tests/main/presenters/test_search_results.py
@@ -1,11 +1,11 @@
-import os
 import json
+import os
 
 from flask import Markup
-from app.main.presenters.search_results import SearchResults
 
-from ...helpers import BaseApplicationTest
 from app.main.helpers import framework_helpers
+from app.main.presenters.search_results import SearchResults
+from ...helpers import BaseApplicationTest
 
 
 def _get_fixture_data():

--- a/tests/main/presenters/test_search_summary.py
+++ b/tests/main/presenters/test_search_summary.py
@@ -1,14 +1,15 @@
-import os
 import json
+import os
 
 from flask import Markup
 from mock import Mock
 from werkzeug.datastructures import MultiDict
+
+from app import content_loader
 from app.main.presenters.search_presenters import filters_for_lot
 from app.main.presenters.search_results import SearchResults
 from app.main.presenters.search_summary import SearchSummary, \
     SummaryRules, SummaryFragment
-from app import content_loader
 from app.main.helpers import framework_helpers
 from ...helpers import BaseApplicationTest
 

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -1,13 +1,14 @@
-import json
 import os
+import json
+
+import pytest
+
+from app import content_loader
+from app.main.helpers import framework_helpers
 from app.main.presenters.service_presenters import (
     Service, Meta,
     chunk_string
 )
-import pytest
-from app import content_loader
-from app.main.helpers import framework_helpers
-
 from ...helpers import BaseApplicationTest
 
 

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -1,14 +1,16 @@
-from flask import Markup
-from lxml import html
-from html import escape as html_escape
-import mock
-import pytest
+from dateutil import parser
 import sys
 from urllib.parse import quote_plus, urlparse
+
+from flask import Markup
+from html import escape as html_escape
+from lxml import html
+import mock
+import pytest
 from werkzeug.exceptions import BadRequest, NotFound
-from dateutil import parser
 
 from dmcontent.content_loader import ContentLoader
+
 from app import data_api_client, search_api_client, content_loader
 from app.main.views.g_cloud import DownloadResultsView
 from ...helpers import BaseApplicationTest

--- a/tests/main/views/test_errors.py
+++ b/tests/main/views/test_errors.py
@@ -1,7 +1,8 @@
 # coding=utf-8
-
 import mock
+
 from dmapiclient import HTTPError
+
 from ...helpers import BaseApplicationTest
 
 

--- a/tests/main/views/test_feedback.py
+++ b/tests/main/views/test_feedback.py
@@ -1,6 +1,6 @@
 from lxml import html
-
 import mock
+
 from ...helpers import BaseApplicationTest
 
 

--- a/tests/main/views/test_g_cloud.py
+++ b/tests/main/views/test_g_cloud.py
@@ -1,4 +1,5 @@
 import mock
+
 from ...helpers import BaseApplicationTest
 
 

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1,13 +1,14 @@
 # coding=utf-8
-
 import json
-from flask import current_app
-import mock
-from urllib.parse import urlparse, parse_qs
-from lxml import html
 import re
-from ...helpers import BaseApplicationTest
+from urllib.parse import urlparse, parse_qs
+
+from flask import current_app
+from lxml import html
+import mock
 import pytest
+
+from ...helpers import BaseApplicationTest
 
 
 class TestApplication(BaseApplicationTest):

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -3,8 +3,7 @@
 import json
 from flask import current_app
 import mock
-from six import iteritems
-from six.moves.urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse, parse_qs
 from lxml import html
 import re
 from ...helpers import BaseApplicationTest
@@ -1160,7 +1159,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self._presenters_search_api_client_patch.stop()
 
     def normalize_qs(self, qs):
-        return {k: set(v) for k, v in iteritems(parse_qs(qs)) if k != "page"}
+        return {k: set(v) for k, v in parse_qs(qs).items() if k != "page"}
 
     def test_catalogue_of_briefs_page(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -1,7 +1,8 @@
-from lxml import html
 import json
-import mock
 import re
+
+from lxml import html
+import mock
 import pytest
 
 from ...helpers import BaseApplicationTest, data_api_client

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -1,11 +1,10 @@
-
-import mock
 import re
+
 from lxml import html
+import mock
 
 from app import data_api_client
 from app.main.helpers import framework_helpers
-
 from ...helpers import BaseApplicationTest
 
 

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -1,7 +1,9 @@
 # coding: utf-8
 import mock
-from ...helpers import BaseApplicationTest
+
 from dmapiclient import APIError
+
+from ...helpers import BaseApplicationTest
 
 
 class TestSuppliersPage(BaseApplicationTest):

--- a/tests/status/views/test_status.py
+++ b/tests/status/views/test_status.py
@@ -1,7 +1,8 @@
 import json
-from ...helpers import BaseApplicationTest
 
 import mock
+
+from ...helpers import BaseApplicationTest
 
 
 class TestStatus(BaseApplicationTest):


### PR DESCRIPTION
For this ticket: https://trello.com/c/2UzWy7qK/4-404-page-on-assets-has-header-links-that-are-broken

Our router app proxies errors (e.g. on an assets domain) to the frontend app's /404 page (i.e. the new route added here).  

Relative links in our normal 404 page will not work if the domain doesn't match, so adding a new page at /404 where we ensure all links in the page are absolute.

**NOTE TO REVIEWER(S)**: The first commit is the only thing with new features.  The rest of the changes here are sorting out imports across the app a bit.