### PR TITLE
Show award status in DOS search results

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -288,6 +288,12 @@ def list_opportunities(framework_family):
         framework_family=framework['framework'],
         framework_family_name='Digital Outcomes and Specialists',
         lot_names=tuple(lot['name'] for lot in lots_by_slug.values() if lot['allowsBrief']),
+        outcome={
+            'awarded': 'awarded',
+            'cancelled': 'cancelled',
+            'closed': 'awaiting outcome',
+            'unsuccessful': 'no suitable suppliers'
+        },
         pagination=pagination_config,
         search_keywords=get_keywords_from_request(request),
         search_query=search_query,

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -27,7 +27,7 @@
     <ul class="search-result-metadata">
         {% if brief.status in ['closed', 'awarded', 'cancelled', 'unsuccessful'] %}
             <li class="search-result-metadata-item">
-                {{ brief.status | capitalize() }}
+                Closed: {{ outcome[brief.status] }}
             </li>
         {% else %}
             <li class="search-result-metadata-item">

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1585,22 +1585,22 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         closed_opportunity_status = document.xpath(
             '//div[@class="search-result"][2]//li[@class="search-result-metadata-item"]'
         )[-1].text_content().strip()
-        assert closed_opportunity_status == "Closed"
+        assert closed_opportunity_status == "Closed: awaiting outcome"
 
         unsuccessful_opportunity_status = document.xpath(
             '//div[@class="search-result"][3]//li[@class="search-result-metadata-item"]'
         )[-1].text_content().strip()
-        assert unsuccessful_opportunity_status == "Unsuccessful"
+        assert unsuccessful_opportunity_status == "Closed: no suitable suppliers"
 
         cancelled_opportunity_status = document.xpath(
             '//div[@class="search-result"][4]//li[@class="search-result-metadata-item"]'
         )[-1].text_content().strip()
-        assert cancelled_opportunity_status == "Cancelled"
+        assert cancelled_opportunity_status == "Closed: cancelled"
 
         awarded_opportunity_status = document.xpath(
             '//div[@class="search-result"][6]//li[@class="search-result-metadata-item"]'
         )[-1].text_content().strip()
-        assert awarded_opportunity_status == "Awarded"
+        assert awarded_opportunity_status == "Closed: awarded"
 
     def test_should_render_summary_for_0_results_in_all_lots(self):
         search_results = self._get_dos_brief_search_api_response_fixture_data()


### PR DESCRIPTION
We now display the status of opportunities in DOS search results with something more accurate than "closed". This should make it more obvious to suppliers what has happened with the brief.

https://trello.com/c/y59qiKOl/335-show-award-status-in-dos-search-results

## Before

<img width="316" alt="screen shot 2018-03-07 at 16 47 35" src="https://user-images.githubusercontent.com/3466862/37105518-49b85c78-2227-11e8-92a8-e346623f3390.png">


## After

<img width="300" alt="screen shot 2018-03-07 at 16 44 28" src="https://user-images.githubusercontent.com/3466862/37105464-2493092a-2227-11e8-806a-62270ab50621.png">

<img width="259" alt="screen shot 2018-03-07 at 16 45 07" src="https://user-images.githubusercontent.com/3466862/37105470-2972683c-2227-11e8-918e-7d55897d8b8a.png">
