### PR TITLE
Also make form actions absolute in /404 page

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -95,8 +95,13 @@ def external_404():
     """
     document = html.fromstring(render_template('errors/404.html'))
     relative_links = document.xpath('//a[starts-with(@href, "/")]')
+    forms_with_relative_actions = document.xpath('//form[starts-with(@action, "/")]')
+
     for link in relative_links:
         link.set("href", urljoin(current_app.config.get("DM_PATCH_FRONTEND_URL", ""), link.get("href")))
+
+    for form in forms_with_relative_actions:
+        form.set("action", urljoin(current_app.config.get("DM_PATCH_FRONTEND_URL", ""), form.get("action")))
 
     return html.tostring(document), 404
 

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -351,20 +351,24 @@ class TestStaticMarketplacePages(BaseApplicationTest):
         assert response1.status_code == 404
         regular_404_document = html.fromstring(response1.get_data(as_text=True))
         regular_relative_links = regular_404_document.xpath('//a[starts-with(@href, "/")]')
-        relative_hrefs = [link.get("href") for link in regular_relative_links]
+        regular_relative_forms = regular_404_document.xpath('//form[starts-with(@action, "/")]')
+        relative_urls = [link.get("href") for link in regular_relative_links] + \
+                        [form.get("action") for form in regular_relative_forms]
 
         # Get the "external" 404 page and check it doesn't contain any relative URLs
         response2 = self.client.get("/404")
         assert response2.status_code == 404
         external_404_document = html.fromstring(response2.get_data(as_text=True))
         external_relative_links = external_404_document.xpath('//a[starts-with(@href, "/")]')
-        assert len(external_relative_links) == 0
+        external_relative_forms = external_404_document.xpath('//form[starts-with(@action, "/")]')
+        assert len(external_relative_links) == len(external_relative_forms) == 0
 
         # Check that there is an absolute URL in the external 404 page for every relative URL in the normal 404 page
         external_links = external_404_document.xpath('//a')
-        external_hrefs = [link.get("href") for link in external_links]
-        for relative_href in relative_hrefs:
-            assert "http://localhost{}".format(relative_href) in external_hrefs
+        external_forms = external_404_document.xpath('//form')
+        external_urls = [link.get("href") for link in external_links] + [form.get("action") for form in external_forms]
+        for relative_url in relative_urls:
+            assert "http://localhost{}".format(relative_url) in external_urls
 
 
 class BaseBriefPageTest(BaseApplicationTest):


### PR DESCRIPTION
Final fix for this ticket: https://trello.com/c/2UzWy7qK/4-404-page-on-assets-has-header-links-that-are-broken

The feedback form action `/feedback` also needs to be made absolute for it to work properly when this page is proxied from a domain other than the main frontend domain.