### PR TITLE
Fliter out live-results along with page from url params when generating clear filters link

### DIFF
--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -42,6 +42,7 @@ def get_request_url_without_any_filters(request, filters, view_name, **kwargs):
             all_request_filters.poplist(_filter['name'])
 
     all_request_filters.poplist('page')
+    all_request_filters.poplist('live-results')
 
     search_link_builder = Href(url_for('.{}'.format(view_name), **kwargs))
     url = search_link_builder(all_request_filters)


### PR DESCRIPTION
The live-results query param is not required in the clear filters link, remove it here as we do with `page` query param

Tested here:
https://github.com/alphagov/digitalmarketplace-functional-tests/pull/488
