### PR TITLE
Use centralised status method

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,54 +1,12 @@
-from flask import jsonify, current_app, request
+from flask import request
 
 from . import status
 from .. import data_api_client, search_api_client
-from dmutils.status import get_flags
+from dmutils.status import get_app_status
 
 
 @status.route('/_status')
 def status():
-
-    if 'ignore-dependencies' in request.args:
-        return jsonify(
-            status="ok",
-        ), 200
-
-    version = current_app.config['VERSION']
-    apis = [
-        {
-            'name': '(Data) API',
-            'key': 'api_status',
-            'status': data_api_client.get_status()
-        }, {
-            'name': 'Search API',
-            'key': 'search_api_status',
-            'status': search_api_client.get_status()
-        }
-    ]
-
-    apis_with_errors = []
-
-    for api in apis:
-        if api['status'] is None or api['status']['status'] != "ok":
-            apis_with_errors.append(api['name'])
-
-    # if no errors found, return as is.  Else, return an error and a message
-    if not apis_with_errors:
-        return jsonify(
-            {api['key']: api['status'] for api in apis},
-            status="ok",
-            version=version,
-            flags=get_flags(current_app)
-        )
-
-    message = "Error connecting to the {}.".format(
-        " and the ".join(apis_with_errors)
-    )
-
-    return jsonify(
-        {api['key']: api['status'] for api in apis},
-        status="error",
-        version=version,
-        message=message,
-        flags=get_flags(current_app)
-    ), 500
+    return get_app_status(data_api_client=data_api_client,
+                          search_api_client=search_api_client,
+                          ignore_dependencies='ignore-dependencies' in request.args)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
@@ -40,7 +40,7 @@ notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.6.0
-python-dateutil==2.6.1
+python-dateutil==2.7.0
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11

--- a/tests/status/views/test_status.py
+++ b/tests/status/views/test_status.py
@@ -76,7 +76,7 @@ class TestStatus(BaseApplicationTest):
 
         assert "{}".format(json_data['status']) == "error"
         assert "{}".format(json_data['api_status']['status']) == "ok"
-        assert json_data.get('search_api_status') is None
+        assert json_data.get('search_api_status') == {'status': 'n/a'}
 
     def test_status_error_in_two_upstream_apis(self):
 


### PR DESCRIPTION
 ## Summary
The status endpoint for all of the apps is highly redundant across
repositories so I've moved it to dm-utils. We now only need to call this
method from the view stub in each app and pass in a couple of resources
(mainly the current_app and any api clients) to get a consistent status
JSON blob back.

 ## Ticket
https://trello.com/c/BBvu6eUk/383-ensure-healthcheck-endpoint-fails-if-low-disk-space