### PR TITLE
Rename framework_framework variable

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -325,10 +325,10 @@ def search_services():
     )
 
 
-@direct_award.route('/<string:framework_framework>', methods=['GET'])
-def saved_search_overview(framework_framework):
+@direct_award.route('/<string:framework_family>', methods=['GET'])
+def saved_search_overview(framework_family):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_framework)
+    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
 
     if not framework:
         abort(404)
@@ -348,16 +348,16 @@ def saved_search_overview(framework_framework):
     )
 
 
-@direct_award.route('/<string:framework_framework>/projects', methods=['GET'])
-def view_projects(framework_framework):
-    return redirect(url_for('.saved_search_overview', framework_framework=framework_framework))
+@direct_award.route('/<string:framework_family>/projects', methods=['GET'])
+def view_projects(framework_family):
+    return redirect(url_for('.saved_search_overview', framework_family=framework_family))
 
 
-@direct_award.route('/<string:framework_framework>/save-search', methods=['GET', 'POST'])
-def save_search(framework_framework):
+@direct_award.route('/<string:framework_family>/save-search', methods=['GET', 'POST'])
+def save_search(framework_family):
     # Get core data
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_framework)
+    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
     lots_by_slug = framework_helpers.get_lots_by_slug(framework)
 
     search_query = url_decode(request.values.get('search_query'))
@@ -404,7 +404,7 @@ def save_search(framework_framework):
                                search_url=url_for('main.search_services', **search_query),
                                request=request,
                                projects=projects,
-                               framework_framework=framework_framework), 400 if request.method == 'POST' else 200
+                               framework_family=framework_family), 400 if request.method == 'POST' else 200
 
     elif save_search_selection == "new_search" and name:
         try:
@@ -437,13 +437,13 @@ def save_search(framework_framework):
     flash(PROJECT_SAVED_MESSAGE, 'success')
 
     return redirect(url_for('.view_project',
-                            framework_framework=framework_framework,
+                            framework_family=framework_family,
                             project_id=project['id']
                             ), code=303)
 
 
-@direct_award.route('/<string:framework_framework>/projects/<int:project_id>', methods=['GET'])
-def view_project(framework_framework, project_id):
+@direct_award.route('/<string:framework_family>/projects/<int:project_id>', methods=['GET'])
+def view_project(framework_family, project_id):
     frameworks_by_slug = framework_helpers.get_frameworks_by_slug(data_api_client)
     # Get the requested Direct Award Project.
     project = data_api_client.get_direct_award_project(project_id=project_id)['project']
@@ -496,10 +496,10 @@ def view_project(framework_framework, project_id):
                            customer_benefits_record_form_email=framework_urls['customer_benefits_record_form_email'])
 
 
-@direct_award.route('/<string:framework_framework>/projects/<int:project_id>/end-search', methods=['GET', 'POST'])
-def end_search(framework_framework, project_id):
+@direct_award.route('/<string:framework_family>/projects/<int:project_id>/end-search', methods=['GET', 'POST'])
+def end_search(framework_family, project_id):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_framework)
+    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
     frameworks_by_slug = framework_helpers.get_frameworks_by_slug(data_api_client)
 
     # Get the requested Direct Award Project.
@@ -533,7 +533,7 @@ def end_search(framework_framework, project_id):
 
         flash(PROJECT_ENDED_MESSAGE, 'success')
 
-        return redirect(url_for('.view_project', framework_framework=framework_framework, project_id=project['id']))
+        return redirect(url_for('.view_project', framework_family=framework_family, project_id=project['id']))
 
     return render_template(
         'direct-award/end-search.html',
@@ -545,12 +545,12 @@ def end_search(framework_framework, project_id):
 
 
 @direct_award.route(
-    '/<string:framework_framework>/projects/<int:project_id>/did-you-award-contract',
+    '/<string:framework_family>/projects/<int:project_id>/did-you-award-contract',
     methods=['GET', 'POST']
 )
-def did_you_award_contract(framework_framework, project_id):
+def did_you_award_contract(framework_family, project_id):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_framework)
+    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
 
     # Get the requested Direct Award Project.
     project = data_api_client.get_direct_award_project(project_id=project_id)['project']
