### PR TITLE
Add award status details to dos search

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -291,6 +291,12 @@ def list_opportunities(framework_family):
         framework_family=framework['framework'],
         framework_family_name='Digital Outcomes and Specialists',
         lot_names=tuple(lot['name'] for lot in lots_by_slug.values() if lot['allowsBrief']),
+        outcomes={
+            'awarded': 'awarded',
+            'cancelled': 'cancelled',
+            'closed': 'awaiting outcome',
+            'unsuccessful': 'no suitable suppliers'
+        },
         pagination=pagination_config,
         search_keywords=get_keywords_from_request(request),
         search_query=search_query,

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -25,9 +25,9 @@
     </ul>
 
     <ul class="search-result-metadata">
-        {% if brief.status in ['closed', 'awarded', 'cancelled', 'unsuccessful'] %}
+        {% if brief.status in outcomes.keys() %}
             <li class="search-result-metadata-item">
-                {{ brief.status | capitalize() }}
+                Closed: {{ outcomes[brief.status] }}
             </li>
         {% else %}
             <li class="search-result-metadata-item">

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.2.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#10.8.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#11.0.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   },
   "scripts": {

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1587,22 +1587,22 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         closed_opportunity_status = document.xpath(
             '//div[@class="search-result"][2]//li[@class="search-result-metadata-item"]'
         )[-1].text_content().strip()
-        assert closed_opportunity_status == "Closed"
+        assert closed_opportunity_status == "Closed: awaiting outcome"
 
         unsuccessful_opportunity_status = document.xpath(
             '//div[@class="search-result"][3]//li[@class="search-result-metadata-item"]'
         )[-1].text_content().strip()
-        assert unsuccessful_opportunity_status == "Unsuccessful"
+        assert unsuccessful_opportunity_status == "Closed: no suitable suppliers"
 
         cancelled_opportunity_status = document.xpath(
             '//div[@class="search-result"][4]//li[@class="search-result-metadata-item"]'
         )[-1].text_content().strip()
-        assert cancelled_opportunity_status == "Cancelled"
+        assert cancelled_opportunity_status == "Closed: cancelled"
 
         awarded_opportunity_status = document.xpath(
             '//div[@class="search-result"][6]//li[@class="search-result-metadata-item"]'
         )[-1].text_content().strip()
-        assert awarded_opportunity_status == "Awarded"
+        assert awarded_opportunity_status == "Closed: awarded"
 
     def test_should_render_summary_for_0_results_in_all_lots(self):
         search_results = self._get_dos_brief_search_api_response_fixture_data()

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#10.8.0":
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#11.0.0":
   version "0.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#e05d70bbdba4b04d0ebebcdf0967cc0244a88bb5"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#cfa0a56590678b0412a35327dab916ea54041121"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.2.0":
   version "0.0.1"


### PR DESCRIPTION
Once more with feeling. This was originally done in PR https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/723 but changes needed to happen to the fields that were being indexed by the search API first.

We now display the status of opportunities in DOS search results with something more accurate than "closed". This should make it more obvious to suppliers what has happened with the brief.

## Before

<img width="316" alt="screen shot 2018-03-07 at 16 47 35" src="https://user-images.githubusercontent.com/3466862/37105518-49b85c78-2227-11e8-92a8-e346623f3390.png">


## After

<img width="300" alt="screen shot 2018-03-07 at 16 44 28" src="https://user-images.githubusercontent.com/3466862/37105464-2493092a-2227-11e8-806a-62270ab50621.png">

<img width="259" alt="screen shot 2018-03-07 at 16 45 07" src="https://user-images.githubusercontent.com/3466862/37105470-2972683c-2227-11e8-918e-7d55897d8b8a.png">

https://trello.com/c/y59qiKOl/335-show-award-status-in-dos-search-results