### PR TITLE
Add Google verification meta tag

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -3,6 +3,7 @@
 {% block head %} 
   {% block custom_meta %}{% endblock %}
   {% include "_stylesheets.html" %}
+  {% include "_site_verification.html" %}
 {% endblock %}
 
 {% block cookie_message %}

--- a/app/templates/_site_verification.html
+++ b/app/templates/_site_verification.html
@@ -1,0 +1,3 @@
+{% if config.GOOGLE_SITE_VERIFICATION %}
+    <meta name="google-site-verification" content="{{ config.GOOGLE_SITE_VERIFICATION }}" />
+{% endif %}

--- a/config.py
+++ b/config.py
@@ -86,6 +86,8 @@ class Config(object):
         }
     }
 
+    GOOGLE_SITE_VERIFICATION = None
+
     @staticmethod
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
@@ -114,6 +116,8 @@ class Test(Config):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
     FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = enabled_since('2017-08-15')
 
+    GOOGLE_SITE_VERIFICATION = "NotARealVerificationKey"
+
 
 class Development(Config):
     DEBUG = True
@@ -132,6 +136,8 @@ class Development(Config):
 
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
     FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = enabled_since('2017-08-15')
+
+    GOOGLE_SITE_VERIFICATION = "NotARealVerificationKey"
 
 
 class Live(Config):
@@ -157,6 +163,8 @@ class Production(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-08')
     FEATURE_FLAGS_DIRECT_AWARD_PROJECTS = enabled_since('2017-10-26')
     DM_PATCH_FRONTEND_URL = 'https://www.digitalmarketplace.service.gov.uk/'
+
+    GOOGLE_SITE_VERIFICATION = "TKGSGZnfHpx1-lKOthI17ANtwk7fz3F4Sbr77I0ppO0"
 
 
 configs = {

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -26,6 +26,11 @@ class TestApplication(BaseApplicationTest):
         assert '<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">' \
             'Find out more about cookies</a></p>' in res.get_data(as_text=True)
 
+    def test_google_verification_code_shown_on_homepage(self):
+        res = self.client.get('/')
+        assert res.status_code == 200
+        assert 'name="google-site-verification" content="NotARealVerificationKey"' in res.get_data(as_text=True)
+
 
 @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
 class TestHomepageAccountCreationVirtualPageViews(BaseApplicationTest):


### PR DESCRIPTION
https://trello.com/c/vFVv5Rye/192-add-a-google-site-verification-tag-for-ash

We need to display the meta tag on the home page, for production only.

I've included a fake key on the Test config so we can at least have a unit test for it (as UATing on preview/staging will be tricky!). I put one in for the Dev config too, it's probably not 100% necessary but I thought it might be useful for any devs working on this in future - happy to take out if people agree it's not required? 