### PR TITLE
tracing: bump digitalmarketplace-apiclient dependency to 14.6.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.0#egg=digitalmarketplace-apiclient==14.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.6.0#egg=digitalmarketplace-apiclient==14.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.0.0#egg=digitalmarketplace-apiclient==14.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.6.0#egg=digitalmarketplace-apiclient==14.6.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0


### PR DESCRIPTION
Trello https://trello.com/c/exuNFb7A/357-zipkin-headers-pt2-api-client

This should bring in support for zipkin span ids.