### PR TITLE
digitalmarketplace-utils dependency: bump to 36.2.2

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,9 +3,9 @@
 
 Flask==0.10.1
 Flask-Login==0.2.11
-Flask-WTF==0.12
+Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@35.4.0#egg=digitalmarketplace-utils==35.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.2#egg=digitalmarketplace-utils==36.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,19 @@
 
 Flask==0.10.1
 Flask-Login==0.2.11
-Flask-WTF==0.12
+Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@35.4.0#egg=digitalmarketplace-utils==35.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.2#egg=digitalmarketplace-utils==36.2.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 backoff==1.0.7
-boto3==1.4.4
-botocore==1.5.95
-certifi==2018.1.18
+boto3==1.4.8
+botocore==1.8.50
+certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
 contextlib2==0.4.0
@@ -27,7 +27,7 @@ Flask-FeatureFlags==0.6
 Flask-Script==2.0.5
 future==0.16.0
 idna==2.6
-inflection==0.2.1
+inflection==0.3.1
 itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
@@ -40,13 +40,13 @@ notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.6.1
-python-dateutil==2.7.0
+python-dateutil==2.7.2
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4
 s3transfer==0.1.13
-six==1.9.0
+six==1.11.0
 unicodecsv==0.14.1
 urllib3==1.22
 Werkzeug==0.14.1


### PR DESCRIPTION
This includes fixes for security issues https://snyk.io/vuln/SNYK-PYTHON-BOTO3-40617 and https://snyk.io/vuln/SNYK-PYTHON-WTFORMS-40581, the fix for the latter requiring a synchronized rollout across all frontends