### PR TITLE
Bugfix 142 search clear filters behaviour with keyword search

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -317,6 +317,10 @@ def search_services():
                 "selector": "#js-dm-live-save-search-form",
                 "html": render_template("search/_services_save_search.html", **template_args)
             },
+            "filter-title": {
+                "selector": "#js-dm-live-filter-title",
+                "html": render_template("search/_filter_title.html", **template_args)
+            },
         }
 
         return jsonify(live_results_dict)

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -325,6 +325,10 @@ def list_opportunities(framework_family):
                 "selector": "#js-dm-live-search-summary-accessible-hint",
                 "html": render_template("search/_summary_accessible_hint.html", **template_args)
             },
+            "filter-title": {
+                "selector": "#js-dm-live-filter-title",
+                "html": render_template("search/_filter_title.html", **template_args)
+            },
         }
 
         return jsonify(live_results_dict)

--- a/app/templates/search/_filter_title.html
+++ b/app/templates/search/_filter_title.html
@@ -1,0 +1,4 @@
+  <div id="js-dm-live-filter-title" class="dm-filter-title js-dm-live-search-fade">
+    <h2 class="apply-filters-title">Apply filters</h2>
+    <a id="dm-clear-all-filters" class="clear-filters-link" href="{{ clear_filters_url }}" role="button">Clear filters</a>
+  </div>

--- a/app/templates/search/_filters.html
+++ b/app/templates/search/_filters.html
@@ -1,8 +1,5 @@
 <div class="dm-filters">
-  <div class="dm-filter-title">
-    <h2 class="apply-filters-title">Apply filters</h2>
-    <a id="dm-clear-all-filters" class="clear-filters-link" href="{{ clear_filters_url }}" role="button">Clear filters</a>
-  </div>
+  {% include "search/_filter_title.html" %}
   <div>
     {% for filter in filters %}
       {%

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.2.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.8.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#11.0.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -610,13 +610,14 @@ class TestSearchFilterOnClick(BaseApplicationTest):
         res = self.client.get('/g-cloud/search?live-results=true')
         data = json.loads(res.get_data(as_text=True))
 
-        assert set(data.keys()) == {
+        assert sorted(data.keys()) == sorted((
             'results',
             'summary',
             'summary-accessible-hint',
             'categories',
             'save-form',
-        }
+            'filter-title'
+        ))
 
         for k, v in data.items():
             assert set(v.keys()) == {'selector', 'html'}
@@ -624,21 +625,29 @@ class TestSearchFilterOnClick(BaseApplicationTest):
             # We want to enforce using css IDs to describe the nodes which should be replaced.
             assert v['selector'].startswith('#')
 
-    @pytest.mark.parametrize('query_string, urls',
-                             (('', {'search/services.html'}),
-                              ('?live-results=true', {"search/_results_wrapper.html",
-                                                      "search/_categories_wrapper.html",
-                                                      "search/_summary.html",
-                                                      "search/_summary_accessible_hint.html",
-                                                      "search/_services_save_search.html",
-                                                      })))
+    live_results_expected_templates = (
+        "search/_results_wrapper.html",
+        "search/_categories_wrapper.html",
+        "search/_summary.html",
+        "search/_summary_accessible_hint.html",
+        "search/_services_save_search.html",
+        "search/_filter_title.html"
+    )
+
+    @pytest.mark.parametrize(
+        ('query_string', 'urls'),
+        (
+            ('', ('search/services.html',)),
+            ('?live-results=true', live_results_expected_templates)
+        )
+    )
     @mock.patch('app.main.views.g_cloud.render_template', autospec=True)
     def test_base_page_renders_search_services(self, render_template_patch, query_string, urls):
         render_template_patch.return_value = '<p>some html</p>'
 
         self.client.get('/g-cloud/search{}'.format(query_string))
 
-        assert urls == set(x[0][0] for x in render_template_patch.call_args_list)
+        assert urls == tuple(x[0][0] for x in render_template_patch.call_args_list)
 
     def test_g_cloud_search_has_js_hidden_filter_button(self):
         res = self.client.get('/g-cloud/search')

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#cfa0a56590678b0412a35327dab916ea54041121"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.2.0":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.8.3":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#ba6f1db4f0960feff221f23e0bb0c86b44a1756c"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#81be966c04bf8fc1819c22921cfa2ecfb2847e78"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
https://trello.com/c/RIlQOOAm/142-search-clear-filters-behaviour-with-keyword-search

In g-cloud search, if you initially search for "apricot" in the keyword search and then on the search screen change the keyword search to "banana" and hit return, the "Clear filters" link still points to a url with "apricot" in it. However if instead of hitting return you click the search button it does update the href. Which is presumably the desired behaviour.

The problem is:
Searching via the form on the page disables full page reloads and instead replaces specific sections of the page dynamically. The ‘clear filters’ link was not included as one of the parts of the page that was reloaded, meaning that the URL was not updating after a live search

The fix is this:
The way to reload part of the content  inside the `dm-filters` div is to create a new div (`js-dm-live-filter-title`) which _is_ repopulated on `live_search` reload. To do this we specify the new div name and its content in the view. The new content is then injected into the `js-dm-live-filter-title` div on each `live_search` reload.