### PR TITLE
Briefs text search

### DIFF
--- a/app/main/presenters/search_results.py
+++ b/app/main/presenters/search_results.py
@@ -4,9 +4,10 @@ from flask import Markup
 class SearchResults(object):
     """Provides access to the search results information"""
 
-    def __init__(self, response, lots_by_slug):
+    def __init__(self, response, lots_by_slug, highlight_fields=frozenset()):
         self.search_results = response['documents']
         self._lots = lots_by_slug
+        self._highlight_fields = highlight_fields
         self._annotate()
         self.total = response['meta']['total']
         if 'page' in response['meta']['query']:
@@ -23,7 +24,7 @@ class SearchResults(object):
 
     def _add_highlighting(self, document):
         if 'highlight' in document:
-            for highlighted_field in ['serviceSummary', 'serviceDescription']:
+            for highlighted_field in self._highlight_fields:
                 if highlighted_field in document['highlight']:
                     document[highlighted_field] = Markup(
                         ''.join(document['highlight'][highlighted_field])

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -202,7 +202,14 @@ def search_services():
         doc_type=doc_type,
         **build_search_query(clean_request_query_params, filters.values(), content_manifest, lots_by_slug)
     )
-    search_results_obj = SearchResults(search_api_response, lots_by_slug)
+    search_results_obj = SearchResults(
+        search_api_response,
+        lots_by_slug,
+        highlight_fields=frozenset((
+            'serviceSummary',
+            'serviceDescription',
+        )),
+    )
 
     # the search api doesn't supply its own pagination information: use this `pagination` function to figure out what
     # links to show

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 import inflection
 from operator import itemgetter
+from itertools import chain
 
 from flask import abort, render_template, request, redirect, current_app, url_for, flash, Markup
 from flask_login import current_user
@@ -244,10 +245,17 @@ def search_services():
         Href(url_for('.{}'.format(view_name))),
     )
 
-    # Filter form should also filter by lot, and by category, when any of those are selected.
-    # (If a sub-category is selected, we also need the parent category id, so that the correct part
-    # of the category tree is displayed when the sub-category appears under multiple parents.)
-    filter_form_hidden_fields_by_name = {f['name']: f for f in selected_category_tree_filters[1:]}
+    filter_form_hidden_fields_by_name = {
+        f["name"]: f
+        for f in chain(
+            # Filter form should also filter by lot, and by category, when any of those are selected.
+            # (If a sub-category is selected, we also need the parent category id, so that the correct part
+            # of the category tree is displayed when the sub-category appears under multiple parents.)
+            selected_category_tree_filters[1:],
+            # add "doc_type" to query string for analytics disambiguation
+            ({"name": "doc_type", "value": doc_type},),
+        )
+    }
 
     current_lot = lots_by_slug.get(current_lot_slug)
 

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from urllib.parse import urljoin
+from itertools import chain
 
 from flask_login import current_user
 from flask import abort, current_app, render_template, request, url_for
@@ -253,7 +254,14 @@ def list_opportunities(framework_family):
         Href(url_for('.{}'.format(view_name), framework_family=framework['framework'])),
     )
 
-    filter_form_hidden_fields_by_name = {f['name']: f for f in selected_category_tree_filters[1:]}
+    filter_form_hidden_fields_by_name = {
+        f["name"]: f
+        for f in chain(
+            selected_category_tree_filters[1:],
+            # add "doc_type" to query string for analytics disambiguation
+            ({"name": "doc_type", "value": doc_type},),
+        )
+    }
     current_lot = lots_by_slug.get(current_lot_slug)
 
     set_filter_states(filters.values(), request)

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -18,8 +18,14 @@ from ..helpers.brief_helpers import (
 )
 from ..helpers.framework_helpers import get_latest_live_framework, get_framework_description, get_lots_by_slug
 from ..helpers.search_helpers import (
-    pagination, get_page_from_request, query_args_for_pagination, get_valid_lot_from_args_or_none, build_search_query,
-    clean_request_args, get_request_url_without_any_filters,
+    build_search_query,
+    clean_request_args,
+    get_keywords_from_request,
+    get_page_from_request,
+    get_request_url_without_any_filters,
+    get_valid_lot_from_args_or_none,
+    pagination,
+    query_args_for_pagination,
 )
 from ..helpers.shared_helpers import get_one_framework_by_status_in_order_of_preference
 from ...main import main
@@ -275,6 +281,7 @@ def list_opportunities(framework_family):
         framework_family_name='Digital Outcomes and Specialists',
         lot_names=tuple(lot['name'] for lot in lots_by_slug.values() if lot['allowsBrief']),
         pagination=pagination_config,
