### PR TITLE
fix reference to data_api_client.get_direct_award_project_services_iter to work with digitalmarketplace-apiclient 15.0.0

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -634,9 +634,11 @@ class DownloadResultsView(SimpleDownloadFileView):
         filename = '{}-{}-results'.format(locked_at.strftime('%Y-%m-%d'), inflection.parameterize(project['name']))
         formatted_locked_at = datetimeformat(locked_at)
 
-        services = self.data_api_client.get_direct_award_project_services_iter(project_id=project['id'],
-                                                                               user_id=current_user.id,
-                                                                               fields=required_fields)
+        services = self.data_api_client.find_direct_award_project_services_iter(
+            project_id=project['id'],
+            user_id=current_user.id,
+            fields=required_fields,
+        )
 
         all_services = []
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.6.0#egg=digitalmarketplace-apiclient==14.6.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@14.6.0#egg=digitalmarketplace-apiclient==14.6.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -497,8 +497,8 @@ class TestDirectAwardDownloadResultsView(TestDirectAwardBase):
 
         data_api_client.record_direct_award_project_download = mock.Mock()
 
-        data_api_client.get_direct_award_project_services_iter = mock.Mock()
-        data_api_client.get_direct_award_project_services_iter.return_value = \
+        data_api_client.find_direct_award_project_services_iter = mock.Mock()
+        data_api_client.find_direct_award_project_services_iter.return_value = \
             self._get_direct_award_project_services_fixture()['services']
 
         data_api_client.get_direct_award_project.return_value = self._get_direct_award_lock_project_fixture()


### PR DESCRIPTION
This was originally missed because of a mistake in the apiclient's version bumping

Also uncovered a problem with the mocking of `data_api_client` used in `tests/main/views/test_direct_award.py` which needs fixing but don't have time to now. Tech debt ticket for this: https://trello.com/c/imymWr7B/387-insufficient-mocking-of-dataapiclient-in-buyer-frontend-tests-could-be-dangerous