### PR TITLE
Set custom config var for absolute URLs on /404 page

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -96,7 +96,7 @@ def external_404():
     document = html.fromstring(render_template('errors/404.html'))
     relative_links = document.xpath('//a[starts-with(@href, "/")]')
     for link in relative_links:
-        link.set("href", urljoin(request.url_root, link.get("href")))
+        link.set("href", urljoin(current_app.config.get("DM_PATCH_FRONTEND_URL", ""), link.get("href")))
 
     return html.tostring(document), 404
 

--- a/config.py
+++ b/config.py
@@ -27,6 +27,9 @@ class Config(object):
     DM_SEARCH_API_AUTH_TOKEN = None
     DM_MANDRILL_API_KEY = None
 
+    # Used for generating absolute URLs from relative URLs when necessary
+    DM_PATCH_FRONTEND_URL = 'http://localhost/'
+
     # matches api(s)
     DM_SEARCH_PAGE_SIZE = 100
 
@@ -141,16 +144,19 @@ class Live(Config):
 class Preview(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-06')
     FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = enabled_since('2017-08-31')
+    DM_PATCH_FRONTEND_URL = 'https://www.preview.marketplace.team/'
 
 
 class Staging(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-07')
     FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = enabled_since('2017-10-25')
+    DM_PATCH_FRONTEND_URL = 'https://www.staging.marketplace.team/'
 
 
 class Production(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-08')
     FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = enabled_since('2017-10-26')
+    DM_PATCH_FRONTEND_URL = 'https://www.digitalmarketplace.service.gov.uk/'
 
 
 configs = {


### PR DESCRIPTION
Second attempt at this ticket: https://trello.com/c/2UzWy7qK/4-404-page-on-assets-has-header-links-that-are-broken

Using the `request.url_root` to generate absolute URLs doesn't work because the proxied requests for the /404 page have `assets.digitalmarketplace` as the request URL.

By adding a custom config variable to let the app know which URL links should be relative to means we can patch this in for requests that come in from a different domain (e.g. for the custom 404 page).

**NOTE TO REVIEWER**: both the naming of the new variable, and whether this is in any way a sane approach or not, is up for debate here.

I should also mention that I've deliberately avoided using Flask's `SERVER_NAME` config for this, as (I strongly suspect) it has more far-reaching consequences than we want or need for the current issue.