### PR TITLE
Reduce limit on frozen saved searches to 30 (from 100)

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -40,7 +40,7 @@ from ..presenters.search_summary import SearchSummary
 from ..presenters.service_presenters import Service
 
 
-END_SEARCH_LIMIT = 100  # TODO: This should be done in the API.
+END_SEARCH_LIMIT = 30  # TODO: This should be done in the API.
 PROJECT_SAVED_MESSAGE = Markup("""Search saved.""")
 PROJECT_ENDED_MESSAGE = Markup("""Search ended. You can now download your search results.""")
 TOO_MANY_RESULTS_MESSAGE = Markup("""

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -445,7 +445,7 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
             "services": [],
             "meta": {
                 "query": {},
-                "total": 1000,
+                "total": 31,
                 "took": 3
             },
             "links": {}

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -12,7 +12,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 from dmcontent.content_loader import ContentLoader
 
 from app import search_api_client, content_loader
-from app.main.views.g_cloud import DownloadResultsView
+from app.main.views.g_cloud import DownloadResultsView, END_SEARCH_LIMIT
 from ...helpers import BaseApplicationTest
 
 
@@ -445,7 +445,7 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
             "services": [],
             "meta": {
                 "query": {},
-                "total": 31,
+                "total": END_SEARCH_LIMIT + 1,
                 "took": 3
             },
             "links": {}


### PR DESCRIPTION
As a buyer I want to limit the number of results I can "save" so that I don't need to compare so many results.

AC:
Reduce the saved search limit from 100 to 30.

Note: Only affect new saved searches from now on.

Ticket: https://trello.com/c/kZm5L3ho/77-reduce-limit-on-frozen-saved-searches-to-30-from-100