@@ -566,15 +566,15 @@ def did_you_award_contract(framework_framework, project_id):
     if form.validate_on_submit():
         if form.did_you_award_a_contract.data == form.STILL_ASSESSING:
             return redirect(url_for('.view_project',
-                                    framework_framework=framework_framework,
+                                    framework_family=framework_family,
                                     project_id=project_id))
         elif form.did_you_award_a_contract.data == form.YES:
             return redirect(url_for('.which_service_won_contract',
-                                    framework_framework=framework_framework,
+                                    framework_family=framework_family,
                                     project_id=project_id))
         elif form.did_you_award_a_contract.data == form.NO:
             return redirect(url_for('.why_didnt_you_award_contract',
-                                    framework_framework=framework_framework,
+                                    framework_family=framework_family,
                                     project_id=project_id))
         else:
             abort(500)  # this should never be reached
@@ -594,23 +594,23 @@ def did_you_award_contract(framework_framework, project_id):
 
 
 @direct_award.route(
-    '/<string:framework_framework>/projects/<int:project_id>/which-service-won-contract',
+    '/<string:framework_family>/projects/<int:project_id>/which-service-won-contract',
     methods=['GET']
 )
-def which_service_won_contract(framework_framework, project_id):
+def which_service_won_contract(framework_family, project_id):
     abort(404)
 
 
 @direct_award.route(
-    '/<string:framework_framework>/projects/<int:project_id>/why-didnt-you-award-contract',
+    '/<string:framework_family>/projects/<int:project_id>/why-didnt-you-award-contract',
     methods=['GET']
 )
-def why_didnt_you_award_contract(framework_framework, project_id):
+def why_didnt_you_award_contract(framework_family, project_id):
     abort(404)
 
 
-@direct_award.route('/<string:framework_framework>/projects/<int:project_id>/results')
-def search_results(framework_framework, project_id):
+@direct_award.route('/<string:framework_family>/projects/<int:project_id>/results')
+def search_results(framework_family, project_id):
     # Get the requested Direct Award Project.
     project = data_api_client.get_direct_award_project(project_id=project_id)['project']
     if not is_direct_award_project_accessible(project, current_user.id):
@@ -794,6 +794,6 @@ class DownloadResultsView(SimpleDownloadFileView):
         return file_rows, column_styles
 
 
-direct_award.add_url_rule('/<string:framework_framework>/projects/<int:project_id>/results/download',
+direct_award.add_url_rule('/<string:framework_family>/projects/<int:project_id>/results/download',
                           view_func=DownloadResultsView.as_view(str('download_results')),
                           methods=['GET'])

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -117,12 +117,12 @@ def external_404():
     return html.tostring(document), 404
 
 
-@main.route('/<framework_framework>/opportunities/<brief_id>')
-def get_brief_by_id(framework_framework, brief_id):
+@main.route('/<framework_family>/opportunities/<brief_id>')
+def get_brief_by_id(framework_family, brief_id):
     briefs = data_api_client.get_brief(brief_id)
     brief = briefs.get('briefs')
 
-    if brief['status'] not in PUBLISHED_BRIEF_STATUSES or brief['frameworkFramework'] != framework_framework:
+    if brief['status'] not in PUBLISHED_BRIEF_STATUSES or brief['frameworkFramework'] != framework_family:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
 
     brief_responses = data_api_client.find_brief_responses(
@@ -139,7 +139,7 @@ def get_brief_by_id(framework_framework, brief_id):
 
     brief_responses_stats = count_brief_responses_by_size_and_status(brief_responses)
 
-    if brief['status'] not in PUBLISHED_BRIEF_STATUSES or brief['frameworkFramework'] != framework_framework:
+    if brief['status'] not in PUBLISHED_BRIEF_STATUSES or brief['frameworkFramework'] != framework_family:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
     try:
         has_supplier_responded_to_brief = (

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -15,11 +15,11 @@
         "label": "Your account"
       },
       {
-        "link": url_for('direct_award.saved_search_overview', framework_framework=framework.framework),
+        "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
         "label": "Your saved searches"
       },
       {
-        "link": url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
         "label": project.name
       }
     ]
@@ -43,7 +43,7 @@
         </h1>
       </header>
 
-      <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_framework=framework.framework, project_id=project.id) }}">
+      <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
         {%
@@ -66,7 +66,7 @@
         {% endwith %}
       </form>
 
-      <p><a href="{{ url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id) }}">Return to overview</a></p>
+      <p><a href="{{ url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id) }}">Return to overview</a></p>
     </div>
   </div>
 

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -15,11 +15,11 @@
         "label": "Your account"
       },
       {
-        "link": url_for('direct_award.saved_search_overview', framework_framework=framework.framework),
+        "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
         "label": "Your saved searches"
       },
       {
-        "link": url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
         "label": project.name
       }
     ]
