### PR TITLE
Update Dockerfile to use v3.1.1, which pins top-level dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:3.1.0
+FROM digitalmarketplace/base-frontend:3.1.1


### PR DESCRIPTION
## Ticket
https://trello.com/c/Y6H3QWlM/315-uwsgi-version-should-be-pinned