### PR TITLE
Consolidate validation mastheads

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -10,6 +10,7 @@ from werkzeug.urls import Href, url_encode, url_decode
 from dmapiclient import HTTPError
 from dmcontent.formats import format_service_price
 from dmcontent.questions import Pricing
+from dmutils.forms import get_errors_from_wtform
 from dmutils.formats import dateformat, DATETIME_FORMAT, datetimeformat
 from dmutils.filters import capitalize_first
 from dmutils.ods import A as AnchorElement
@@ -574,7 +575,6 @@ def did_you_award_contract(framework_family, project_id):
         abort(400)
 
     form = DidYouAwardAContractForm()
-
     if form.validate_on_submit():
         if form.did_you_award_a_contract.data == form.STILL_ASSESSING:
             return redirect(url_for('.view_project',
@@ -591,10 +591,7 @@ def did_you_award_contract(framework_family, project_id):
         else:
             abort(500)  # this should never be reached
 
-    errors = {
-        input_name: {'input_name': input_name, 'question': getattr(form, input_name).label}
-        for input_name in form.errors.keys()
-    }
+    errors = get_errors_from_wtform(form)
 
     return render_template(
         'direct-award/did-you-award-contract.html',
@@ -602,7 +599,7 @@ def did_you_award_contract(framework_family, project_id):
         errors=errors,
         project=project,
         framework=framework
-    ), 200 if not form.errors else 400
+    ), 200 if not errors else 400
 
 
 @direct_award.route(
@@ -644,10 +641,7 @@ def which_service_won_contract(framework_family, project_id):
         flash('Contract awarded.')
         return redirect(url_for('.view_project', framework_family=framework_family, project_id=project['id']))
 
-    errors = [{
-        'input_name': input_name,
-        'question': getattr(form, input_name).label,
-    } for input_name in form.errors.keys()]
+    errors = get_errors_from_wtform(form)
 
     return render_template(
         'direct-award/which-service-won-contract.html',
@@ -656,7 +650,7 @@ def which_service_won_contract(framework_family, project_id):
         framework=framework,
         services=services,
         form=form,
-    ), 200
+    ), 200 if not errors else 400
 
 
 @direct_award.route(
@@ -678,14 +672,11 @@ def why_did_you_not_award_the_contract(framework_family, project_id):
 
     form = WhyDidYouNotAwardForm()
 
-    if request.method == "POST" and form.validate_on_submit():
+    if form.validate_on_submit():
         flash('You’ve updated ‘' + project['name'] + '’')
         return redirect(url_for('.view_project', framework_family=framework_family, project_id=project['id']))
 
-    errors = [{
-        'input_name': input_name,
-        'question': getattr(form, input_name).label,
-    } for input_name in form.errors.keys()]
+    errors = get_errors_from_wtform(form)
 
     return render_template(
         'direct-award/why-didnt-you-award-contract.html',
@@ -693,7 +684,7 @@ def why_did_you_not_award_the_contract(framework_family, project_id):
         framework=framework,
         form=form,
         errors=errors,
-    ), 200
+    ), 200 if not errors else 400
 
 
 @direct_award.route('/<string:framework_family>/projects/<int:project_id>/results')

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -29,19 +29,14 @@
 {% endblock %}
 
 {% block main_content %}
-
-{% if errors %}
-  {% include "toolkit/forms/validation.html" %}
-{% endif %}
+{% include "toolkit/forms/validation.html" %}
 
 <div class="did-you-award-contract-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <header class="page-heading">
-        <h1>
-          Did you award a contract for ‘{{project.name}}’?
-        </h1>
-      </header>
+      {% with heading = ("Did you award a contract for ‘" + project.name + "’?") %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
 
       <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
@@ -51,7 +46,7 @@
           name = "did_you_award_a_contract",
           type = "radio",
           value = form.did_you_award_a_contract.value,
-          error = form.did_you_award_a_contract.errors[0],
+          error = errors.get('did_you_award_a_contract', {}).get('message', None),
           options = form.did_you_award_a_contract.options
         %}
           {% include "toolkit/forms/selection-buttons.html" %}

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -33,19 +33,13 @@
 {% endblock %}
 
 {% block main_content %}
-
-{% if errors %}
-  {% include "toolkit/forms/validation.html" %}
-{% endif %}
+{% include "toolkit/forms/validation.html" %}
 
 <div class="which-service-won-contract-page">
   <div class="grid-row">
-    <div class="column-two-thirds">
-      <header class="page-heading">
-        <h1>
-          Which service won the contract?
-        </h1>
-      </header>
+    {% with heading = 'Which service won the contract?' %}
+      {% include 'toolkit/page-heading.html' %}
+    {% endwith %}
 
       {% if form.which_service_won_the_contract.options %}
 
@@ -56,7 +50,7 @@
           name = "which_service_won_the_contract",
           type = "radio",
           value = form.which_service_won_the_contract.value,
-          error = form.which_service_won_the_contract.errors[0],
+          error = errors.get('which_service_won_the_contract', {}).get('message', None),
           options = form.which_service_won_the_contract.options
         %}
           {% include "toolkit/forms/selection-buttons.html" %}

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -33,19 +33,14 @@
 {% endblock %}
 
 {% block main_content %}
-
-{% if errors %}
-  {% include "toolkit/forms/validation.html" %}
-{% endif %}
+{% include "toolkit/forms/validation.html" %}
 
 <div class="why-didnt-you-award-contract-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      <header class="page-heading">
-        <h1>
-          Why didn’t you award a contract?
-        </h1>
-      </header>
+      {% with heading = "Why didn’t you award a contract?" %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
 
       <form method="POST" action="{{ url_for('direct_award.why_did_you_not_award_the_contract', framework_family=framework.framework, project_id=project.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
@@ -54,7 +49,7 @@
           name = form.why_did_you_not_award_the_contract.name,
           type = "radio",
           value = form.why_did_you_not_award_the_contract.value,
-          error = form.why_did_you_not_award_the_contract.errors[0],
+          error = errors.get('why_did_you_not_award_the_contract', {}).get('message', None),
           options = form.why_did_you_not_award_the_contract.options
         %}
           {% include "toolkit/forms/selection-buttons.html" %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.11.1#egg=digitalmarketplace-utils==36.11.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@38.2.0#egg=digitalmarketplace-utils==38.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@36.11.1#egg=digitalmarketplace-utils==36.11.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@38.2.0#egg=digitalmarketplace-utils==38.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 
@@ -51,4 +51,4 @@ unicodecsv==0.14.1
 urllib3==1.22
 Werkzeug==0.14.1
 workdays==1.4
-WTForms==2.1
+WTForms==2.2.1


### PR DESCRIPTION
 ## Summary
Update utils to pull in `get_errors_from_wtform` (step 1 in
consolidating validation mastheads to a central template). Requires
updates to pages that use WTForms.

One notable view has been excluded - the save search page. This uses a
blend of WTForms and custom HTML to display a special kind of radio form
with some hidden questions. A tech debt ticket exists to tackle this
form but I don't have time to do it at the moment, so needs to be
prioritised for later.

 ## Ticket
https://trello.com/c/RSYEM3FL/448