@@ -58,7 +58,7 @@
 
       <br>
       <form
-        action="{{ url_for('direct_award.end_search', framework_framework=framework.framework, project_id=project.id) }}"
+        action="{{ url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id) }}"
         method="POST"
         >
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
@@ -71,7 +71,7 @@
           >End search and continue</button>
       </form>
       
-      <p><a href="{{ url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id) }}">Return to overview</a></p>      
+      <p><a href="{{ url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id) }}">Return to overview</a></p>
     </div>
   </div>
 

--- a/app/templates/direct-award/index.html
+++ b/app/templates/direct-award/index.html
@@ -41,7 +41,7 @@
       field_headings_visible=True
     ) %}
       {% call summary.row() %}
-        {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_framework=framework.framework, project_id=item.id)) }}
+        {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_family=framework.framework, project_id=item.id)) }}
         {{ summary.text(item.createdAt | datetimeformat ) }}
       {% endcall %}
     {% endcall %}
@@ -56,7 +56,7 @@
       field_headings_visible=True
     ) %}
       {% call summary.row() %}
-        {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_framework=framework.framework, project_id=item.id)) }}
+        {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_family=framework.framework, project_id=item.id)) }}
         {{ summary.text(item.lockedAt | datetimeformat ) }}
       {% endcall %}
     {% endcall %}

--- a/app/templates/direct-award/results.html
+++ b/app/templates/direct-award/results.html
@@ -15,11 +15,11 @@
         "label": "Your account"
       },
       {
-        "link": url_for('direct_award.saved_search_overview', framework_framework=framework.framework),
+        "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
         "label": "Your saved searches"
       },
       {
-        "link": url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
         "label": project.name
       }
     ]
@@ -56,7 +56,7 @@
       items = [
           {
               "title": "Download search results as a spreadsheet",
-              "link": url_for('direct_award.download_results', framework_framework=framework.framework, project_id=project.id, filetype='ods'),
+              "link": url_for('direct_award.download_results', framework_family=framework.framework, project_id=project.id, filetype='ods'),
               "file_type": "ODS",
               "analytics": "trackEvent",
               "analytics_category": "Direct Award",
@@ -65,7 +65,7 @@
           },
           {
               "title": "Download search results as comma-separated values",
-              "link": url_for('direct_award.download_results', framework_framework=framework.framework, project_id=project.id, filetype='csv'),
+              "link": url_for('direct_award.download_results', framework_family=framework.framework, project_id=project.id, filetype='csv'),
               "file_type": "CSV",
               "analytics": "trackEvent",
               "analytics_category": "Direct Award",
@@ -81,7 +81,7 @@
     <h2>After you download your search results</h2>
       <p>Review or compare services to find the cheapest or best value for money.<br>You can use the spreadsheet to help record your decisions.<br>Read the <a href="{{ framework_urls.buyers_guide_compare_services_url }}">{{ framework.framework|title }} Buyers' Guide</a> for details
     of how to compare services.</p>
-      <p><a href="{{ url_for('direct_award.view_project', framework_framework=framework.framework, project_id=project.id) }}">Return to overview</a></p>
+      <p><a href="{{ url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id) }}">Return to overview</a></p>
     </div>
   </div>
 </div>

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -27,7 +27,7 @@
           "label": "Your account"
       },
       {
-          "link": url_for('direct_award.saved_search_overview', framework_framework=framework.framework),
+          "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
           "label": "Your saved searches"
       }
     ]
