### PR TITLE
Make quotes curly

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -704,7 +704,7 @@ def tell_us_about_contract(framework_family, project_id, outcome_id):
             },
             user_email=current_user.email_address,
         )
-        flash("You've updated '{}'".format(project['name']), 'success')
+        flash("You’ve updated ‘{}’".format(project['name']), 'success')
         return redirect(url_for('.view_project', framework_family=framework_family, project_id=project_id))
 
     errors = get_errors_from_wtform(form)
@@ -750,7 +750,7 @@ def why_did_you_not_award_the_contract(framework_family, project_id):
             data_api_client.create_direct_award_project_outcome_none_suitable(
                 project_id=project_id,
                 user_email=current_user.email_address)
-        flash("You've updated {}".format(project['name']))
+        flash("You’ve updated ‘{}’".format(project['name']))
         return redirect(url_for('.view_project', framework_family=framework_family, project_id=project['id']))
 
     errors = get_errors_from_wtform(form)

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -700,7 +700,7 @@ class TestDirectAwardTellUsAboutContract(TestDirectAwardBase):
         res = client.post(self.url, data=data)
         assert res.status_code == 302
         assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1')
-        self.assert_flashes("You've updated 'My procurement project'", 'success')
+        self.assert_flashes("You’ve updated ‘My procurement project’", 'success')
 
     def test_tell_us_about_contract_post_raises_400_and_shows_validation_messages_if_no_form_input(self, client):
         res = client.post(self.url)


### PR DESCRIPTION
Some new flash messages used straight quotes and apostrophes instead of the curly ones.