### PR TITLE
Tell us about your contract page

### DIFF
--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -1,7 +1,14 @@
 from flask_wtf import FlaskForm
-from wtforms.fields import RadioField
-from wtforms.validators import Length, Optional, InputRequired
+
+from wtforms.fields import DecimalField, RadioField
+from wtforms.validators import DataRequired, Length, NumberRange, Optional, InputRequired
+
+from dmutils.forms.fields import DateField
+from dmutils.forms.validators import GreaterThan
+
 from dmutils.forms import StripWhitespaceStringField
+
+from decimal import Decimal
 
 
 class CreateProjectForm(FlaskForm):
@@ -11,9 +18,8 @@ class CreateProjectForm(FlaskForm):
             Length(min=1,
                    max=100,
                    message="Names must be between 1 and 100 characters"),
-            Optional()
-        ]
-    )
+            Optional(),
+        ])
 
 
 # TODO: move this into dmutils.forms
@@ -35,9 +41,8 @@ class DidYouAwardAContractForm(FlaskForm):
         choices=[
             (YES, 'Yes'),
             (NO, 'No'),
-            (STILL_ASSESSING, 'We are still assessing services')
-        ]
-    )
+            (STILL_ASSESSING, 'We are still assessing services'),
+        ])
 
 
 class WhichServiceWonTheContractForm(FlaskForm):
@@ -58,6 +63,42 @@ class WhichServiceWonTheContractForm(FlaskForm):
             "value": service["id"],
             "description": service["supplier"]["name"]
         } for service in services['services']]
+
+
+class TellUsAboutContractForm(FlaskForm):
+    INPUT_REQUIRED_MESSAGE = "You need to answer this question."
+    INVALID_DATE_MESSAGE = "Your answer must be a valid date."
+    INVALID_VALUE_MESSAGE = "Enter your value in pounds and pence using numbers and decimals only" \
+                            ", for example 9900.05 for 9900 pounds and 5 pence."
+
+    start_date = DateField(
+        "Start date",
+        validators=[
+            InputRequired(INPUT_REQUIRED_MESSAGE),
+            DataRequired(INVALID_DATE_MESSAGE),
+        ])
+
+    end_date = DateField(
+        "End date",
+        validators=[
+            InputRequired(INPUT_REQUIRED_MESSAGE),
+            DataRequired(INVALID_DATE_MESSAGE),
+            GreaterThan("start_date", "Your end date must be later than the start date."),
+        ])
+
+    value_in_pounds = DecimalField(
+        "Value",
+        validators=[
+            InputRequired(INPUT_REQUIRED_MESSAGE),
+            DataRequired(INVALID_VALUE_MESSAGE),
+            NumberRange(min=Decimal('0.01'), message=INVALID_VALUE_MESSAGE),
+        ])
+
+    buying_organisation = StripWhitespaceStringField(
+        "Organisation buying the service",
+        validators=[
+            InputRequired(INPUT_REQUIRED_MESSAGE)
+        ])
 
 
 class WhyDidYouNotAwardForm(FlaskForm):

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -640,7 +640,7 @@ def which_service_won_contract(framework_family, project_id):
 
     if request.method == "POST" and form.validate_on_submit():
         flash('Contract awarded.')
-        return redirect(url_for('.view_project', framework_family=framework_family, project_id=project['id']))
+        return redirect(url_for('.tell_us_about_contract', framework_family=framework_family, project_id=project['id']))
 
     errors = get_errors_from_wtform(form)
 

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -21,6 +21,7 @@ from ..exceptions import AuthException
 from ..forms.direct_award_forms import (
     CreateProjectForm,
     DidYouAwardAContractForm,
+    TellUsAboutContractForm,
     WhichServiceWonTheContractForm,
     WhyDidYouNotAwardForm
 )
@@ -650,6 +651,40 @@ def which_service_won_contract(framework_family, project_id):
         framework=framework,
         services=services,
         form=form,
