### PR TITLE
Use frameworks version 10.8.0

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -195,8 +195,11 @@ def list_opportunities(framework_family):
     doc_type = 'briefs'
     updated_request_args = None
 
-    if 'status' not in clean_request_query_params.keys():
-        updated_request_args = MultiDict([('status', 'live'), ('status', 'closed')])
+    # This will exclude anything with a 'withdrawn' status
+    if 'statusOpenClosed' not in clean_request_query_params.keys():
+        updated_request_args = MultiDict(
+            [('statusOpenClosed', 'open'), ('statusOpenClosed', 'closed')]
+        )
         updated_request_args.update(clean_request_query_params)
 
     search_api_response = search_api_client.search(

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.2.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.2.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.8.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   },
   "scripts": {

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1182,7 +1182,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self._view_search_api_client.search.assert_called_once_with(
             index='briefs-digital-outcomes-and-specialists',
             doc_type='briefs',
-            status='live,closed'
+            statusOpenClosed='open,closed'
         )
 
         heading = document.xpath('normalize-space(//h1/text())')
@@ -1200,8 +1200,8 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         }
         assert len(document.xpath("//form[@method='get']//ul[@class='lot-filters--last-list']//strong")) == 0
 
-        status_inputs = document.xpath("//form[@method='get']//input[@name='status']")
-        assert set(element.get("value") for element in status_inputs) == {"live", "closed"}
+        status_inputs = document.xpath("//form[@method='get']//input[@name='statusOpenClosed']")
+        assert set(element.get("value") for element in status_inputs) == {"open", "closed"}
         assert not any(element.get("checked") for element in status_inputs)
 
         location_inputs = document.xpath("//form[@method='get']//input[@name='location']")
@@ -1237,8 +1237,8 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert specialist_role_labels[1].strip() == "Technical architect"
 
     def test_catalogue_of_briefs_page_filtered(self):
-        original_url = "/digital-outcomes-and-specialists/opportunities?page=2&status=live&lot=digital-outcomes"\
-            "&location=wales"
+        original_url = "/digital-outcomes-and-specialists/opportunities?page=2"\
+            "&statusOpenClosed=open&lot=digital-outcomes&location=wales"
         res = self.client.get(original_url)
         assert res.status_code == 200
 
@@ -1248,7 +1248,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self._view_search_api_client.search.assert_called_once_with(
             index='briefs-digital-outcomes-and-specialists',
             doc_type='briefs',
-            status='live',
+            statusOpenClosed='open',
             lot='digital-outcomes',
             location='wales',
             page='2',
@@ -1282,12 +1282,12 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             h="/digital-outcomes-and-specialists/opportunities?lot=digital-outcomes",
         )
 
-        status_inputs = document.xpath("//form[@method='get']//input[@name='status']")
+        status_inputs = document.xpath("//form[@method='get']//input[@name='statusOpenClosed']")
         assert {
             element.get("value"): bool(element.get("checked"))
             for element in status_inputs
         } == {
-            "live": True,
+            "open": True,
             "closed": False,
         }
 
@@ -1329,7 +1329,8 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             "864 results found in Digital outcomes"
 
     def test_catalogue_of_briefs_page_filtered_keyword_search(self):
-        original_url = "/digital-outcomes-and-specialists/opportunities?page=2&status=live&lot=digital-outcomes"\
+        original_url = "/digital-outcomes-and-specialists/opportunities?page=2"\
+            "&statusOpenClosed=open&lot=digital-outcomes"\
             "&location=offsite&q=Richie+Poldy"
         res = self.client.get(original_url)
         assert res.status_code == 200
@@ -1340,7 +1341,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self._view_search_api_client.search.assert_called_once_with(
             index='briefs-digital-outcomes-and-specialists',
             doc_type='briefs',
-            status='live',
+            statusOpenClosed='open',
             lot='digital-outcomes',
             location='offsite',
             page='2',
@@ -1375,12 +1376,12 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             h="/digital-outcomes-and-specialists/opportunities?lot=digital-outcomes&q=Richie+Poldy",
         )
 
-        status_inputs = document.xpath("//form[@method='get']//input[@name='status']")
+        status_inputs = document.xpath("//form[@method='get']//input[@name='statusOpenClosed']")
         assert {
             element.get("value"): bool(element.get("checked"))
             for element in status_inputs
         } == {
-            "live": True,
+            "open": True,
             "closed": False,
         }
 
@@ -1433,7 +1434,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self._view_search_api_client.search.assert_called_once_with(
             index='briefs-digital-outcomes-and-specialists',
             doc_type='briefs',
-            status='live,closed',
+            statusOpenClosed='open,closed',
             lot='digital-outcomes',
         )
 
@@ -1457,12 +1458,12 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             'User research participants (39)': 'a',
         }
 
-        status_inputs = document.xpath("//form[@method='get']//input[@name='status']")
+        status_inputs = document.xpath("//form[@method='get']//input[@name='statusOpenClosed']")
         assert {
             element.get("value"): bool(element.get("checked"))
             for element in status_inputs
         } == {
-            "live": False,
+            "open": False,
             "closed": False,
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#10.2.0":
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#10.8.0":
   version "0.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#ea0d37c23827bda76cfdab8517f2e665b441c5dc"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#e05d70bbdba4b04d0ebebcdf0967cc0244a88bb5"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.2.0":
   version "0.0.1"


### PR DESCRIPTION
Version 10.8.0 of the frameworks contains the new mapping transformations for the briefs search filtering on 'open' and 'closed'.

The reason for this change is to allow the original pre transformed status of a brief to be stored in Elasticsearch while maintaining the ability to filter on 'open' and 'closed'. A future PR will surface the
actual status in the search results for users.

The parameters for filtering have changed:

## Before

`/opportunities?q=&doc_type=briefs&status=live`

`/opportunities?q=&doc_type=briefs&status=closed`

## After

`/opportunities?q=&doc_type=briefs&statusOpenClosed=open`

`/opportunities?q=&doc_type=briefs&statusOpenClosed=closed`



Related frameworks PR: https://github.com/alphagov/digitalmarketplace-frameworks/pull/506

https://trello.com/c/y59qiKOl/335-show-award-status-in-dos-search-results