### PR TITLE
Update cookies page to include new GA cookie in line with gov.uk

### DIFF
--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -74,6 +74,12 @@
                 </td>
                 <td>2 years</td>
             </tr>
+            <tr>
+                <td>_gid</td>
+                <td>Helps us count how many people visit the Digital Marketplace by tracking if you’ve visited the service before
+                </td>
+                <td>24 hours</td>
+            </tr>
              <tr>
                 <td>_gat</td>
                 <td>Used to manage the rate at which page view requests are made


### PR DESCRIPTION
https://trello.com/c/RNzdFVME/188-update-dm-cookies-with-gid-from-ga-inline-with-govuk

It looks like GA now has an _gid key for it's cookies. We need to add that to https://www.digitalmarketplace.service.gov.uk/cookies in line with
https://www.gov.uk/help/cookies

(Yes, it's the same as the one above, see here: https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage)