### PR TITLE
bump digitalmarketplace-utils dependency to 35.4.0, set DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS for production & staging

### DIFF
--- a/config.py
+++ b/config.py
@@ -142,6 +142,12 @@ class Live(Config):
     DM_LOG_PATH = '/var/log/digitalmarketplace/application.log'
     DM_HTTP_PROTO = 'https'
 
+    # use of invalid email addresses with live api keys annoys Notify
+    DM_NOTIFY_REDIRECT_DOMAINS_TO_ADDRESS = {
+        "example.com": "simulate-delivered@notifications.service.gov.uk",
+        "example.gov.uk": "simulate-delivered-2@notifications.service.gov.uk",
+    }
+
 
 class Preview(Live):
     FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-06')

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.4.0#egg=digitalmarketplace-utils==35.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.12
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.4.0#egg=digitalmarketplace-utils==35.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
@@ -39,7 +39,7 @@ monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.6.0
+PyJWT==1.6.1
 python-dateutil==2.7.0
 python-json-logger==0.1.4
 pytz==2015.4


### PR DESCRIPTION
Trello https://trello.com/c/YQB2HkiD/225-functional-tests-send-emails-to-invalid-email-addresses

Did I remember correctly that we decided we should set this for production and staging but preview will probably be fine as it should have a sandbox token anyway...?