### PR TITLE
Update utils version to wrap errors from Mandrill code

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.2#egg=digitalmarketplace-utils==36.2.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.1#egg=digitalmarketplace-utils==36.10.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.2.2#egg=digitalmarketplace-utils==36.2.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.1#egg=digitalmarketplace-utils==36.10.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
@@ -24,7 +24,7 @@ cryptography==1.9
 docopt==0.4.0
 docutils==0.14
 Flask-FeatureFlags==0.6
-Flask-Script==2.0.5
+Flask-Script==2.0.6
 future==0.16.0
 idna==2.6
 inflection==0.3.1
@@ -39,8 +39,8 @@ monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.6.1
-python-dateutil==2.7.2
+PyJWT==1.6.3
+python-dateutil==2.7.3
 python-json-logger==0.1.4
 pytz==2015.4
 PyYAML==3.11


### PR DESCRIPTION
Connected to this pull request: https://github.com/alphagov/digitalmarketplace-utils/pull/393/files

@risicle @samuelhwilliams @Wynndow are you ok for below changes to go into buyer-frontend?
https://github.com/alphagov/digitalmarketplace-utils/compare/36.2.2...36.10.1

