### PR TITLE
New states for stage 6 on search summary (task list) page

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -480,6 +480,20 @@ def view_project(framework_family, project_id):
     content_loader.load_messages(framework['slug'], ['urls'])
     framework_urls = content_loader.get_message(framework['slug'], 'urls')
 
+    # Project outcome
+
+    project_outcome_label = None
+
+    if project['outcome'] and project['outcome']['result'] == "cancelled":
+        project_outcome_label = "The work has been cancelled"
+    elif project['outcome'] and project['outcome']['result'] == "none-suitable":
+        project_outcome_label = "No suitable services found"
+    elif project['outcome'] and project['outcome']['result'] == "awarded":
+        archived_service_id = project['outcome']['resultOfDirectAward']['archivedService']['id']
+        archived_service = data_api_client.get_archived_service(archived_service_id=archived_service_id)['services']
+        project_outcome_label = \
+            "Contract awarded to {}: {}".format(archived_service['supplierName'], archived_service['serviceName'])
+
     # Current Project Stage
     current_project_stage = None
 
@@ -507,7 +521,8 @@ def view_project(framework_family, project_id):
                            framework_urls=framework_urls,
                            call_off_contract_url=framework_urls['call_off_contract_url'],
                            customer_benefits_record_form_url=framework_urls['customer_benefits_record_form_url'],
-                           customer_benefits_record_form_email=framework_urls['customer_benefits_record_form_email'])
+                           customer_benefits_record_form_email=framework_urls['customer_benefits_record_form_email'],
+                           project_outcome_label=project_outcome_label)
 
 
 @direct_award.route('/<string:framework_family>/projects/<int:project_id>/end-search', methods=['GET', 'POST'])

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -104,7 +104,9 @@
                 data-analytics-action=\"External Link\"
                 >how to award a contract when you buy services</a>."])|safe},
               {"type": "text", "text": ''.join(["The buyer and supplier must both sign a copy of the contract before the service can be used."])|safe},
-              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not project.downloadedAt else {}
+              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not search.searchedAt
+              else {"type": "box", "style": "complete", "label": project_outcome_label } if project.outcome
+              else {"type": "action", "label": "Tell us the outcome", "href": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"}
             ]
           },
           {

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -340,7 +340,8 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
         assert self._task_has_link(tasklist, 5,
                                    '/buyers/direct-award/g-cloud/projects/1/results') is True
 
-        assert self._cannot_start_from_task(tasklist, 6) is True
+        assert self._task_has_link(tasklist, 6,
+                                   '/buyers/direct-award/g-cloud/projects/1/did-you-award-contract') is True
 
     def test_overview_renders_specific_elements_for_search_downloaded_state(self):
         searches = self._get_direct_award_project_searches_fixture()


### PR DESCRIPTION
As a user I want to see the state of my procurement / saved search.

States:

+ Contract awarded to x
+ No suitable services
+ The work has been canceled
+ Can't start yet (if the search isn't locked yet)
+ Tell us the outcome

https://docs.google.com/document/d/1uX__E-5tPWLWKQpX0w-2Dn3WzjLqeEg3JlBYnTFHhJU/edit#

Ticket: https://trello.com/c/2rthNi7A/71-new-states-for-stage-6-on-search-summary-task-list-page