### PR TITLE
FE-1 Did you award a contract for 'Buying some hosting'? page details

### DIFF
--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -1,5 +1,6 @@
 from flask_wtf import FlaskForm
-from wtforms.validators import Length, Optional
+from wtforms.fields import RadioField
+from wtforms.validators import Length, Optional, InputRequired
 
 from dmutils.forms import StripWhitespaceStringField
 
@@ -12,5 +13,17 @@ class CreateProjectForm(FlaskForm):
                    max=100,
                    message="Names must be between 1 and 100 characters"),
             Optional()
+        ]
+    )
+
+
+class DidYouAwardAContractForm(FlaskForm):
+    did_you_award_a_contract = RadioField(
+        "Did you award a contract?",
+        validators=[InputRequired(message="You need to answer this question.")],
+        choices=[
+            ('yes', 'Yes'),
+            ('no', 'No'),
+            ('still-assessing', 'We are still assessing services')
         ]
     )

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -17,7 +17,7 @@ from dmutils.views import SimpleDownloadFileView
 
 from app import search_api_client, data_api_client, content_loader
 from ..exceptions import AuthException
-from ..forms.direct_award_forms import CreateProjectForm
+from ..forms.direct_award_forms import CreateProjectForm, DidYouAwardAContractForm
 from ..helpers.search_helpers import (
     get_keywords_from_request, pagination,
     get_page_from_request, query_args_for_pagination,
@@ -542,6 +542,61 @@ def end_search(framework_framework, project_id):
         disable_end_search_btn=disable_end_search_btn,
         search_count=search_count,
     )
+
+
+@direct_award.route(
+    '/<string:framework_framework>/projects/<int:project_id>/did-you-award-contract',
+    methods=['GET', 'POST']
+)
+def did_you_award_contract(framework_framework, project_id):
+    all_frameworks = data_api_client.find_frameworks().get('frameworks')
+    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_framework)
+
+    # Get the requested Direct Award Project.
+    project = data_api_client.get_direct_award_project(project_id=project_id)['project']
+
+    form = DidYouAwardAContractForm()
+    form.did_you_award_a_contract.options = [{"label": label, "value": value}
+                                             for value, label in form.did_you_award_a_contract.choices]
+
+    if form.validate_on_submit():
+        if form.did_you_award_a_contract.data == 'still-assessing':
+            return redirect(url_for('.view_project',
+                                    framework_framework=framework_framework,
+                                    project_id=project_id))
+        elif form.did_you_award_a_contract.data == 'yes':
+            return redirect(url_for('.which_service_won_contract',
+                                    framework_framework=framework_framework,
+                                    project_id=project_id))
+        elif form.did_you_award_a_contract.data == 'no':
+            return redirect(url_for('.why_didnt_you_award_contract',
+                                    framework_framework=framework_framework,
+                                    project_id=project_id))
+        else:
+            abort(500)  # this should never be reached
+
+    return render_template(
+        'direct-award/did-you-award-contract.html',
+        form=form,
+        project=project,
+        framework=framework
+    ), 200 if not form.errors else 400
+
+
+@direct_award.route(
+    '/<string:framework_framework>/projects/<int:project_id>/which-service-won-contract',
+    methods=['GET']
+)
+def which_service_won_contract(framework_framework, project_id):
+    pass
+
+
+@direct_award.route(
+    '/<string:framework_framework>/projects/<int:project_id>/why-didnt-you-award-contract',
+    methods=['GET']
+)
+def why_didnt_you_award_contract(framework_framework, project_id):
+    pass
 
 
 @direct_award.route('/<string:framework_framework>/projects/<int:project_id>/results')

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -1,0 +1,70 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+{% block page_title %}Did you award a contract? - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with
+    items = [
+      {
+        "link": url_for('main.index'),
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for('external.buyer_dashboard'),
+        "label": "Your account"
+      },
+      {
+        "link": url_for('direct_award.saved_search_overview', framework_framework=framework.framework),
+        "label": "Your saved searches"
+      },
+      {
+        "link": url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id),
+        "label": project.name
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+<div class="did-you-award-contract-page">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <header class="page-heading">
+        <h1>
+          Did you award a contract for '{{project.name}}'?
+        </h1>
+      </header>
+
+      <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_framework=framework.framework, project_id=project.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+
+        {%
+          with
+          name = "did_you_award_a_contract",
+          type = "radio",
+          value = form.did_you_award_a_contract.value,
+          error = form.did_you_award_a_contract.errors[0],
+          options = form.did_you_award_a_contract.options
+        %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
+
+        {%
+          with
+          type = "save",
+          label = "Save and continue"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+      </form>
+
+      <p><a href="{{ url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id) }}">Return to overview</a></p>
+    </div>
+  </div>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
[Trello](https://trello.com/c/yIUrcLLo/73-fe-1-did-you-award-a-contract-for-buying-some-hosting-page-details)

1. Added "Did you award a contract?" page
2. Created a `DidYouAwardAContractForm` class for validating the radio input
3. Created a test suite `TestDirectAwardAwardContract` for the page, HTML form, and redirects
4. Created a route function `award_contract` that passes the tests

Currently as there are no routes for `which-service-won-contract` and `why-didnt-you-award-contract` the tests for those have been passed by sliming.

Dealing with the "We are still assessing services" flow is in ticket [#110](https://trello.com/c/5Lrp1lOK/110-fe-8-we-are-still-assessing-flow)