### PR TITLE
Restrict opportunity pages

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -584,10 +584,10 @@ def did_you_award_contract(framework_family, project_id):
         else:
             abort(500)  # this should never be reached
 
-    errors = [{
-        'input_name': input_name,
-        'question': getattr(form, input_name).label,
-    } for input_name in form.errors.keys()]
+    errors = {
+        input_name: {'input_name': input_name, 'question': getattr(form, input_name).label}
+        for input_name in form.errors.keys()
+    }
 
     return render_template(
         'direct-award/did-you-award-contract.html',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#11.5.5",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.1#egg=digitalmarketplace-utils==36.10.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.11.1#egg=digitalmarketplace-utils==36.11.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.10.1#egg=digitalmarketplace-utils==36.10.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@36.11.1#egg=digitalmarketplace-utils==36.11.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
@@ -39,7 +39,7 @@ monotonic==0.3
 notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.6.3
+PyJWT==1.6.4
 python-dateutil==2.7.3
 python-json-logger==0.1.4
 pytz==2015.4

--- a/tests/fixtures/frameworks.json
+++ b/tests/fixtures/frameworks.json
@@ -50,7 +50,9 @@
       "name": "G-Cloud 7",
       "slug": "g-cloud-7",
       "status": "live",
-      "variations": {}
+      "variations": {},
+      "hasDirectAward": true,
+      "hasFurtherCompetition": false
     },
     {
       "allow_declaration_reuse": false,
@@ -102,7 +104,9 @@
       "name": "G-Cloud 6",
       "slug": "g-cloud-6",
       "status": "expired",
-      "variations": {}
+      "variations": {},
+      "hasDirectAward": true,
+      "hasFurtherCompetition": false
     },
     {
       "allow_declaration_reuse": true,
@@ -223,7 +227,9 @@
       "name": "G-Cloud 5",
       "slug": "g-cloud-5",
       "status": "expired",
-      "variations": {}
+      "variations": {},
+      "hasDirectAward": true,
+      "hasFurtherCompetition": false
     },
     {
       "allow_declaration_reuse": false,
@@ -275,7 +281,9 @@
       "name": "G-Cloud 4",
       "slug": "g-cloud-4",
       "status": "expired",
-      "variations": {}
+      "variations": {},
+      "hasDirectAward": true,
+      "hasFurtherCompetition": false
     },
     {
       "allow_declaration_reuse": true,
@@ -330,7 +338,9 @@
       "name": "Digital Outcomes and Specialists 2",
       "slug": "digital-outcomes-and-specialists-2",
       "status": "live",
-      "variations": {}
+      "variations": {},
+      "hasDirectAward": false,
+      "hasFurtherCompetition": true
     },
     {
       "allow_declaration_reuse": true,
@@ -382,7 +392,9 @@
       "name": "Digital Outcomes and Specialists",
       "slug": "digital-outcomes-and-specialists",
       "status": "live",
-      "variations": {}
+      "variations": {},
+      "hasDirectAward": false,
+      "hasFurtherCompetition": true
     },
     {
       "allow_declaration_reuse": false,
@@ -425,7 +437,9 @@
       "name": "G-Cloud 9",
       "slug": "g-cloud-9",
       "status": "live",
-      "variations": {}
+      "variations": {},
+      "hasDirectAward": true,
+      "hasFurtherCompetition": false
     }
   ]
 }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,7 @@ import json
 import mock
 from werkzeug.http import parse_cookie
 
+from dmutils import api_stubs
 from dmutils.formats import DATETIME_FORMAT
 
 from app import create_app, data_api_client
@@ -88,7 +89,45 @@ class BaseApplicationTest(object):
 
     @staticmethod
     def _get_frameworks_list_fixture_data():
