### PR TITLE
Buyer FE test refactor

### DIFF
--- a/app/main/helpers/direct_award_helpers.py
+++ b/app/main/helpers/direct_award_helpers.py
@@ -1,13 +1,11 @@
 from operator import itemgetter
 
-from app import data_api_client
-
 
 def is_direct_award_project_accessible(project, user_id):
     return any([user['id'] == user_id for user in project['users']])
 
 
-def get_direct_award_projects(user_id, return_type="all", sort_by_key=None, latest_first=None):
+def get_direct_award_projects(data_api_client, user_id, return_type="all", sort_by_key=None, latest_first=None):
     projects = data_api_client.find_direct_award_projects(user_id, latest_first=latest_first).get('projects', [])
 
     res = {

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -336,7 +336,7 @@ def saved_search_overview(framework_framework):
     content_loader.load_messages(framework['slug'], ['descriptions', 'urls'])
     framework_short_description = content_loader.get_message(framework['slug'], 'descriptions', 'framework_short')
 
-    projects = get_direct_award_projects(current_user.id, latest_first=True)
+    projects = get_direct_award_projects(data_api_client, current_user.id, latest_first=True)
     projects['closed_projects'].sort(key=itemgetter('lockedAt'), reverse=True)
 
     return render_template(
@@ -376,7 +376,7 @@ def save_search(framework_framework):
     name_is_invalid = save_search_selection == "new_search" and not name
 
     if request.method == 'GET' or not form.validate_on_submit() or not save_search_selection or name_is_invalid:
-        projects = get_direct_award_projects(current_user.id, 'open_projects', 'name')
+        projects = get_direct_award_projects(data_api_client, current_user.id, 'open_projects', 'name')
         projects.sort(key=lambda x: x['name'])
 
         # Retrieve results so we can display SearchSummary

--- a/tests/main/helpers/test_framework_helpers.py
+++ b/tests/main/helpers/test_framework_helpers.py
@@ -1,22 +1,22 @@
-from app import data_api_client
 from app.main.helpers import framework_helpers
 
 from ...helpers import BaseApplicationTest
 
 
 class TestBuildSearchQueryHelpers(BaseApplicationTest):
+
+    def setup_method(self, method):
+        super().setup_method(method)
+
+        self.available_frameworks = self._get_frameworks_list_fixture_data().get('frameworks')
+
     def test_get_latest_live_framework(self):
         latest_framework_when_fixture_updated = 'g-cloud-9'  # fixture set in base class
-
-        latest_framework_data = framework_helpers.get_latest_live_framework(
-            data_api_client.find_frameworks().get('frameworks'),
-            'g-cloud'
-        )
+        latest_framework_data = framework_helpers.get_latest_live_framework(self.available_frameworks, 'g-cloud')
         assert latest_framework_data['slug'] == latest_framework_when_fixture_updated
 
     def test_get_lots_by_slug(self):
-        g_cloud_9_data = next((f for f in data_api_client.find_frameworks().get('frameworks')
-                               if f['slug'] == 'g-cloud-9'))
+        g_cloud_9_data = next((f for f in self.available_frameworks if f['slug'] == 'g-cloud-9'))
         lots_by_slug = framework_helpers.get_lots_by_slug(g_cloud_9_data)
         assert lots_by_slug['cloud-hosting'] == g_cloud_9_data['lots'][0]
         assert lots_by_slug['cloud-software'] == g_cloud_9_data['lots'][1]

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -318,6 +318,7 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
 
     def teardown_method(self, method):
         self.search_api_client_patch.stop()
+        super().teardown_method(method)
 
     def test_top_level_category_selection(self):
         url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&filterExample=option+1" \

--- a/tests/main/presenters/test_search_results.py
+++ b/tests/main/presenters/test_search_results.py
@@ -39,13 +39,16 @@ class TestSearchResults(BaseApplicationTest):
         return False
 
     def setup_method(self, method):
-        super(TestSearchResults, self).setup_method(method)
+        super().setup_method(method)
 
         self.fixture = _get_fixture_data()
         self.multiple_pages_fixture = _get_fixture_multiple_pages_data()
         self._lots_by_slug = framework_helpers.get_lots_by_slug(
             self._get_framework_fixture_data('g-cloud-6')['frameworks']
         )
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     def test_search_results_is_set(self):
         search_results_instance = SearchResults(self.fixture, self._lots_by_slug)

--- a/tests/main/presenters/test_search_results.py
+++ b/tests/main/presenters/test_search_results.py
@@ -47,9 +47,6 @@ class TestSearchResults(BaseApplicationTest):
             self._get_framework_fixture_data('g-cloud-6')['frameworks']
         )
 
-    def teardown_method(self, method):
-        super().teardown_method(method)
-
     def test_search_results_is_set(self):
         search_results_instance = SearchResults(self.fixture, self._lots_by_slug)
         assert hasattr(search_results_instance, 'search_results')

--- a/tests/main/presenters/test_search_summary.py
+++ b/tests/main/presenters/test_search_summary.py
@@ -57,7 +57,7 @@ def _get_fixture_multiple_pages_data():
 
 class TestSearchSummary(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestSearchSummary, self).setup_method(method)
+        super().setup_method(method)
 
         self._lots_by_slug = framework_helpers.get_lots_by_slug(
             self._get_framework_fixture_data('g-cloud-6')['frameworks']
@@ -73,6 +73,9 @@ class TestSearchSummary(BaseApplicationTest):
             ('lot', 'saas'),
             ('q', 'email'),
         ))
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     def test_write_list_as_sentence_with_one_item(self):
         assert SearchSummary.write_list_as_sentence(['item1'], 'and') == u"item1"
@@ -331,7 +334,7 @@ class TestSearchSummary(BaseApplicationTest):
         assert search_summary.markup() == Markup(u"5 results found with option1 and option2")
 
 