+    ), 200 if not errors else 400
+
+
+@direct_award.route(
+    '/<string:framework_family>/projects/<int:project_id>/tell-us-about-contract',
+    methods=['GET', 'POST']
+)
+def tell_us_about_contract(framework_family, project_id):
+    all_frameworks = data_api_client.find_frameworks().get('frameworks')
+    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
+
+    # Get the requested Direct Award Project.
+    project = data_api_client.get_direct_award_project(project_id=project_id)['project']
+
+    if not is_direct_award_project_accessible(project, current_user.id):
+        abort(404)
+
+    if not project['lockedAt']:
+        abort(400)
+
+    form = TellUsAboutContractForm()
+
+    if form.validate_on_submit():
+        flash(Markup(f"""You've updated '{project['name']}'"""), 'success')
+        return redirect(url_for('.view_project', framework_family=framework_family, project_id=project_id))
+
+    errors = get_errors_from_wtform(form)
+
+    return render_template(
+        'direct-award/tell-us-about-contract.html',
+        project=project,
+        framework=framework,
+        form=form,
+        errors=errors,
     ), 200 if not errors else 400
 
 

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -1,0 +1,115 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+{% block page_title %}Tell us about your contract - Digital Marketplace{% endblock %}
+
+{% block breadcrumb %}
+  {%
+    with
+    items = [
+      {
+        "link": url_for('main.index'),
+        "label": "Digital Marketplace"
+      },
+      {
+        "link": url_for('external.buyer_dashboard'),
+        "label": "Your account"
+      },
+      {
+        "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
+        "label": "Your saved searches"
+      },
+      {
+        "link": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
+        "label": project.name
+      },
+      {
+        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id),
+        "label": "Did you award a contract?"
+      },
+      {
+        "link": url_for('direct_award.which_service_won_contract', framework_family=framework.framework, project_id=project.id),
+        "label": "Which service won the contract?"
+      }
+    ]
+  %}
+    {% include "toolkit/breadcrumb.html" %}
+  {% endwith %}
+{% endblock %}
+
+{% block main_content %}
+
+{% include "toolkit/forms/validation.html" %}
+
+<div class="tell-us-about-contract-page">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      {% with heading="Tell us about your contract" %}
+        {% include "toolkit/page-heading.html" %}
+      {% endwith %}
+
+      <form method="POST" action="{{ url_for('direct_award.tell_us_about_contract', framework_family=framework.framework, project_id=project.id) }}" class="tell-us-about-contract-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+
+        {%
+          with
+          name = "start_date",
+          hint = "For example, 31 12 2020",
+          question = "Start date",
+          data = form.start_date._value(),
+          error = errors.get('start_date', {}).get('message', None)
+        %}
+          {% include "toolkit/forms/date.html" %}
+        {% endwith %}
+
+        {%
+          with
+          name = "end_date",
+          hint = "For example, 31 12 2020",
+          question = "End date",
+          data = form.end_date._value(),
+          error = errors.get('end_date', {}).get('message', None)
+        %}
+          {% include "toolkit/forms/date.html" %}
+        {% endwith %}
+
+        {%
+          with
+          question = "Value",
+          name = "value_in_pounds",
+          unit_in_full = "pounds",
+          unit = "£",
+          unit_position = "before",
+          hint = "For example, 9900.95 for 9900 pounds and 95 pence",
+          value = form.value_in_pounds._value(),
+          error = errors.get('value_in_pounds', {}).get('message', None)
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+
+        {%
+          with
+          question = "Organisation buying the service",
+          name = "buying_organisation",
+          hint = "For example, National Audit Office or Lewisham Council",
+          value = form.buying_organisation._value(),
+          error = errors.get('buying_organisation', {}).get('message', None)
+        %}
+          {% include "toolkit/forms/textbox.html" %}
+        {% endwith %}
+
+        {%
+          with
+          type = "save",
+          label = "Submit"
+        %}
+          {% include "toolkit/button.html" %}
+        {% endwith %}
+
+      </form>
+
+      <p><a href="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.framework, project_id=project.id) }}">Previous page</a></p>
+
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@38.2.0#egg=digitalmarketplace-utils==38.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@38.3.0#egg=digitalmarketplace-utils==38.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@38.2.0#egg=digitalmarketplace-utils==38.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@38.3.0#egg=digitalmarketplace-utils==38.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.4.1#egg=digitalmarketplace-content-loader==4.4.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@15.0.0#egg=digitalmarketplace-apiclient==15.0.0
 

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -592,6 +592,16 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
             '/buyers/direct-award/g-cloud/projects/1/which-service-won-contract')
         assert res.status_code == 400
 
+    def test_which_service_did_you_award_should_redirect_to_tell_us_about_contract(self):
+        self.login_as_buyer()
+
+        res = self.client.post(
+            '/buyers/direct-award/g-cloud/projects/1/which-service-won-contract',
+            data={'which_service_won_the_contract': '123456789'})
+
+        assert res.status_code == 302
+        assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1/tell-us-about-contract')
+
 
 class TestDirectAwardTellUsAboutContract(TestDirectAwardBase):
     url = '/buyers/direct-award/g-cloud/projects/1/tell-us-about-contract'

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -593,6 +593,114 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
         assert res.status_code == 400
 
 
