### PR TITLE
Remove Markup where not needed

### DIFF
--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -5,7 +5,7 @@ import flask_featureflags
 main = Blueprint('main', __name__)
 direct_award = Blueprint('direct_award', __name__, url_prefix='/buyers/direct-award')
 
-LOGIN_REQUIRED_MESSAGE = Markup("""You must log in with a buyer account to see this page.""")
+LOGIN_REQUIRED_MESSAGE = "You must log in with a buyer account to see this page."
 
 
 @direct_award.before_request

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import inflection
 from operator import itemgetter
 
-from flask import abort, render_template, request, redirect, current_app, url_for, flash, Markup
+from flask import abort, render_template, request, redirect, current_app, url_for, flash
 from flask_login import current_user
 from werkzeug.urls import Href, url_encode, url_decode
 
@@ -48,10 +48,10 @@ from ..presenters.service_presenters import Service
 
 
 END_SEARCH_LIMIT = 30  # TODO: This should be done in the API.
-PROJECT_SAVED_MESSAGE = Markup("Search saved.")
-PROJECT_ENDED_MESSAGE = Markup("Search ended. You can now download your search results.")
-TOO_MANY_RESULTS_MESSAGE = Markup(f"You have too many services to review. Refine your search until you have no more "
-                                  f"than {END_SEARCH_LIMIT} results.")
+PROJECT_SAVED_MESSAGE = "Search saved."
+PROJECT_ENDED_MESSAGE = "Search ended. You can now download your search results."
+TOO_MANY_RESULTS_MESSAGE = f"You have too many services to review. Refine your search until you have no more " \
+                           f"than {END_SEARCH_LIMIT} results."
 
 
 @main.route('/g-cloud')
@@ -674,7 +674,7 @@ def tell_us_about_contract(framework_family, project_id):
     form = TellUsAboutContractForm()
 
     if form.validate_on_submit():
-        flash(Markup(f"""You've updated '{project['name']}'"""), 'success')
+        flash(f"You've updated '{project['name']}'", 'success')
         return redirect(url_for('.view_project', framework_family=framework_family, project_id=project_id))
 
     errors = get_errors_from_wtform(form)

--- a/tests/main/presenters/test_search_summary.py
+++ b/tests/main/presenters/test_search_summary.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-from flask import Markup
 from mock import Mock
 from werkzeug.datastructures import MultiDict
 
@@ -321,7 +320,7 @@ class TestSearchSummary(BaseApplicationTest):
         search_summary = SearchSummary(9, self.request_args, filter_groups, self._lots_by_slug)
         search_summary.get_starting_sentence = get_starting_sentence
         search_summary.filters_fragments = []
-        assert search_summary.markup() == Markup(u"5 results found")
+        assert search_summary.markup() == u"5 results found"
 
     def test_markup_method_works_with_fragments(self):
         def get_starting_sentence():
@@ -331,7 +330,7 @@ class TestSearchSummary(BaseApplicationTest):
         search_summary = SearchSummary(9, self.request_args, filter_groups, self._lots_by_slug)
         search_summary.get_starting_sentence = get_starting_sentence
         search_summary.filters_fragments = [fragment]
-        assert search_summary.markup() == Markup(u"5 results found with option1 and option2")
+        assert search_summary.markup() == u"5 results found with option1 and option2"
 
 
 class TestSummaryRules:

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -2,7 +2,6 @@ from dateutil import parser
 import sys
 from urllib.parse import quote_plus, urlparse
 
-from flask import Markup
 from html import escape as html_escape
 from lxml import html
 import mock
@@ -871,7 +870,7 @@ class TestDirectAwardDownloadResultsView(TestDirectAwardBase):
         assert file_context['filename'] == '2017-09-08-my-procurement-project-results'
         assert file_context['sheetname'] == "Search results"
         assert file_context['locked_at'] == 'Friday 8 September 2017 at 1:00am BST'
-        assert file_context['search_summary'] == Markup('1 result found in All categories')
+        assert file_context['search_summary'] == '1 result found in All categories'
 
     def test_get_file_data_and_column_styles(self):
         """This test will quite closely reproduce the implementation, but is the only way I can think of to tightly


### PR DESCRIPTION
By default, Flask escapes strings so that they are displayed raw. If a string needs to include HTML, it should be wrapped in a `Markup`.

However, as noted by @samuelhwilliams in https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/779#discussion_r194142446, wrapping text in `Markup` should be done with caution.

This PR removes instances where Markup has been used unnecessarily, so in future people don't get the wrong idea about where it should be used (like I did!).