### PR TITLE
search results: slightly modify the style & content of listed results

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -125,6 +125,7 @@
 
 .search-result-important-metadata {
   li {
-    @include bold-19;
+    @include bold-16;
+    color: $black;
   }
 }

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -34,7 +34,7 @@
                 Published: {{ brief.publishedAt|dateformat }}
             </li>
             <li class="search-result-metadata-item">
-                Closing date for questions: {{ brief.clarificationQuestionsClosedAt|dateformat }}
+                Deadline for asking questions: {{ brief.clarificationQuestionsClosedAt|dateformat }}
             </li>
             <li class="search-result-metadata-item">
                 Closing: {{ brief.applicationsClosedAt|dateformat }}

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -14,11 +14,11 @@
     </ul>
 
     <ul class="search-result-metadata">
-        <li class="search-result-metadata-item">
+        <li class="search-result-metadata-item-inline">
             {{ brief.lot.name }}
         </li>
         {% if 'specialistRole' in brief %}
-        <li class="search-result-metadata-item">
+        <li class="search-result-metadata-item-inline">
             {{ brief.specialistRole | capitalize() }}
         </li>
         {% endif %}
@@ -32,6 +32,9 @@
         {% else %}
             <li class="search-result-metadata-item">
                 Published: {{ brief.publishedAt|dateformat }}
+            </li>
+            <li class="search-result-metadata-item">
+                Closing date for questions: {{ brief.clarificationQuestionsClosedAt|dateformat }}
             </li>
             <li class="search-result-metadata-item">
                 Closing: {{ brief.applicationsClosedAt|dateformat }}

--- a/app/templates/search/_services_results.html
+++ b/app/templates/search/_services_results.html
@@ -12,10 +12,10 @@
         {{ service.serviceSummary or service.serviceDescription }} {# G-Cloud 9 uses serviceDescription, not serviceSummary. #}
     </p>
     <ul aria-label="tags" class="search-result-metadata">
-        <li class="search-result-metadata-item">
+        <li class="search-result-metadata-item-inline">
             {{ service.lot.name }}
         </li>
-        <li class="search-result-metadata-item">
+        <li class="search-result-metadata-item-inline">
             {{ service.frameworkName }}
         </li>
     </ul>

--- a/tests/fixtures/dos_brief_search_api_response.json
+++ b/tests/fixtures/dos_brief_search_api_response.json
@@ -2,6 +2,7 @@
   "documents": [
     {
       "applicationsClosedAt": "2017-12-01T23:59:59.000000Z",
+      "clarificationQuestionsClosedAt": "2017-11-26T23:59:59.000000Z",
       "highlight": {
         "applicationsClosedAt": ["2017-12-01T23:59:59.000000Z"],
         "id": ["5731"],
@@ -24,6 +25,7 @@
     },
     {
       "applicationsClosedAt": "2016-05-13T23:59:59.000000Z",
+      "clarificationQuestionsClosedAt": "2016-05-10T23:59:59.000000Z",
       "highlight": {
         "applicationsClosedAt": ["2016-05-13T23:59:59.000000Z"],
         "id": ["48"],
@@ -48,6 +50,7 @@
     },
     {
       "applicationsClosedAt": "2016-11-09T23:59:59.000000Z",
+      "clarificationQuestionsClosedAt": "2016-11-05T23:59:59.000000Z",
       "highlight": {
         "applicationsClosedAt": ["2016-11-09T23:59:59.000000Z"],
         "id": ["1183"],
@@ -73,6 +76,7 @@
     {
       "applicationsClosedAt": "2016-06-29T23:59:59.000000Z",
       "cancelledAt": "2017-10-05T10:34:09.783235Z",
+      "clarificationQuestionsClosedAt": "2016-06-23T23:59:59.000000Z",
       "highlight": {
         "applicationsClosedAt": ["2016-06-29T23:59:59.000000Z"],
         "cancelledAt": ["2017-10-05T10:34:09.783235Z"],
@@ -98,6 +102,7 @@
     },
     {
       "applicationsClosedAt": "2017-12-01T23:59:59.000000Z",
+      "clarificationQuestionsClosedAt": "2017-11-28T23:59:59.000000Z",
       "highlight": {
         "applicationsClosedAt": ["2017-12-01T23:59:59.000000Z"],
         "id": ["5731"],
@@ -120,6 +125,7 @@
     },
     {
       "applicationsClosedAt": "2017-03-13T23:59:59.000000Z",
+      "clarificationQuestionsClosedAt": "2017-03-10T23:59:59.000000Z",
       "awardedBriefResponseId": 33846,
       "highlight": {
         "applicationsClosedAt": ["2017-03-13T23:59:59.000000Z"],

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1473,7 +1473,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         live_opportunity_qs_closing_at = document.xpath(
             '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'
         )[-2].text_content().strip()
-        assert live_opportunity_qs_closing_at == "Closing date for questions: Sunday 26 November 2017"
+        assert live_opportunity_qs_closing_at == "Deadline for asking questions: Sunday 26 November 2017"
 
         live_opportunity_closing_at = document.xpath(
             '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1467,8 +1467,13 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
 
         live_opportunity_published_at = document.xpath(
             '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'
-        )[-2].text_content().strip()
+        )[-3].text_content().strip()
         assert live_opportunity_published_at == "Published: Friday 17 November 2017"
+
+        live_opportunity_qs_closing_at = document.xpath(
+            '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'
+        )[-2].text_content().strip()
+        assert live_opportunity_qs_closing_at == "Closing date for questions: Sunday 26 November 2017"
 
         live_opportunity_closing_at = document.xpath(
             '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'


### PR DESCRIPTION
Trello https://trello.com/c/Ng8G6f9K/294-suppliers-can-view-date-questions-close-on-dos-search-page

Bringing in a new frontend-toolkit version (https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/403), use a mixture of `.search-result-metadata-item` and `.search-result-metadata-item-inline` to show information. Add `clarificationQuestionsClosedAt` field to listed briefs.
Brief search:
![20180209_brief_search_result](https://user-images.githubusercontent.com/807447/36034434-0025e2a4-0dac-11e8-8125-93eac6f0a7a4.png)
Service search:
![20180209_service_search_result](https://user-images.githubusercontent.com/807447/36034447-066fcefe-0dac-11e8-8836-baafb64ae32f.png)

 Note this also depends upon an updates briefs search-api mapping to return `clarificationQuestionsClosedAt` at all. PRs: https://github.com/alphagov/digitalmarketplace-frameworks/pull/495 https://github.com/alphagov/digitalmarketplace-search-api/pull/138. Also I may still be making some style tweaks based on jeremy's feedback.

