### PR TITLE
Add Privacy notice page

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -86,6 +86,11 @@ def cookies():
     return render_template('content/cookies.html')
 
 
+@main.route('/privacy-notice')
+def privacy_notice():
+    return render_template('content/privacy-notice.html')
+
+
 @main.route('/terms-and-conditions')
 def terms_and_conditions():
     return render_template('content/terms-and-conditions.html')

--- a/app/templates/content/privacy-notice.html
+++ b/app/templates/content/privacy-notice.html
@@ -1,0 +1,167 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+{% block page_title %}How your data is used (‘Privacy Notice’) - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with
+    items = [
+      {
+          "link": url_for('.index'),
+          "label": "Digital Marketplace"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+  <div class="help-page grid-row legal-content">
+    <div class="column-two-thirds">
+
+      
+      <header class="page-heading">
+        <h1>How your data is used (‘Privacy Notice’)</h1>
+      </header>
+      <p>The Digital Marketplace is built and run by the Government Digital Service (GDS).</p>
+      <p>We collect your personal data as part of our service. We use it when you create user accounts on our platform, in order to buy or sell digital services. This is fully compliant with UK and EU law.</p>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">How and why your data is collected</h2>
+      </div>
+
+      <h3>What personal data we collect</h3>
+      <div class="check-list">
+        <p class="lead">We collect several points of personal data from our users. These are:</p>
+        <ul class="list-bullet">
+          <li>email addresses and contact details (phone number and address)</li>
+          <li>company and company contact information (suppliers only)</li>
+        </ul>
+      </div>
+
+      <h3>Your email address and contact details</h3>
+      <div class="check-list">
+        <p class="lead">When you give us your email we will only use it so that you can:</p>
+        <ul class="list-bullet">
+          <li>log in securely</li>
+          <li>be contacted about a particular contract, application or brief</li>
+          <li>receive updates from a mailing list you’ve subscribed to (for example if you’ve asked to be notified when a new framework opens)</li>
+        </ul>
+      </div>
+
+      <h3>Your company information</h3>
+      <div class="check-list">
+        <p>When suppliers register for the Digital Marketplace, they need to provide us with several pieces of data, including their company contact information.</p>
+        <p class="lead">We use that to:</p>
+        <ul class="list-bullet">
+          <li>inform buyers who they can get in touch with at your company</li>
+          <li>register a company on a framework to sell services</li>
+          <li>update suppliers on the status of their applications to frameworks or briefs</li>
+        </ul>
+      </div>
+      <p>You will always be told if the personal data you provide is going to be displayed on the Digital Marketplace.</p>
+
+      <h3>Cookies and analytics</h3>
+      <p>You can read our <a href="{{ url_for('.cookies') }}">full cookie policy</a> and to find out how we use cookies to track user journeys using Google Analytics.</p>
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">Sharing your information</h2>
+      </div>
+      <p>Some of your information is shared with the Crown Commercial Service (CCS) so they can manage the live services or frameworks and make sure spend data is collected correctly.</p>
+      <p>Your data is either shared directly from our database or through the admin function of the Digital Marketplace which gives staff access to the data they need to do their jobs.</p>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">How long your personal data is stored</h2>
+      </div>
+      <p>If you have an active account on the Digital Marketplace we will keep your data stored in our database for as long as you have an account.</p>
+
+      <h3>If your account becomes inactive</h3>
+      <p>We’ll keep your data for 3 years, this includes your email, username and password unless you ask us to delete it before then.</p>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">Children’s privacy protection</h2>
+      </div>
+      <p>We understand the importance of protecting children's privacy online. The Digital Marketplace is not designed for, or intentionally targeted at, children 13 years of age or younger. It is not our policy to intentionally collect or maintain data about anyone under the age of 13.</p>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">Where your data might go</h2>
+      </div>
+      <p>Your personal data may be transferred outside of the European Economic Area (EEA). If this happens, we’ll make sure wherever possible that you are given the same level of legal protection as within the EEA.</p>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">How we protect your data and keep it secure</h2>
+      </div>
+      <p>We follow industry standard best practices for keeping the your personal data secure, and to prevent unauthorised access or disclosure.</p>
+      <p>We also make sure that any third parties that we deal with have an obligation to keep all personal data they process on our behalf secure.</p>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">What are your rights</h2>
+      </div>
+      <div class="check-list">
+        <p class="lead">You have the right to ask for :</p>
+        <ul class="list-bullet">
+          <li>information about how your personal data is processed</li>
+          <li>a copy of all the personal data you’ve have given to us</li>
+          <li>any mistakes  about your personal data to be  corrected</li>
+          <li>your personal data to be  erased if there is no longer a need for us to hold it</li>
+        </ul>
+      </div>
+      <p>If your personal data is processed on the basis of consent, then you have the right to withdraw your consent at any time.</p>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">Changes to this notice</h2>
+      </div>
+      <p>We may modify or amend this privacy notice at any time. Any modification or amendment to this privacy notice will be applied to your data as of the revision date. We encourage you to review this privacy notice regularly to stay informed about how we are protecting your data.</p>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">Who controls your data</h2>
+      </div>
+      <p>The data controller for your personal data is the Cabinet Office.</p>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">How to contact us</h2>
+      </div>
+      <p>If you have any questions about anything in this document or if you believe your personal data has been misused or mishandled you can contact the Cabinet Office Data Protection Officer (DPO) at: <a href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a></p>
+      <p>Or by post at:</p>
+        <div class="application-notice">
+          <div class="application-notice">
+            <ul>
+              <li>Data Protection Officer</li>
+              <li>Cabinet Office</li>
+              <li>70 Whitehall</li>
+              <li><p>London SW1A 2AS</p></li>
+            </ul>
+          </div>
+        </div>
+
+
+      <div class="dmspeak">
+        <h2 class="heading-xmedium">Making a complaint to an independent body</h2>
+      </div>
+      <div class="check-list">
+        <p class="lead">You can make a complaint to the Information Commissioner’s Office (ICO) by:</p>
+        <ul class="list-bullet">
+          <li>emailing <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a></li>
+          <li>phoning <a href="tel:0303 123 1113">0303 123 1113</a></li>
+          <li>post:</li>
+            <div class="application-notice">
+              <p>Information Commissioner's Office</p>
+              <p>Wycliffe House</p>
+              <p>Water Lane</p>
+              <p>Wilmslow</p>
+              <p>Cheshire SK9 5AF</p>
+            </div>
+        </ul>
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
We require a 'Privacy Notice' to be GDPR compliant. Here it is!

Exactly the same content as in the Google doc which has been reviewed and signed off

See doc here:
https://docs.google.com/document/d/1vgzpO3faPv17doM6aaE1aAHgrhmwmcKcn44CFklaMTk/edit?ts=5a9d79f8#

See ticket here:
https://trello.com/c/KJvWWDaD/191-add-privacy-notice-as-new-page-with-link-in-dm-footer

After this is merged we need the fe toolkit ticket here to be merged then up all the frontends:
https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/438



![screen shot 2018-05-14 at 12 55 30](https://user-images.githubusercontent.com/3469840/39996064-43a001c2-5776-11e8-9435-b7a142a7fe05.png)
![screen shot 2018-05-14 at 12 55 49](https://user-images.githubusercontent.com/3469840/39996355-1b2c13ce-5777-11e8-974f-488acd2988f1.png)
![screen shot 2018-05-14 at 12 56 06](https://user-images.githubusercontent.com/3469840/39996086-4e433d42-5776-11e8-8296-334daec9421f.png)
<img width="636" alt="screen shot 2018-05-14 at 12 56 20" src="https://user-images.githubusercontent.com/3469840/39996088-51b807d2-5776-11e8-910d-e3db67cec0ad.png">
