### PR TITLE
add banner to account page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
+//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/user-research-consent-banner.js
 //= require _analytics.js'
 //= require _onready.js'
 //= require _selection-buttons.js

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -42,6 +42,7 @@ $path: "/static/images/";
 @import "toolkit/_statistics.scss";
 @import "toolkit/_temporary-message.scss";
 @import "toolkit/_report-a-problem.scss";
+@import "toolkit/_user-research-consent-banner.scss";
 @import "toolkit/forms/_dates.scss";
 @import "toolkit/forms/_hint.scss";
 @import "toolkit/forms/_keyword-search.scss";

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -20,6 +20,10 @@
   {% include "toolkit/proposition-header.html" %}
 {% endblock %}
 
+{% block after_header %}
+  {% include "toolkit/user-research-consent-banner.html" %}
+{% endblock %}
+
 {% block content %}
     {% block top_header %}
     {% endblock %}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.2.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.8.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.2.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.5.0#egg=digitalmarketplace-utils==34.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.5.0#egg=digitalmarketplace-utils==34.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#ea0d37c23827bda76cfdab8517f2e665b441c5dc"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.2.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.8.0":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#ba6f1db4f0960feff221f23e0bb0c86b44a1756c"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#0e59c3cf8eec9df06134f3674ff84006d12abe37"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Add the user research banner to the account page using the existing GOV.uk pattern. Allow for links to 'sign up to mailing list' page

As a  user I should be presented with the banner to sign up to the user research mailing list when I log in if: I have not already closed it and I have not already signed up for this.
This is the first point of contact for getting users to sign up to the mailing list.

The close link should set a cookie value of 'seen_this_banner_thing' to true so we don't show it again
The sign up link should link to the new sign up page.

https://trello.com/c/OJ9lFk1M/129-add-banner-to-account-page