### PR TITLE
Do not show user research banner on home page

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,6 +12,8 @@
 
 {% block phase_banner %}{% endblock %}
 
+{% block after_header %}{% endblock %}
+
  {% block body_classes %}index-page-body{% endblock %}
 
 {% block main_content %}


### PR DESCRIPTION
A clash with the the homepage design mean that the user research banner
looks buggy.

It was decided by @kubabartwicki that it would be better
not to show the banner, rather than risk putting off visitors.