### PR TITLE
bump version to 28.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.8.3",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#11.0.1",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "0.0.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#24e0546a9374dae5adc6d0b4f60bb490626f2ea0"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.8.3":
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.2":
   version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#81be966c04bf8fc1819c22921cfa2ecfb2847e78"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#0c37d935ec74230b4e595992eb0b069fb7e8eff3"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
The 'Apply for this Opportunity' button (Buyer FE) is too close to the 'Log in to ask a question' link on mobile.

This bug may be repeated elsewhere in the FE apps!

(This happens when a form is created with just one element [submit button] )

https://trello.com/c/OYFHcH77/139-button-too-close-to-links-on-mobile

Before:
![screenshot_20171219-170531](https://user-images.githubusercontent.com/4599889/37354197-015565b4-26d9-11e8-8dc4-0ef2c89d90ce.png)

After:
<img width="400" alt="screen shot 2018-03-13 at 16 07 48" src="https://user-images.githubusercontent.com/4599889/37354181-f76d3202-26d8-11e8-9df8-6a6819dccd34.png">