@@ -84,7 +84,7 @@
             "custom_body_list": [
               {"type": "text", "text": "End your search to create a spreadsheet of the services you’ve found. You should only do this when you have finished searching for services."},
               {"type": "text", "text": "You cannot edit your search once it has ended."},
-              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not search.createdAt else {"type": "action", "label": "End search", "href": url_for('direct_award.end_search', framework_framework=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"} if not search.searchedAt else {"type": "box", "style": "complete", "label": ''.join(["Search ended on ", search.searchedAt|datetimeformat()])}
+              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not search.createdAt else {"type": "action", "label": "End search", "href": url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"} if not search.searchedAt else {"type": "box", "style": "complete", "label": ''.join(["Search ended on ", search.searchedAt|datetimeformat()])}
             ]
           },
           {
@@ -95,8 +95,8 @@
                 data-analytics-category=\"Direct Award\"
                 data-analytics-action=\"External Link\"
                 >compare services</a>."])|safe},
-              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not search.searchedAt else {"type": "action", "label": "Download search results", "href": url_for('direct_award.search_results', framework_framework=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"} if not project.downloadedAt else {"type": "box", "style": "complete", "label": "Search results downloaded"},
-              {"type": "text", "text": ''.join(["<a href=\"", url_for('direct_award.search_results', framework_framework=framework.framework, project_id=project.id)|e, "\"
+              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not search.searchedAt else {"type": "action", "label": "Download search results", "href": url_for('direct_award.search_results', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"} if not project.downloadedAt else {"type": "box", "style": "complete", "label": "Search results downloaded"},
+              {"type": "text", "text": ''.join(["<a href=\"", url_for('direct_award.search_results', framework_family=framework.framework, project_id=project.id)|e, "\"
                 data-analytics=\"trackEvent\"
                 data-analytics-category=\"Direct Award\"
                 data-analytics-action=\"Internal Link\"

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -1,7 +1,7 @@
 {% for brief in briefs %}
 <div class="search-result">
     <h2 class="search-result-title">
-        <a href="{{ url_for('.get_brief_by_id', framework_framework=framework_family, brief_id=brief.id) }}">{{ brief.title }}</a>
+        <a href="{{ url_for('.get_brief_by_id', framework_family=framework_family, brief_id=brief.id) }}">{{ brief.title }}</a>
     </h2>
 
     <ul class="search-result-important-metadata">

--- a/app/templates/search/_services_save_search.html
+++ b/app/templates/search/_services_save_search.html
@@ -1,5 +1,5 @@
 <div id="js-dm-live-save-search-form">
-  <form action="{{ url_for('direct_award.save_search', framework_framework=framework_family) }}">
+  <form action="{{ url_for('direct_award.save_search', framework_family=framework_family) }}">
     <input type="hidden" name="search_query" value="{{ search_query_url }}">
     <div class="button-save-wrapper grid-row">
       <div class="save-summary-text column-three-quarters">


### PR DESCRIPTION
 ## Summary
`framework_framework` is an unnecessarily obtuse variable name and is
not overly descriptive of what it actually means. When used, this
describes the 'family' of framework being referenced. For example,
G-Cloud 10 is in the 'G-Cloud' family of frameworks. Digital Outcomes
and Specialists 2 is in the 'Digital Outcomes and Specialists' family.
Let's change all the references of `framework_framework` to
`framework_family`

 ## Ticket
https://trello.com/c/iqFcVKpd/14