-        return BaseApplicationTest._get_fixture_data('frameworks.json')
+        old_gcloud_lots = [api_stubs.lot(lot_id=1, slug='saas', name='Software as a Service'),
+                           api_stubs.lot(lot_id=2, slug='paas', name='Platform as a Service'),
+                           api_stubs.lot(lot_id=3, slug='iaas', name='Infrastructure as a Service'),
+                           api_stubs.lot(lot_id=4, slug='scs', name='Specialist Cloud Services')]
+
+        new_gcloud_lots = [api_stubs.lot(lot_id=1, slug='cloud-hosting', name='Cloud hosting'),
+                           api_stubs.lot(lot_id=2, slug='cloud-software', name='Cloud software'),
+                           api_stubs.lot(lot_id=3, slug='cloud-support', name='Cloud support')]
+
+        dos_lots = [api_stubs.lot(lot_id=5, slug='digital-outcomes', name='Digital outcomes', allows_brief=True),
+                    api_stubs.lot(lot_id=6, slug='digital-specialists', name='Digital specialists', allows_brief=True),
+                    api_stubs.lot(lot_id=7, slug='user-research-studios', name='User research studios'),
+                    api_stubs.lot(lot_id=8, slug='user-research-participants', name='User research participants',
+                                  allows_brief=True)]
+
+        g_cloud_8_variation = {
+            "1": {
+                "countersignedAt": "2016-10-05T11:00:00.000000Z",
+                "countersignerName": "Dan Saxby",
+                "countersignerRole": "Category Director",
+                "createdAt": "2016-08-19T15:31:00.000000Z"
+            }
+        }
+
+        frameworks = [
+            api_stubs.framework(framework_id=4, slug='g-cloud-7', status='live', lots=old_gcloud_lots),
+            api_stubs.framework(framework_id=1, slug='g-cloud-6', status='expired', lots=old_gcloud_lots),
+            api_stubs.framework(framework_id=6, slug='g-cloud-8', status='live', lots=old_gcloud_lots,
+                                framework_agreement_version='v1.0', framework_variations=g_cloud_8_variation),
+            api_stubs.framework(framework_id=3, slug='g-cloud-5', status='expired', lots=old_gcloud_lots),
+            api_stubs.framework(framework_id=2, slug='g-cloud-4', status='expired', lots=old_gcloud_lots),
+            api_stubs.framework(framework_id=7, slug='digital-outcomes-and-specialists-2', status='live',
+                                lots=dos_lots, framework_agreement_version='v1.0', has_further_competition=True),
+            api_stubs.framework(framework_id=5, slug='digital-outcomes-and-specialists', status='live',
+                                lots=dos_lots, framework_agreement_version='v1.0', has_further_competition=True),
+            api_stubs.framework(framework_id=8, slug='g-cloud-9', status='live', lots=new_gcloud_lots),
+        ]
+
+        return {'frameworks': [framework['frameworks'] for framework in frameworks]}
 
     @staticmethod
     def _get_g4_service_fixture_data():

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1766,17 +1766,12 @@ class TestCatalogueOfBriefsFilterOnClick(BaseApplicationTest):
 
         self.data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