+class TestDirectAwardTellUsAboutContract(TestDirectAwardBase):
+    url = '/buyers/direct-award/g-cloud/projects/1/tell-us-about-contract'
+
+    @pytest.fixture
+    def client(self):
+        self.login_as_buyer()
+        return self.client
+
+    @pytest.fixture
+    def xpath(self, client):
+        res = client.get(self.url)
+        doc = html.fromstring(res.get_data(as_text=True))
+        return doc.xpath
+
+    @pytest.fixture
+    def data(self):
+        return {
+            'start_date-day': '31',
+            'start_date-month': '12',
+            'start_date-year': '2019',
+            'end_date-day': '1',
+            'end_date-month': '6',
+            'end_date-year': '2021',
+            'buying_organisation': 'Lewisham Council',
+            'value_in_pounds': '100.00'
+        }
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client.get_direct_award_project.return_value = self._get_direct_award_lock_project_fixture()
+
+    def test_tell_us_about_contract_exists(self, client):
+        assert client.get(self.url).status_code == 200
+
+    def test_tell_us_about_contract_renders(self, xpath):
+        assert xpath('boolean(//h1[contains(normalize-space(), "Tell us about your contract")])')
+
+    def test_tell_us_about_contract_form_fields(self, xpath):
+        assert xpath('count(//input[@type="text"][substring-after(@name, "start_date")])') == 3
+        assert xpath('count(//input[@type="text"][substring-after(@name, "end_date")])') == 3
+        assert xpath('boolean(//input[@type="text"][contains(@name, "value_in_pounds")])')
+        assert xpath('boolean(//input[@type="text"][contains(@name, "buying_organisation")])')
+        assert xpath('boolean(//input[@type="submit"][@value="Submit"])')
+
+    def test_previous_page_button_exists_and_points_to_previous_page(self, xpath):
+        assert xpath(
+            'boolean('
+            '//a[@href="/buyers/direct-award/g-cloud/projects/1/which-service-won-contract"]'
+            '[contains(normalize-space(), "Previous page")])')
+
+    def test_tell_us_about_contract_form_action_url_is_tell_us_about_contract_url(self, xpath):
+        assert xpath('//form[@class="tell-us-about-contract-form"]/@action')[0] == self.url
+
+    def test_tell_us_about_contract_raises_404_if_project_does_not_exist(self, client):
+        self.data_api_client.get_direct_award_project.side_effect = HTTPError(mock.Mock(status_code=404))
+
+        assert client.get('/buyers/direct-award/g-cloud/projects/31415/tell-us-about-contract').status_code == 404
+
+    def test_tell_us_about_contract_raises_404_if_project_is_not_accessible(self, client):
+        self.data_api_client.get_direct_award_project.return_value['project']['id'] = 314159
+        self.data_api_client.get_direct_award_project.return_value['project']['users'][0]['id'] = 321
+
+        assert client.get('/buyers/direct-award/g-cloud/projects/31415/tell-us-about-contract').status_code == 404
+
+    def test_tell_us_about_contract_successful_post_redirects_to_project_overview(self, client, data):
+        res = client.post(self.url, data=data)
+        assert res.status_code == 302
+        assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1')
+        self.assert_flashes("You've updated 'My procurement project'", 'success')
+
+    def test_tell_us_about_contract_post_raises_400_and_shows_validation_messages_if_no_form_input(self, client):
+        res = client.post(self.url)
+        xpath = html.fromstring(res.get_data(as_text=True)).xpath
+        assert res.status_code == 400
+        assert xpath('boolean(//div[@class="validation-masthead"])')
+        assert xpath('count(//a[@class="validation-masthead-link"])') == 4
+        assert xpath('count(//span[@class="validation-message"])') == 4
+
+    @pytest.mark.parametrize('invalid_data', (
+        {'start_date-year': 'year', 'start_date-month': 'mo', 'start_date-day': 'da'},
+        {'end_date-year': 'year', 'end_date-month': 'mo', 'end_date-day': 'da'},
+        {'value_in_pounds': 'money'},
+        {'buying_organisation': ''},
+    ))
+    def test_invalid_data_raises_400_and_has_validation_messages_but_remains_in_form(self, client, data, invalid_data):
+        data.update(invalid_data)
+        res = client.post(self.url, data=data)
+        assert res.status_code == 400
+
+        xpath = html.fromstring(res.get_data(as_text=True)).xpath
+        assert xpath('count(//span[@class="validation-message"])') == 1
+        assert xpath('boolean(//div[@class="validation-masthead"])')
+        assert xpath('count(//a[@class="validation-masthead-link"])') == 1
+
+        for field, value in data.items():
+            assert xpath(f'//input[@name="{field}"]/@value')[0] == value
+
+    def test_if_end_date_is_before_start_date_raise_400_and_show_validation_message(self, client, data):
+        data.update({'end_date-year': str(int(data['start_date-year']) - 1)})
+        res = client.post(self.url, data=data)
+        assert res.status_code == 400
+
+        xpath = html.fromstring(res.get_data(as_text=True)).xpath
+        assert xpath('count(//span[@class="validation-message"])') == 1
+        assert xpath('boolean(//div[@class="validation-masthead"])')
+        assert xpath('count(//a[@class="validation-masthead-link"])') == 1
+
+
 class TestDirectAwardNonAwardContract(TestDirectAwardBase):
     def setup_method(self, method):
         super().setup_method(method)


### PR DESCRIPTION
Ticket:
[Trello](https://trello.com/c/kPG8B9ZJ/74-fe-3-tell-us-about-your-contract-page)

This page is for users to tell Digital Marketplace about the length and
value of the contract they are awarding through G-Cloud.

It is reviving #770, but it does less to make the features easier to review.

The DateField class has been moved to dmutils (merged in https://github.com/alphagov/digitalmarketplace-utils/pull/406) and the modifications to WTForms have been removed. They will be added at a later date when another dmutils PR (https://github.com/alphagov/digitalmarketplace-utils/pull/400) is merged.

This PR also is consistent with the work @samuelhwilliams has done recently with validation mastheads and form errors.

tl;dr please approve! 👍 🙏 😁 