### PR TITLE
Dh 110 instrument ga tracking to capture clicks made on downloads and external links

### DIFF
--- a/app/assets/javascripts/analytics/_init.js
+++ b/app/assets/javascripts/analytics/_init.js
@@ -7,5 +7,6 @@
     this.events.init();
     this.virtualPageViews.init();
     this.scrollTracking.init();
+    this.trackExternalLinks.init();
   };
 })(window);

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -6,6 +6,7 @@ var manifest = {
     '../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js',
     '../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js',
     '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_register.js',
+    '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_trackExternalLinks.js',
     '../../../app/assets/javascripts/analytics/_pageViews.js',
     '../../../app/assets/javascripts/analytics/_events.js',
     '../../../app/assets/javascripts/analytics/_virtualPageViews.js',

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -32,11 +32,12 @@ describe("GOVUK.Analytics", function () {
 
   describe('when initialised', function () {
 
-    it('should initialise pageviews, events, virtual pageviews and scroll tracking', function () {
+    it('should initialise pageviews, events, virtual pageviews, track external links and scroll tracking', function () {
       spyOn(window.GOVUK.GDM.analytics, 'register');
       spyOn(window.GOVUK.GDM.analytics.pageViews, 'init');
       spyOn(window.GOVUK.GDM.analytics.events, 'init');
       spyOn(window.GOVUK.GDM.analytics.scrollTracking, 'init');
+      spyOn(window.GOVUK.GDM.analytics.trackExternalLinks, 'init');
 
       window.GOVUK.GDM.analytics.init();
 
@@ -44,6 +45,7 @@ describe("GOVUK.Analytics", function () {
       expect(window.GOVUK.GDM.analytics.pageViews.init).toHaveBeenCalled();
       expect(window.GOVUK.GDM.analytics.events.init).toHaveBeenCalled();
       expect(window.GOVUK.GDM.analytics.scrollTracking.init).toHaveBeenCalled();
+      expect(window.GOVUK.GDM.analytics.trackExternalLinks.init).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
A lot of GA tracking comes 'out of the box' but a notable exception is tracking to capture clicks on downloads and external links. Additional code is required in order to capture these.

Currently, we are tracking some downloads and external links on the DM site (those that were specifically required for previous mission work).

The proposal is to have all downloads and external links tracked automatically across the whole site, similar to how GOV.UK have done.

The advantage of doing this is that we have key data available straight away at the start of mission teams rather than having to prioritise the work, use up dev resource and then wait for enough data to populate before being able to carry out analysis.

---> includes making sure all links on the homepage are tracked, so we can measure which links are used the most and least.

Ticket: https://trello.com/c/i912cDBe/110-instrument-ga-tracking-to-capture-clicks-made-on-downloads-and-external-links