### PR TITLE
Updated G-Cloud too many results error message

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -44,7 +44,7 @@ END_SEARCH_LIMIT = 30  # TODO: This should be done in the API.
 PROJECT_SAVED_MESSAGE = Markup("""Search saved.""")
 PROJECT_ENDED_MESSAGE = Markup("""Search ended. You can now download your search results.""")
 TOO_MANY_RESULTS_MESSAGE = Markup("""
-    You have too many services to review. Refine your search terms until you have no more than 30 results.""")
+    You have too many services to review. Refine your search until you have no more than 30 results.""")
 
 
 @main.route('/g-cloud')

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -41,10 +41,10 @@ from ..presenters.service_presenters import Service
 
 
 END_SEARCH_LIMIT = 30  # TODO: This should be done in the API.
-PROJECT_SAVED_MESSAGE = Markup("""Search saved.""")
-PROJECT_ENDED_MESSAGE = Markup("""Search ended. You can now download your search results.""")
-TOO_MANY_RESULTS_MESSAGE = Markup("""
-    You have too many services to review. Refine your search until you have no more than 30 results.""")
+PROJECT_SAVED_MESSAGE = Markup("Search saved.")
+PROJECT_ENDED_MESSAGE = Markup("Search ended. You can now download your search results.")
+TOO_MANY_RESULTS_MESSAGE = Markup(f"You have too many services to review. Refine your search until you have no more "
+                                  f"than {END_SEARCH_LIMIT} results.")
 
 
 @main.route('/g-cloud')


### PR DESCRIPTION
Updated G-Cloud too many results error message

Amend to: https://trello.com/c/kZm5L3ho/77-reduce-limit-for-ending-a-search-to-30-from-100

@DilwoarH Will the content change break the tests? Does this need a version bump as well?