### PR TITLE
Layout tweaks on saved search task list page

### DIFF
--- a/app/assets/scss/_index-page.scss
+++ b/app/assets/scss/_index-page.scss
@@ -2,6 +2,10 @@
 
 .index-page {
 
+  .flash-message-container {
+    margin-bottom: 40px; // adds in specific margin for index page due to layout of page
+  }
+
   h2 {
     @include bold-27;
     margin-bottom: $gutter;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,9 +12,11 @@
 
 {% block phase_banner %}{% endblock %}
 
+ {% block body_classes %}index-page{% endblock %}
+
 {% block main_content %}
 
-<div class="index-page grid-row">
+<div class="grid-row">
   <div class="column-two-thirds">
     <h2>Find technology or people for digital projects in the public sector</h2>
       {% set items = [] %}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.2",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.13.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#11.5.5",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "11.5.5"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#a8cd0937a73adfb3498a70ae02135ac2691f8c20"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.10.2":
-  version "0.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#0c37d935ec74230b4e595992eb0b069fb7e8eff3"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.13.2":
+  version "28.13.2"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#bf04236b096c3270da7a51ae51cdb48561c75d49"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
The main heading on the task list page has too much vertical space at its top margin. This is especially bad when you first create the search, where the flash message directly above seems to have too much space at its bottom margin.

Ticket: https://trello.com/c/z1RNJnQy/18-layout-tweaks-on-saved-search-task-list-page

Required PR: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/433


Before:
![screen_shot_2018-01-15_at_18 18 45](https://user-images.githubusercontent.com/4599889/38871073-aa5fafd2-4247-11e8-8340-6f6055fdfafc.png)

After:
<img width="1152" alt="screen shot 2018-04-17 at 13 59 40" src="https://user-images.githubusercontent.com/4599889/38871060-9b88145e-4247-11e8-9f16-ee90db39f5ce.png">