### PR TITLE
search pages: use better aria-relevant value for increased compatibility and reduced weirdness across screen readers

### DIFF
--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -70,7 +70,7 @@
       instead, we have this dedicated (and more importantly, persistent) wrapper
       element, which itself can be the target of `aria-controls=`
     #}
-    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="all">
+    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="additions text">
       {% include 'search/_summary_accessible_hint.html' %}
     </div>
     {% include 'search/_summary.html' %}

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -59,7 +59,7 @@
       instead, we have this dedicated (and more importantly, persistent) wrapper
       element, which itself can be the target of `aria-controls=`
     #}
-    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="all">
+    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="additions text">
       {% include 'search/_summary_accessible_hint.html' %}
     </div>
     {% include 'search/_summary.html' %}


### PR DESCRIPTION
Trello https://trello.com/c/qUViIfu9/172-dynamic-content-on-the-search-pages-which-updates-without-a-page-reload-is-marked-up-using-wai-aria-live-regions

Works better on Chrome/JAWS and Mac VoiceOver.