### PR TITLE
Delete PERMANENT_SESSION_LIFETIME variable from config

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,8 +16,6 @@ class Config(object):
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SECURE = True
 
-    PERMANENT_SESSION_LIFETIME = 4 * 3600
-
     WTF_CSRF_ENABLED = True
     WTF_CSRF_TIME_LIMIT = None
 


### PR DESCRIPTION
We delete PERMANENT_SESSION_LIFETIME variable from config, as the one in user-frontend is enough for all frontends. The session lifetime in user-frontend has been reduced from 4 hours to 1 hour.

Trello ticket: https://trello.com/c/KvdDwvnk/400-inadequate-session-timeout