+        search_keywords=get_keywords_from_request(request),
         search_query=search_query,
         summary=search_summary.markup(),
         total=search_results_obj.total,

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -210,7 +210,13 @@ def list_opportunities(framework_family):
             brief['specialistRole'] = content.summary(brief).get_question('specialistRole').value
         brief['location'] = content.summary(brief).get_question('location').value
 
-    search_results_obj = SearchResults(search_api_response, lots_by_slug)
+    search_results_obj = SearchResults(
+        search_api_response,
+        lots_by_slug,
+        highlight_fields=frozenset((
+            'summary',
+        )),
+    )
 
     pagination_config = pagination(
         search_results_obj.total,

--- a/app/templates/search/_filters_and_categories_wrapper.html
+++ b/app/templates/search/_filters_and_categories_wrapper.html
@@ -1,14 +1,12 @@
-{% if framework_family == 'g-cloud' %}
-  {%
-    with
-    id = "keywords",
-    name = "q",
-    label = "Keyword search",
-    value = search_keywords
-  %}
-    {% include "toolkit/forms/keyword-search.html" %}
-  {% endwith %}
-{%endif%}
+{%
+  with
+  id = "keywords",
+  name = "q",
+  label = "Keyword search",
+  value = search_keywords
+%}
+  {% include "toolkit/forms/keyword-search.html" %}
+{% endwith %}
 
 {% include 'search/_categories_wrapper.html' %}
 

--- a/tests/main/presenters/test_search_results.py
+++ b/tests/main/presenters/test_search_results.py
@@ -73,8 +73,24 @@ class TestSearchResults(BaseApplicationTest):
         assert hasattr(search_results_instance, 'page')
         assert search_results_instance.page == "20"
 
+    def test_no_highlighting_if_no_fields_specified(self):
+        search_results_instance = SearchResults(
+            self.fixture,
+            self._lots_by_slug,
+        )
+        result_with_no_highlight = self._get_service_result_by_id(
+            search_results_instance.search_results, '4-G4-0871-001'
+        )
+        assert result_with_no_highlight['serviceSummary'].startswith(
+            u"Fastly CDN (Content Delivery Network) speeds up delivery of your website and its content to your users"
+        )
+
     def test_highlighting_for_one_line_summary(self):
-        search_results_instance = SearchResults(self.fixture, self._lots_by_slug)
+        search_results_instance = SearchResults(
+            self.fixture,
+            self._lots_by_slug,
+            highlight_fields=frozenset(("serviceSummary",)),
+        )
         result_with_one_line_highlight = self._get_service_result_by_id(
             search_results_instance.search_results, '4-G4-0871-001'
         )
@@ -83,7 +99,11 @@ class TestSearchResults(BaseApplicationTest):
         )
 
     def test_highlighting_for_multiple_line_summary(self):
-        search_results_instance = SearchResults(self.fixture, self._lots_by_slug)
+        search_results_instance = SearchResults(
+            self.fixture,
+            self._lots_by_slug,
+            highlight_fields=frozenset(("serviceSummary", "serviceDescription",)),
+        )
         result_with_multi_line_highlight = self._get_service_result_by_id(
             search_results_instance.search_results, '4-G1-0340-001'
         )

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1617,6 +1617,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
 
         assert kv_pairs == {
             'lot': 'digital-outcomes',
+            'doc_type': 'briefs',
         }
 
 

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -570,7 +570,8 @@ class TestSearchResults(BaseApplicationTest):
         assert kv_pairs == {
             'lot': 'cloud-software',
             'serviceCategories': 'content management system (cms)',
-            'parentCategory': 'electronic document and records management (edrm)'
+            'parentCategory': 'electronic document and records management (edrm)',
+            'doc_type': 'services',
         }
 
 


### PR DESCRIPTION
Again, this is quite straightforward, basically just enabling g-cloud features on brief search. Trello https://trello.com/c/qdNbRJ4e/331-supplier-can-search-for-buyer-on-dos

Depends on https://github.com/alphagov/digitalmarketplace-search-api/pull/141 and https://github.com/alphagov/digitalmarketplace-frameworks/pull/499

![20180226_brief_search](https://user-images.githubusercontent.com/807447/36679253-a95bb39c-1b0a-11e8-8f44-b93e4aa61436.png)

~~~~Yet to address: analytics concerns...~~~~ Now addresses the development aspects of https://trello.com/c/PjxXNmjt/339-instrument-ga-to-capture-free-text-search-queries-submitted-from-the-new-dos-search-filter too.