### PR TITLE
Add link to MISO spend data on the homepage

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -100,6 +100,13 @@
       </div>
     {% endif %}
 
+      <div class="padding-bottom-small">
+        <p>
+          <a href="https://www.gov.uk/government/collections/digital-marketplace-sales" class="top-level-link">
+            See Digital Marketplace sales figures
+          </a>
+        </p>
+      </div>
     </aside>
   </div>
 </div>

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -297,6 +297,7 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
         assert 'View Digital Outcomes and Specialists opportunities' in sidebar_link_texts
         assert 'Become a supplier' in sidebar_link_texts
+        assert 'See Digital Marketplace sales figures' in sidebar_link_texts
 
     @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
     def test_homepage_sidebar_messages_when_logged_in(self, data_api_client):


### PR DESCRIPTION
We would like to make it easier for users to see spend data about the marketplace.

https://trello.com/c/M331O7MN/370-add-link-to-govuk-miso-spend-data-on-dm-homepage

## Before

<img width="273" alt="screen shot 2018-03-07 at 14 25 16" src="https://user-images.githubusercontent.com/3466862/37097544-a04bbc4c-2213-11e8-9ee0-dfdff0ae566d.png">

## After

<img width="287" alt="screen shot 2018-03-08 at 13 52 15" src="https://user-images.githubusercontent.com/3466862/37154458-fff75f56-22d7-11e8-9931-a3c28506f437.png">