-class TestSummaryRules(object):
+class TestSummaryRules:
     def setup_method(self, method):
         if SummaryRules.loaded is False:
             SummaryRules.load_rules(manifest=os.path.join(
@@ -392,7 +395,7 @@ class TestSummaryRules(object):
         SummaryRules.loaded = False
 
 
-class TestSummaryFragment(object):
+class TestSummaryFragment:
     def _get_mock(self, key):
         return self.rules[key]
 

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -32,7 +32,7 @@ def test_chunk_string():
 
 class TestService(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestService, self).setup_method(method)
+        super().setup_method(method)
 
         self.fixture = _get_fixture_data()
         self.fixture = self.fixture['services']
@@ -43,6 +43,9 @@ class TestService(BaseApplicationTest):
         self.service = Service(
             self.fixture, content_loader.get_manifest('g-cloud-6', 'display_service'), self._lots_by_slug
         )
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     def test_title_attribute_is_set(self):
         assert self.service.title == self.fixture['serviceName']
@@ -90,7 +93,7 @@ class TestService(BaseApplicationTest):
         assert len(service.summary_manifest.sections[0].questions) == 5
 
 
-class TestMeta(object):
+class TestMeta:
     def setup_method(self, method):
         self.fixture = _get_fixture_data()['services']
         self.meta = Meta(self.fixture)

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -472,15 +472,14 @@ class TestDirectAwardResultsPage(TestDirectAwardBase):
     def test_results_page_download_links_work(self):
         self.login_as_buyer()
 
-        with self.app.app_context():
-            res = self.client.get('/buyers/direct-award/g-cloud/projects/1/results')
-            doc = html.fromstring(res.get_data(as_text=True))
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1/results')
+        doc = html.fromstring(res.get_data(as_text=True))
 
-            download_links = doc.xpath('//ul[@class="document-list"]//a[@class="document-link-with-icon"]/@href')
+        download_links = doc.xpath('//ul[@class="document-list"]//a[@class="document-link-with-icon"]/@href')
 
-            for download_link in download_links:
-                res = self.client.get(download_link)
-                assert res.status_code == 200
+        for download_link in download_links:
+            res = self.client.get(download_link)
+            assert res.status_code == 200
 
 
 class TestDirectAwardDownloadResultsView(TestDirectAwardBase):

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -18,7 +18,7 @@ from ...helpers import BaseApplicationTest
 
 class TestDirectAwardBase(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestDirectAwardBase, self).setup_method(method)
+        super().setup_method(method)
         self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
         self._search_api_client = self._search_api_client_patch.start()
         self._search_api_client.aggregate.return_value = \
@@ -50,6 +50,7 @@ class TestDirectAwardBase(BaseApplicationTest):
         self._search_api_client_patch.stop()
         self._search_api_client_presenters_patch.stop()
         self._search_api_client_helpers_patch.stop()
+        super().teardown_method(method)
 
 
 class TestDirectAward(TestDirectAwardBase):
@@ -172,7 +173,7 @@ class TestDirectAward(TestDirectAwardBase):
 
 class TestDirectAwardProjectOverview(TestDirectAwardBase):
     def setup_method(self, method):
-        super(TestDirectAwardProjectOverview, self).setup_method(method)
+        super().setup_method(method)
 
         self._search_api_client.get_frontend_params_from_search_api_url.return_value = (('q', 'accelerator'), )
 
@@ -180,6 +181,9 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
 
         self.content_loader = ContentLoader('tests/fixtures/content')
         self.content_loader.load_messages('g9', ['urls'])
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     def _task_has_link(self, tasklist, task, link):
         """Task here refers to the tasklist item number rather than the zero-indexed python array. This feels easier to
@@ -374,12 +378,12 @@ class TestDirectAwardURLGeneration(BaseApplicationTest):
     """This class has been separated out from above because we only want to mock a couple of methods on the API clients,
     not all of them (like the class above)"""
     def setup_method(self, method):
-        super(TestDirectAwardURLGeneration, self).setup_method(method)
+        super().setup_method(method)
 
         self.g9_search_results = self._get_g9_search_results_fixture_data()
 
     def teardown_method(self, method):
-        super(TestDirectAwardURLGeneration, self).teardown_method(method)
+        super().teardown_method(method)
 
     @pytest.mark.parametrize('search_api_url, frontend_url',
                              (
@@ -484,7 +488,7 @@ class TestDirectAwardResultsPage(TestDirectAwardBase):
 
 class TestDirectAwardDownloadResultsView(TestDirectAwardBase):
     def setup_method(self, method):
-        super(TestDirectAwardDownloadResultsView, self).setup_method(method)
+        super().setup_method(method)
 
         self.project_id = 1
         self.kwargs = {'project_id': 1}
@@ -513,10 +517,9 @@ class TestDirectAwardDownloadResultsView(TestDirectAwardBase):
         self.view._init_hook()
 
     def teardown_method(self, method):
-        super(TestDirectAwardDownloadResultsView, self).teardown_method(method)
-
         self._request_patch.stop()
         self._current_user_patch.stop()
+        super().teardown_method(method)
 
     def test_init_hook(self):
         assert self.view.data_api_client is data_api_client

--- a/tests/main/views/test_errors.py
+++ b/tests/main/views/test_errors.py
@@ -8,6 +8,13 @@ from ...helpers import BaseApplicationTest
 
 @mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
 class TestErrors(BaseApplicationTest):
+
+    def setup_method(self, method):
+        super().setup_method(method)
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
+
     def test_404(self, search_api_mock):
         res = self.client.get('/g-cloud/service/1234')
         assert res.status_code == 404

--- a/tests/main/views/test_errors.py
+++ b/tests/main/views/test_errors.py
@@ -6,16 +6,18 @@ from dmapiclient import HTTPError
 from ...helpers import BaseApplicationTest
 
 
-@mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
 class TestErrors(BaseApplicationTest):
 
     def setup_method(self, method):
         super().setup_method(method)
+        self.search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
+        self.search_api_client = self.search_api_client_patch.start()
 
     def teardown_method(self, method):
+        self.search_api_client_patch.stop()
         super().teardown_method(method)
 
-    def test_404(self, search_api_mock):
+    def test_404(self):
         res = self.client.get('/g-cloud/service/1234')
         assert res.status_code == 404
         assert "Check you've entered the correct web " \
@@ -28,7 +30,7 @@ class TestErrors(BaseApplicationTest):
             "enquiries@digitalmarketplace.service.gov.uk</a>" \
             in res.get_data(as_text=True)
 
-    def test_410(self, search_api_mock):
+    def test_410(self):
         res = self.client.get('/digital-services/framework')
         assert res.status_code == 410
         assert "Check you've entered the correct web " \
@@ -41,12 +43,12 @@ class TestErrors(BaseApplicationTest):
             "enquiries@digitalmarketplace.service.gov.uk</a>" \
             in res.get_data(as_text=True)
 
-    def test_500(self, search_api_mock):
+    def test_500(self):
         self.app.config['DEBUG'] = False
 
         api_response = mock.Mock()
         api_response.status_code = 503
-        search_api_mock.search.side_effect = HTTPError(api_response)
+        self.search_api_client.search.side_effect = HTTPError(api_response)
 
         res = self.client.get('/g-cloud/search?q=email')
         assert res.status_code == 503

--- a/tests/main/views/test_g_cloud.py
+++ b/tests/main/views/test_g_cloud.py
@@ -5,7 +5,7 @@ from ...helpers import BaseApplicationTest
 
 class TestGCloudIndexResults(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestGCloudIndexResults, self).setup_method(method)
+        super().setup_method(method)
 
         self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
         self._search_api_client = self._search_api_client_patch.start()
@@ -14,6 +14,7 @@ class TestGCloudIndexResults(BaseApplicationTest):
 
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
+        super().teardown_method(method)
 
     def test_renders_correct_search_links(self):
         self._search_api_client.search.return_value = self.search_results

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -12,11 +12,6 @@ from ...helpers import BaseApplicationTest
 
 
 class TestApplication(BaseApplicationTest):
-    def setup_method(self, method):
-        super().setup_method(method)
-
-    def teardown_method(self, method):
-        super().teardown_method(method)
 
     def test_analytics_code_should_be_in_javascript(self):
         res = self.client.get('/static/javascripts/application.js')

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -35,16 +35,18 @@ class TestApplication(BaseApplicationTest):
         assert 'name="google-site-verification" content="NotARealVerificationKey"' in res.get_data(as_text=True)
 
 
-@mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
 class TestHomepageAccountCreationVirtualPageViews(BaseApplicationTest):
 
     def setup_method(self, method):
         super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
 
     def teardown_method(self, method):
+        self.data_api_client_patch.stop()
         super().teardown_method(method)
 
-    def test_data_analytics_track_page_view_is_shown_if_account_created_flash_message(self, data_api_client):
+    def test_data_analytics_track_page_view_is_shown_if_account_created_flash_message(self):
         with self.client.session_transaction() as session:
             session['_flashes'] = [('track-page-view', 'buyers?account-created=true')]
 
@@ -57,14 +59,13 @@ class TestHomepageAccountCreationVirtualPageViews(BaseApplicationTest):
         assert flash_banner_match is None, "Unexpected flash banner message '{}'.".format(
             flash_banner_match.groups()[0])
 
-    def test_data_analytics_track_page_view_not_shown_if_no_account_created_flash_message(self, data_api_client):
+    def test_data_analytics_track_page_view_not_shown_if_no_account_created_flash_message(self):
         res = self.client.get("/")
         data = res.get_data(as_text=True)
 
         assert 'data-analytics="trackPageView" data-url="buyers?account-created=true"' not in data
 
 
-@mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
 class TestHomepageBrowseList(BaseApplicationTest):
 
     mock_live_dos_1_framework = {
@@ -90,12 +91,15 @@ class TestHomepageBrowseList(BaseApplicationTest):
 
     def setup_method(self, method):
         super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
 
     def teardown_method(self, method):
+        self.data_api_client_patch.stop()
         super().teardown_method(method)
 
-    def test_dos_links_are_shown(self, data_api_client):
-        data_api_client.find_frameworks.return_value = {
+    def test_dos_links_are_shown(self):
+        self.data_api_client.find_frameworks.return_value = {
             "frameworks": [
                 self.mock_live_dos_1_framework
             ]
@@ -111,11 +115,11 @@ class TestHomepageBrowseList(BaseApplicationTest):
         assert link_texts[-1] == "Buy physical datacentre space"
         assert "Find specialists to work on digital projects" not in link_texts
 
-    def test_links_are_for_existing_dos_framework_when_a_new_dos_framework_in_standstill_exists(self, data_api_client):
+    def test_links_are_for_existing_dos_framework_when_a_new_dos_framework_in_standstill_exists(self):
         mock_standstill_dos_2_framework = self.mock_live_dos_2_framework.copy()
         mock_standstill_dos_2_framework.update({"status": "standstill"})
 
-        data_api_client.find_frameworks.return_value = {
+        self.data_api_client.find_frameworks.return_value = {
             "frameworks": [
                 self.mock_live_dos_1_framework,
                 mock_standstill_dos_2_framework,
@@ -135,8 +139,8 @@ class TestHomepageBrowseList(BaseApplicationTest):
         for index, lot_slug in enumerate(lots):
             assert link_locations[index] == dos_base_path.format(lot_slug)
 
-    def test_links_are_for_the_newest_live_dos_framework_when_multiple_live_dos_frameworks_exist(self, data_api_client):
-        data_api_client.find_frameworks.return_value = {
+    def test_links_are_for_the_newest_live_dos_framework_when_multiple_live_dos_frameworks_exist(self):
+        self.data_api_client.find_frameworks.return_value = {
             "frameworks": [
                 self.mock_live_dos_1_framework,
                 self.mock_live_dos_2_framework,
@@ -156,11 +160,11 @@ class TestHomepageBrowseList(BaseApplicationTest):
         for index, lot_slug in enumerate(lots):
             assert link_locations[index] == dos2_base_path.format(lot_slug)
 
-    def test_links_are_for_live_dos_framework_when_expired_dos_framework_exists(self, data_api_client):
+    def test_links_are_for_live_dos_framework_when_expired_dos_framework_exists(self):
         mock_expired_dos_1_framework = self.mock_live_dos_1_framework.copy()
         mock_expired_dos_1_framework.update({"status": "expired"})
 
-        data_api_client.find_frameworks.return_value = {
+        self.data_api_client.find_frameworks.return_value = {
             "frameworks": [
                 mock_expired_dos_1_framework,
                 self.mock_live_dos_2_framework,
@@ -180,14 +184,14 @@ class TestHomepageBrowseList(BaseApplicationTest):
         for index, lot_slug in enumerate(lots):
             assert link_locations[index] == dos2_base_path.format(lot_slug)
 
-    def test_non_dos_links_are_shown_if_no_live_dos_framework(self, data_api_client):
+    def test_non_dos_links_are_shown_if_no_live_dos_framework(self):
         mock_expired_dos_1_framework = self.mock_live_dos_1_framework.copy()
         mock_expired_dos_1_framework.update({"status": "expired"})
         mock_expired_dos_2_framework = self.mock_live_dos_2_framework.copy()
         mock_expired_dos_2_framework.update({"status": "expired"})
         mock_g_cloud_9_framework = self.mock_live_g_cloud_9_framework.copy()
 
-        data_api_client.find_frameworks.return_value = {
+        self.data_api_client.find_frameworks.return_value = {
             "frameworks": [
                 mock_expired_dos_1_framework,
                 mock_expired_dos_2_framework,
@@ -210,8 +214,11 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
     def setup_method(self, method):
         super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
 
     def teardown_method(self, method):
+        self.data_api_client_patch.stop()
         super().teardown_method(method)
 
     @staticmethod
@@ -246,9 +253,8 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         assert len(message_container_contents) > 0
         assert message_container_contents[0].xpath('text()')[0].strip() == "Sell services"
 
-    @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
-    def _load_homepage(self, framework_slugs_and_statuses, framework_messages, data_api_client):
-        data_api_client.find_frameworks.return_value = self._find_frameworks(framework_slugs_and_statuses)
+    def _load_homepage(self, framework_slugs_and_statuses, framework_messages):
+        self.data_api_client.find_frameworks.return_value = self._find_frameworks(framework_slugs_and_statuses)
         res = self.client.get('/')
         assert res.status_code == 200
         response_data = res.get_data(as_text=True)
@@ -299,9 +305,8 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
         self._load_homepage(framework_slugs_and_statuses, framework_messages)
 
-    @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
-    def test_homepage_sidebar_messages_when_logged_out(self, data_api_client):
-        data_api_client.find_frameworks.return_value = self._find_frameworks([
+    def test_homepage_sidebar_messages_when_logged_out(self):
+        self.data_api_client.find_frameworks.return_value = self._find_frameworks([
             ('digital-outcomes-and-specialists', 'live')
         ])
         res = self.client.get('/')
@@ -319,9 +324,8 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         assert 'Become a supplier' in sidebar_link_texts
         assert 'See Digital Marketplace sales figures' in sidebar_link_texts
 
-    @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
-    def test_homepage_sidebar_messages_when_logged_in(self, data_api_client):
-        data_api_client.find_frameworks.return_value = self._find_frameworks([
+    def test_homepage_sidebar_messages_when_logged_in(self):
+        self.data_api_client.find_frameworks.return_value = self._find_frameworks([
             ('digital-outcomes-and-specialists', 'live')
         ])
         self.login_as_supplier()
@@ -341,13 +345,12 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
         assert 'Become a supplier' not in sidebar_link_texts
 
     # here we've given an valid framework with a valid status but there is no message.yml file to read from
-    @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
-    def test_g_cloud_6_open_blows_up(self, data_api_client):
+    def test_g_cloud_6_open_blows_up(self):
         framework_slugs_and_statuses = [
             ('g-cloud-6', 'open')
         ]
 
-        data_api_client.find_frameworks.return_value = self._find_frameworks(framework_slugs_and_statuses)
+        self.data_api_client.find_frameworks.return_value = self._find_frameworks(framework_slugs_and_statuses)
         res = self.client.get('/')
         assert res.status_code == 500
 
@@ -400,17 +403,17 @@ class BaseBriefPageTest(BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
 
-        self._data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
-        self._data_api_client = self._data_api_client_patch.start()
+        self.data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
 
         self.brief = self._get_dos_brief_fixture_data()
         self.brief_responses = self._get_dos_brief_responses_fixture_data()
         self.brief_id = self.brief['briefs']['id']
-        self._data_api_client.get_brief.return_value = self.brief
-        self._data_api_client.find_brief_responses.return_value = self.brief_responses
+        self.data_api_client.get_brief.return_value = self.brief
+        self.data_api_client.find_brief_responses.return_value = self.brief_responses
 
     def teardown_method(self, method):
-        self._data_api_client_patch.stop()
+        self.data_api_client_patch.stop()
         super().teardown_method(method)
 
 
@@ -464,7 +467,7 @@ class TestBriefPage(BaseBriefPageTest):
 
     def test_application_stats_pluralised_correctly(self):
         brief_id = self.brief['briefs']['id']
-        self._data_api_client.find_brief_responses.return_value = {
+        self.data_api_client.find_brief_responses.return_value = {
             "briefResponses": [
                 {
                     "id": 14275,
@@ -504,7 +507,7 @@ class TestBriefPage(BaseBriefPageTest):
 
     def test_dos_brief_displays_application_stats_correctly_when_no_applications(self):
         brief_id = self.brief['briefs']['id']
-        self._data_api_client.find_brief_responses.return_value = {"briefResponses": []}
+        self.data_api_client.find_brief_responses.return_value = {"briefResponses": []}
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))
         assert res.status_code == 200
 
@@ -648,7 +651,7 @@ class TestBriefPage(BaseBriefPageTest):
 
     def test_cannot_apply_to_awarded_brief(self):
         self.brief['briefs']['status'] = "awarded"
-        self._data_api_client.find_brief_responses.return_value = {
+        self.data_api_client.find_brief_responses.return_value = {
             "briefResponses": [
                 {
                     "awardDetails": {"awardedContractStartDate": "2017-08-21", "awardedContractValue": "20000.00"},
@@ -714,7 +717,7 @@ class TestBriefPage(BaseBriefPageTest):
     def test_supplier_start_application(self):
         self.login_as_supplier()
         # mocking that we haven't applied
-        self._data_api_client.find_brief_responses.return_value = {
+        self.data_api_client.find_brief_responses.return_value = {
             "briefResponses": []
         }
         brief_id = self.brief['briefs']['id']
@@ -749,7 +752,7 @@ class TestBriefPage(BaseBriefPageTest):
         self.login_as_supplier()
         self.brief['briefs']['status'] = 'awarded'
 
-        self._data_api_client.find_brief_responses.return_value = {
+        self.data_api_client.find_brief_responses.return_value = {
             "briefResponses": [
                 {
                     "awardDetails": {"awardedContractStartDate": "2017-08-21", "awardedContractValue": "20000.00"},
@@ -777,7 +780,7 @@ class TestBriefPage(BaseBriefPageTest):
         self.login_as_supplier()
         self.brief['briefs']['status'] = 'closed'
 
-        self._data_api_client.find_brief_responses.return_value = {
+        self.data_api_client.find_brief_responses.return_value = {
             "briefResponses": [
                 {
                     "awardDetails": {"pending": True},
@@ -804,7 +807,7 @@ class TestBriefPage(BaseBriefPageTest):
     def test_supplier_applied_view_application_for_opportunity_awarded_to_other_supplier(self):
         self.login_as_supplier()
 
-        self._data_api_client.find_brief_responses.return_value = {
+        self.data_api_client.find_brief_responses.return_value = {
             "briefResponses": [
                 {
                     "awardDetails": {"awardedContractStartDate": "2017-08-21", "awardedContractValue": "20000.00"},
@@ -1145,9 +1148,9 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
             self._get_dos_brief_search_api_aggregations_response_user_research_fixture_data(),
         ]
 
-        self._data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
-        self._data_api_client = self._data_api_client_patch.start()
-        self._data_api_client.find_frameworks.return_value = {'frameworks': [
+        self.data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.find_frameworks.return_value = {'frameworks': [
             {
                 'id': 3,
                 'name': "Digital Outcomes and Specialists 2",
@@ -1190,7 +1193,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         ]}
 
     def teardown_method(self, method):
-        self._data_api_client_patch.stop()
+        self.data_api_client_patch.stop()
         self._view_search_api_client_patch.stop()
         self._presenters_search_api_client_patch.stop()
         super().teardown_method(method)
@@ -1203,7 +1206,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        self._data_api_client.find_frameworks.assert_called_once_with()
+        self.data_api_client.find_frameworks.assert_called_once_with()
 
         self._view_search_api_client.search.assert_called_once_with(
             index='briefs-digital-outcomes-and-specialists',
@@ -1270,7 +1273,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
 
         document = html.fromstring(res.get_data(as_text=True))
 
-        self._data_api_client.find_frameworks.assert_called_once_with()
+        self.data_api_client.find_frameworks.assert_called_once_with()
         self._view_search_api_client.search.assert_called_once_with(
             index='briefs-digital-outcomes-and-specialists',
             doc_type='briefs',
@@ -1363,7 +1366,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
 
         document = html.fromstring(res.get_data(as_text=True))
 
-        self._data_api_client.find_frameworks.assert_called_once_with()
+        self.data_api_client.find_frameworks.assert_called_once_with()
         self._view_search_api_client.search.assert_called_once_with(
             index='briefs-digital-outcomes-and-specialists',
             doc_type='briefs',
@@ -1455,7 +1458,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         assert res.status_code == 200
         document = html.fromstring(res.get_data(as_text=True))
 
-        self._data_api_client.find_frameworks.assert_called_once_with()
+        self.data_api_client.find_frameworks.assert_called_once_with()
 
         self._view_search_api_client.search.assert_called_once_with(
             index='briefs-digital-outcomes-and-specialists',
@@ -1576,7 +1579,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         res = self.client.get('/digital-giraffes-and-monkeys/opportunities')
 
         assert res.status_code == 404
-        self._data_api_client.find_frameworks.assert_called_once_with()
+        self.data_api_client.find_frameworks.assert_called_once_with()
 
     def test_briefs_search_has_js_hidden_filter_button(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')
@@ -1766,9 +1769,9 @@ class TestCatalogueOfBriefsFilterOnClick(BaseApplicationTest):
             self._get_dos_brief_search_api_aggregations_response_user_research_fixture_data(),
         ]
 
-        self._data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
-        self._data_api_client = self._data_api_client_patch.start()
-        self._data_api_client.find_frameworks.return_value = {'frameworks': [
+        self.data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+        self.data_api_client.find_frameworks.return_value = {'frameworks': [
             {
                 'id': 3,
                 'name': "Digital Outcomes and Specialists 2",
@@ -1782,7 +1785,7 @@ class TestCatalogueOfBriefsFilterOnClick(BaseApplicationTest):
         }
 
     def teardown_method(self, method):
-        self._data_api_client_patch.stop()
+        self.data_api_client_patch.stop()
         self._view_search_api_client_patch.stop()
         self._presenters_search_api_client_patch.stop()
         super().teardown_method(method)
@@ -1847,7 +1850,6 @@ class TestCatalogueOfBriefsFilterOnClick(BaseApplicationTest):
         assert len(filter_button) == 1
 
 
-@mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
 class TestGCloudHomepageLinks(BaseApplicationTest):
 
     mock_live_g_cloud_framework = {
@@ -1859,18 +1861,21 @@ class TestGCloudHomepageLinks(BaseApplicationTest):
 
     def setup_method(self, method):
         super().setup_method(method)
+        self.data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
 
     def teardown_method(self, method):
+        self.data_api_client_patch.stop()
         super().teardown_method(method)
 
     @pytest.mark.parametrize('framework_slug, gcloud_content',
                              (('g-cloud-8', 'Find cloud technology and support'),
                               ('g-cloud-9', 'Find cloud hosting, software and support')))
-    def test_g_cloud_homepage_content_is_correct(self, data_api_client, framework_slug, gcloud_content):
-        data_api_client.find_frameworks.return_value = {
+    def test_g_cloud_homepage_content_is_correct(self, framework_slug, gcloud_content):
+        self.data_api_client.find_frameworks.return_value = {
             "frameworks": [self.mock_live_g_cloud_framework.copy()]
         }
-        data_api_client.find_frameworks.return_value['frameworks'][0].update({'slug': framework_slug})
+        self.data_api_client.find_frameworks.return_value['frameworks'][0].update({'slug': framework_slug})
 
         res = self.client.get("/")
         document = html.fromstring(res.get_data(as_text=True))

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -13,7 +13,10 @@ from ...helpers import BaseApplicationTest
 
 class TestApplication(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestApplication, self).setup_method(method)
+        super().setup_method(method)
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     def test_analytics_code_should_be_in_javascript(self):
         res = self.client.get('/static/javascripts/application.js')
@@ -34,6 +37,13 @@ class TestApplication(BaseApplicationTest):
 
 @mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
 class TestHomepageAccountCreationVirtualPageViews(BaseApplicationTest):
+
+    def setup_method(self, method):
+        super().setup_method(method)
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
+
     def test_data_analytics_track_page_view_is_shown_if_account_created_flash_message(self, data_api_client):
         with self.client.session_transaction() as session:
             session['_flashes'] = [('track-page-view', 'buyers?account-created=true')]
@@ -77,6 +87,12 @@ class TestHomepageBrowseList(BaseApplicationTest):
         "status": "live",
         "id": 8
     }
+
+    def setup_method(self, method):
+        super().setup_method(method)
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     def test_dos_links_are_shown(self, data_api_client):
         data_api_client.find_frameworks.return_value = {
@@ -191,8 +207,12 @@ class TestHomepageBrowseList(BaseApplicationTest):
 
 
 class TestHomepageSidebarMessage(BaseApplicationTest):
+
     def setup_method(self, method):
-        super(TestHomepageSidebarMessage, self).setup_method(method)
+        super().setup_method(method)
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     @staticmethod
     def _find_frameworks(framework_slugs_and_statuses):
@@ -333,8 +353,12 @@ class TestHomepageSidebarMessage(BaseApplicationTest):
 
 
 class TestStaticMarketplacePages(BaseApplicationTest):
+
     def setup_method(self, method):
-        super(TestStaticMarketplacePages, self).setup_method(method)
+        super().setup_method(method)
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     def test_cookie_page(self):
         res = self.client.get('/cookies')
@@ -374,7 +398,7 @@ class TestStaticMarketplacePages(BaseApplicationTest):
 
 class BaseBriefPageTest(BaseApplicationTest):
     def setup_method(self, method):
-        super(BaseBriefPageTest, self).setup_method(method)
+        super().setup_method(method)
 
         self._data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
         self._data_api_client = self._data_api_client_patch.start()
@@ -387,6 +411,7 @@ class BaseBriefPageTest(BaseApplicationTest):
 
     def teardown_method(self, method):
         self._data_api_client_patch.stop()
+        super().teardown_method(method)
 
 
 class TestBriefPage(BaseBriefPageTest):
@@ -818,7 +843,7 @@ class TestBriefPage(BaseBriefPageTest):
 class TestBriefPageQandASectionViewQandASessionDetails(BaseBriefPageTest):
 
     def setup_method(self, method):
-        super(TestBriefPageQandASectionViewQandASessionDetails, self).setup_method(method)
+        super().setup_method(method)
         self.brief['briefs']['questionAndAnswerSessionDetails'] = {'many': 'details'}
         self.brief['briefs']['clarificationQuestionsAreClosed'] = False
 
@@ -896,7 +921,7 @@ class TestBriefPageQandASectionViewQandASessionDetails(BaseBriefPageTest):
 class TestBriefPageQandASectionAskAQuestion(BaseBriefPageTest):
 
     def setup_method(self, method):
-        super(TestBriefPageQandASectionAskAQuestion, self).setup_method(method)
+        super().setup_method(method)
         self.brief['briefs']['clarificationQuestionsAreClosed'] = False
 
     def test_live_brief_ask_a_question(self):
@@ -967,7 +992,7 @@ class TestBriefPageQandASectionAskAQuestion(BaseBriefPageTest):
 
 class TestAwardedBriefPage(BaseBriefPageTest):
     def setup_method(self, method):
-        super(TestAwardedBriefPage, self).setup_method(method)
+        super().setup_method(method)
         self.brief['briefs']['status'] = 'awarded'
         self.brief['briefs']['awardedBriefResponseId'] = 14276
 
@@ -1010,7 +1035,7 @@ class TestAwardedBriefPage(BaseBriefPageTest):
 
 class TestCancelledBriefPage(BaseBriefPageTest):
     def setup_method(self, method):
-        super(TestCancelledBriefPage, self).setup_method(method)
+        super().setup_method(method)
         self.brief['briefs']['status'] = 'cancelled'
 
     def test_cancelled_banner_shown_on_cancelled_brief_page(self):
@@ -1032,7 +1057,7 @@ class TestCancelledBriefPage(BaseBriefPageTest):
 
 class TestUnsuccessfulBriefPage(BaseBriefPageTest):
     def setup_method(self, method):
-        super(TestUnsuccessfulBriefPage, self).setup_method(method)
+        super().setup_method(method)
         self.brief['briefs']['status'] = 'unsuccessful'
 
     def test_unsuccessful_banner_shown_on_unsuccessful_brief_page(self):
@@ -1054,7 +1079,7 @@ class TestUnsuccessfulBriefPage(BaseBriefPageTest):
 
 class TestWithdrawnSpecificBriefPage(BaseBriefPageTest):
     def setup_method(self, method):
-        super(TestWithdrawnSpecificBriefPage, self).setup_method(method)
+        super().setup_method(method)
         self.brief['briefs']['status'] = "withdrawn"
         self.brief['briefs']['withdrawnAt'] = "2016-11-25T10:47:23.126761Z"
 
@@ -1104,7 +1129,7 @@ class TestWithdrawnSpecificBriefPage(BaseBriefPageTest):
 
 class TestCatalogueOfBriefsPage(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestCatalogueOfBriefsPage, self).setup_method(method)
+        super().setup_method(method)
 
         self._view_search_api_client_patch = mock.patch('app.main.views.marketplace.search_api_client', autospec=True)
         self._view_search_api_client = self._view_search_api_client_patch.start()
@@ -1168,6 +1193,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self._data_api_client_patch.stop()
         self._view_search_api_client_patch.stop()
         self._presenters_search_api_client_patch.stop()
+        super().teardown_method(method)
 
     def normalize_qs(self, qs):
         return {k: set(v) for k, v in parse_qs(qs).items() if k != "page"}
@@ -1759,6 +1785,7 @@ class TestCatalogueOfBriefsFilterOnClick(BaseApplicationTest):
         self._data_api_client_patch.stop()
         self._view_search_api_client_patch.stop()
         self._presenters_search_api_client_patch.stop()
+        super().teardown_method(method)
 
     @pytest.mark.parametrize('query_string, content_type',
                              (('', 'text/html; charset=utf-8'),
@@ -1829,6 +1856,12 @@ class TestGCloudHomepageLinks(BaseApplicationTest):
         "status": "live",
         "id": 5
     }
+
+    def setup_method(self, method):
+        super().setup_method(method)
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     @pytest.mark.parametrize('framework_slug, gcloud_content',
                              (('g-cloud-8', 'Find cloud technology and support'),

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -34,7 +34,7 @@ def get_0_results_search_response():
 
 class TestSearchResults(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestSearchResults, self).setup_method(method)
+        super().setup_method(method)
 
         self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
         self._search_api_client = self._search_api_client_patch.start()
@@ -52,6 +52,7 @@ class TestSearchResults(BaseApplicationTest):
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
         self._search_api_client_presenters_patch.stop()
+        super().teardown_method(method)
 
     def test_search_page_results_service_links(self):
         self._search_api_client.search.return_value = \
@@ -576,7 +577,7 @@ class TestSearchResults(BaseApplicationTest):
 
 class TestSearchFilterOnClick(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestSearchFilterOnClick, self).setup_method(method)
+        super().setup_method(method)
 
         self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
         self._search_api_client = self._search_api_client_patch.start()
@@ -596,6 +597,7 @@ class TestSearchFilterOnClick(BaseApplicationTest):
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
         self._search_api_client_presenters_patch.stop()
+        super().teardown_method(method)
 
     @pytest.mark.parametrize('query_string, content_type',
                              (('', 'text/html; charset=utf-8'),

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -5,7 +5,7 @@ from lxml import html
 import mock
 import pytest
 
-from ...helpers import BaseApplicationTest, data_api_client
+from ...helpers import BaseApplicationTest
 
 
 def find_pagination_links(res_data):
@@ -36,6 +36,11 @@ class TestSearchResults(BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
 
+        self.data_api_client_patch = mock.patch('app.main.views.g_cloud.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
+
+        self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
+
         self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
         self._search_api_client = self._search_api_client_patch.start()
 
@@ -52,6 +57,7 @@ class TestSearchResults(BaseApplicationTest):
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
         self._search_api_client_presenters_patch.stop()
+        self.data_api_client_patch.stop()
         super().teardown_method(method)
 
     def test_search_page_results_service_links(self):
@@ -444,8 +450,11 @@ class TestSearchResults(BaseApplicationTest):
             assert expected_lot_counts[category_name] == int(number_of_services)
 
     def test_search_results_sends_aggregation_request_without_page_filter(self):
-        data_api_client.find_frameworks.return_value = {'frameworks': [self._get_framework_fixture_data('g-cloud-9')
-                                                                       ['frameworks']]}
+        self.data_api_client.find_frameworks.return_value = {
+            'frameworks': [
+                self._get_framework_fixture_data('g-cloud-9')['frameworks']
+            ]
+        }
         self._search_api_client.search.return_value = self.search_results
 
         res = self.client.get('/g-cloud/search?page=2')

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -451,9 +451,7 @@ class TestSearchResults(BaseApplicationTest):
 
     def test_search_results_sends_aggregation_request_without_page_filter(self):
         self.data_api_client.find_frameworks.return_value = {
-            'frameworks': [
-                self._get_framework_fixture_data('g-cloud-9')['frameworks']
-            ]
+            'frameworks': [self._get_framework_fixture_data('g-cloud-9')['frameworks']]
         }
         self._search_api_client.search.return_value = self.search_results
 

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -29,7 +29,7 @@ class UnavailableBanner(object):
 class TestServicePage(BaseApplicationTest):
 
     def setup_method(self, method):
-        super(TestServicePage, self).setup_method(method)
+        super().setup_method(method)
 
         self.supplier = self._get_supplier_fixture_data()
 
@@ -43,6 +43,9 @@ class TestServicePage(BaseApplicationTest):
         self.lots = framework_helpers.get_lots_by_slug(
             self._get_framework_fixture_data('g-cloud-6')['frameworks']
         )
+
+    def teardown_method(self, method):
+        super().teardown_method(method)
 
     def _assert_contact_details(self, document):
 

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -8,7 +8,7 @@ from ...helpers import BaseApplicationTest
 
 class TestSuppliersPage(BaseApplicationTest):
     def setup_method(self, method):
-        super(TestSuppliersPage, self).setup_method(method)
+        super().setup_method(method)
 
         self._data_api_client_patch = mock.patch('app.main.suppliers.data_api_client', autospec=True)
         self._data_api_client = self._data_api_client_patch.start()
@@ -26,6 +26,7 @@ class TestSuppliersPage(BaseApplicationTest):
 
     def teardown_method(self, method):
         self._data_api_client_patch.stop()
+        super().teardown_method(method)
 
     def test_should_call_api_with_correct_params(self):
         self.client.get('/g-cloud/suppliers')

--- a/tests/status/views/test_status.py
+++ b/tests/status/views/test_status.py
@@ -10,27 +10,27 @@ class TestStatus(BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
 
-        self._data_api_client_patch = mock.patch('app.status.views.data_api_client', autospec=True)
-        self._data_api_client = self._data_api_client_patch.start()
+        self.data_api_client_patch = mock.patch('app.status.views.data_api_client', autospec=True)
+        self.data_api_client = self.data_api_client_patch.start()
 
-        self._search_api_client_patch = mock.patch('app.status.views.search_api_client', autospec=True)
-        self._search_api_client = self._search_api_client_patch.start()
+        self.search_api_client_patch = mock.patch('app.status.views.search_api_client', autospec=True)
+        self.search_api_client = self.search_api_client_patch.start()
 
     def teardown_method(self, method):
-        self._data_api_client_patch.stop()
-        self._search_api_client_patch.stop()
+        self.data_api_client_patch.stop()
+        self.search_api_client_patch.stop()
 
     def test_should_return_200_from_elb_status_check(self):
         status_response = self.client.get('/_status?ignore-dependencies')
         assert status_response.status_code == 200
-        assert self._data_api_client.called is False
+        assert self.data_api_client.called is False
 
     def test_status_ok(self):
-        self._data_api_client.get_status.return_value = {
+        self.data_api_client.get_status.return_value = {
             'status': 'ok'
         }
 
-        self._search_api_client.get_status.return_value = {
+        self.search_api_client.get_status.return_value = {
             'status': 'ok'
         }
 
@@ -42,13 +42,13 @@ class TestStatus(BaseApplicationTest):
         assert "{}".format(json_data['search_api_status']['status']) == "ok"
 
     def test_status_error_in_one_upstream_api(self):
-        self._data_api_client.get_status.return_value = {
+        self.data_api_client.get_status.return_value = {
             'status': 'error',
             'app_version': None,
             'message': 'Cannot connect to Database'
         }
 
-        self._search_api_client.get_status.return_value = {
+        self.search_api_client.get_status.return_value = {
             'status': 'ok'
         }
 
@@ -63,11 +63,11 @@ class TestStatus(BaseApplicationTest):
 
     def test_status_no_response_in_one_upstream_api(self):
 
-        self._data_api_client.get_status.return_value = {
+        self.data_api_client.get_status.return_value = {
             'status': 'ok'
         }
 
-        self._search_api_client.get_status.return_value = None
+        self.search_api_client.get_status.return_value = None
 
         response = self.client.get('/_status')
         assert response.status_code == 500
@@ -80,13 +80,13 @@ class TestStatus(BaseApplicationTest):
 
     def test_status_error_in_two_upstream_apis(self):
 
-        self._data_api_client.get_status.return_value = {
+        self.data_api_client.get_status.return_value = {
             'status': 'error',
             'app_version': None,
             'message': 'Cannot connect to Database'
         }
 
-        self._search_api_client.get_status.return_value = {
+        self.search_api_client.get_status.return_value = {
             'status': 'error',
             'app_version': None,
             'message': 'Cannot connect to elasticsearch'

--- a/tests/status/views/test_status.py
+++ b/tests/status/views/test_status.py
@@ -8,7 +8,7 @@ from ...helpers import BaseApplicationTest
 class TestStatus(BaseApplicationTest):
 
     def setup_method(self, method):
-        super(TestStatus, self).setup_method(method)
+        super().setup_method(method)
 
         self._data_api_client_patch = mock.patch('app.status.views.data_api_client', autospec=True)
         self._data_api_client = self._data_api_client_patch.start()


### PR DESCRIPTION
Part of the ongoing test refactor (see Briefs FE equivalent for details https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/93)

- Removes unnecessary `app.app_context` managers
- Python3 `super()` syntax
- Standardising `setup()` and `teardown()` methods across the tests
- Patch the `data_api_client` in the test class setup method. This is split into per-file commits for ease of reviewing.

This also required refactoring one of the helper functions `get_direct_award_projects` to accept the `data_api_client` instance as an argument, to avoid importing it twice  (and thus having to patch it twice). This is consistent with patterns used on the other helper functions.