-        self.data_api_client.find_frameworks.return_value = {'frameworks': [
-            {
-                'id': 3,
-                'name': "Digital Outcomes and Specialists 2",
-                'slug': "digital-outcomes-and-specialists-2",
-                'framework': "digital-outcomes-and-specialists",
-                'lots': [
-                    {'name': 'Digital outcomes', 'slug': 'digital-outcomes', 'allowsBrief': True}
-                ],
-                'status': 'live',
-            }]
+        self.data_api_client.find_frameworks.return_value = {
+            'frameworks': [
+                api_stubs.framework(framework_id=3, slug='digital-outcomes-and-specialists-2', status='live',
+                                    lots=[api_stubs.lot(slug='digital-outcomes', name='Digital outcomes',
+                                                        allows_brief=True)], has_further_competition=True)['frameworks']
+            ]
         }
 
     def teardown_method(self, method):

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -10,6 +10,8 @@ import pytest
 
 from ...helpers import BaseApplicationTest
 
+from dmutils import api_stubs
+
 
 class TestApplication(BaseApplicationTest):
 
@@ -404,6 +406,7 @@ class BaseBriefPageTest(BaseApplicationTest):
         self.brief = self._get_dos_brief_fixture_data()
         self.brief_responses = self._get_dos_brief_responses_fixture_data()
         self.brief_id = self.brief['briefs']['id']
+        self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
         self.data_api_client.get_brief.return_value = self.brief
         self.data_api_client.find_brief_responses.return_value = self.brief_responses
 
@@ -413,6 +416,16 @@ class BaseBriefPageTest(BaseApplicationTest):
 
 
 class TestBriefPage(BaseBriefPageTest):
+
+    @pytest.mark.parametrize('framework_family, expected_status_code',
+                             (
+                                 ('digital-outcomes-and-specialists', 200),
+                                 ('g-cloud', 404),
+                             ))
+    def test_404_on_framework_that_does_not_support_further_competition(self, framework_family, expected_status_code):
+        brief_id = self.brief['briefs']['id']
+        res = self.client.get(f'/{framework_family}/opportunities/{brief_id}')
+        assert res.status_code == expected_status_code
 
     def test_dos_brief_404s_if_brief_is_draft(self):
         self.brief['briefs']['status'] = 'draft'
@@ -1145,46 +1158,24 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
 
         self.data_api_client_patch = mock.patch('app.main.views.marketplace.data_api_client', autospec=True)
         self.data_api_client = self.data_api_client_patch.start()
+
+        dos_lots = [api_stubs.lot(slug='digital-outcomes', name='Digital outcomes', allows_brief=True),
+                    api_stubs.lot(slug='digital-specialists', name='Digital specialists', allows_brief=True),
+                    api_stubs.lot(slug='user-research-participants', name='User research participants',
+                                  allows_brief=True),
+                    api_stubs.lot(slug='user-research-studios', name='User research studios', allows_brief=False)]
+
+        gcloud_lots = [api_stubs.lot(slug='cloud-hosting', allows_brief=True),
+                       api_stubs.lot(slug='cloud-software', allows_brief=False),
+                       api_stubs.lot(slug='cloud-support', allows_brief=True)]
+
         self.data_api_client.find_frameworks.return_value = {'frameworks': [
-            {
-                'id': 3,
-                'name': "Digital Outcomes and Specialists 2",
-                'slug': "digital-outcomes-and-specialists-2",
-                'framework': "digital-outcomes-and-specialists",
-                'lots': [
-                    {'name': 'Digital outcomes', 'slug': 'digital-outcomes', 'allowsBrief': True},
-                    {'name': 'Digital specialists', 'slug': 'digital-specialists', 'allowsBrief': True},
-                    {'name': 'User research participants', 'slug': 'user-research-participants', 'allowsBrief': True},
-                    {'name': 'User research studios', 'slug': 'user-research-studios', 'allowsBrief': False},
-                ],
-                'status': 'live',
-            },
-            {
-                'id': 1,
-                'name': "Digital Outcomes and Specialists",
-                'slug': "digital-outcomes-and-specialists",
-                'framework': "digital-outcomes-and-specialists",
-                'lots': [
-                    {'name': 'Lot 1', 'slug': 'lot-one', 'allowsBrief': True},
-                    {'name': 'Lot 2', 'slug': 'lot-two', 'allowsBrief': False},
-                    {'name': 'Lot 3', 'slug': 'lot-three', 'allowsBrief': True},
-                    {'name': 'Lot 4', 'slug': 'lot-four', 'allowsBrief': True},
-                ],
-                'status': 'expired',
-            },
-            {
-                'id': 2,
-                'name': "Foobar",
-                'slug': "foobar",
-                'framework': "foobar",
-                'lots': [
-                    {'name': 'Lot 1', 'slug': 'lot-one', 'allowsBrief': True},
-                    {'name': 'Lot 2', 'slug': 'lot-two', 'allowsBrief': False},
-                    {'name': 'Lot 3', 'slug': 'lot-three', 'allowsBrief': True},
-                    {'name': 'Lot 4', 'slug': 'lot-four', 'allowsBrief': True},
-                ],
-                'status': 'expired',
-            },
+            api_stubs.framework(framework_id=3, slug='digital-outcomes-and-specialists-2', status='live',
+                                lots=dos_lots, has_further_competition=True)['frameworks'],
+            api_stubs.framework(framework_id=1, slug='digital-outcomes-and-specialists', status='expired',
+                                lots=dos_lots, has_further_competition=True)['frameworks'],
+            api_stubs.framework(framework_id=2, slug='foobar', status='expired', lots=gcloud_lots)['frameworks'],
+            api_stubs.framework(framework_id=4, slug='g-cloud-9', status='live', lots=gcloud_lots)['frameworks']
         ]}
 
     def teardown_method(self, method):
@@ -1195,6 +1186,15 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
 
     def normalize_qs(self, qs):
         return {k: set(v) for k, v in parse_qs(qs).items() if k != "page"}
+
+    @pytest.mark.parametrize('framework_family, expected_status_code',
+                             (
+                                 ('digital-outcomes-and-specialists', 200),
+                                 ('g-cloud', 404),
+                             ))
+    def test_404_on_framework_that_does_not_support_further_competition(self, framework_family, expected_status_code):
+        res = self.client.get(f'/{framework_family}/opportunities')
+        assert res.status_code == expected_status_code
 
     def test_catalogue_of_briefs_page(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "11.5.5"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#a8cd0937a73adfb3498a70ae02135ac2691f8c20"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v28.15.0":
-  version "28.15.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#05167f7a96843fe3e893448a64770ec9dd01684c"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v29.0.0":
+  version "29.0.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87b8535689b160c26c0ac53d9d6bb96cde10c277"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
 ## Summary
We have some opportunity routes that accept a framework family in the
route. Where this is the case, we should check that the framework
actually supports opportunity-style views before rendering a response.

 ## Ticket
https://trello.com/c/WruHrcBf/456