### PR TITLE
Check the project id of the draft outcome in 'Tell us about your contract'

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -687,6 +687,9 @@ def tell_us_about_contract(framework_family, project_id, outcome_id):
     if outcome['completed']:
         abort(410)
 
+    if outcome['resultOfDirectAward']['project']['id'] != project_id:
+        abort(404)
+
     form = TellUsAboutContractForm()
 
     if form.validate_on_submit():

--- a/tests/fixtures/direct_award_project_outcome_awarded_fixture.json
+++ b/tests/fixtures/direct_award_project_outcome_awarded_fixture.json
@@ -1,0 +1,11 @@
+{
+  "outcome": {
+    "result": "awarded",
+    "completed": false,
+    "resultOfDirectAward": {
+      "project": {
+        "id": 1
+      }
+    }
+  }
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -223,10 +223,28 @@ class BaseApplicationTest(object):
         return BaseApplicationTest._get_direct_award_project_fixture(lockedAt=False)
 
     @staticmethod
-    def _get_direct_award_completed_project_fixture():
-        fixture = BaseApplicationTest._get_direct_award_lock_project_fixture()
-        fixture['project']['outcome'] = {'completed': True}
-        return fixture
+    def _get_direct_award_project_outcome_awarded_fixture():
+        return BaseApplicationTest._get_fixture_data('direct_award_project_outcome_awarded_fixture.json')
+
+    @staticmethod
+    def _get_direct_award_project_completed_outcome_awarded_fixture():
+        outcome = BaseApplicationTest._get_direct_award_project_outcome_awarded_fixture()
+        outcome['outcome']['completed'] = True
+        return outcome
+
+    @staticmethod
+    def _get_direct_award_project_with_outcome_awarded_fixture():
+        project = BaseApplicationTest._get_direct_award_lock_project_fixture()
+        project['project']['outcome'] = \
+            BaseApplicationTest._get_direct_award_project_outcome_awarded_fixture()['outcome']
+        return project
+
+    @staticmethod
+    def _get_direct_award_project_with_completed_outcome_awarded_fixture():
+        project = BaseApplicationTest._get_direct_award_lock_project_fixture()
+        project['project']['outcome'] = \
+            BaseApplicationTest._get_direct_award_project_completed_outcome_awarded_fixture()['outcome']
+        return project
 
     @staticmethod
     def _get_direct_award_project_searches_fixture(only_active=False):

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -551,7 +551,7 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
 
     def test_award_contract_raises_410_if_outcome_is_completed(self):
         self.data_api_client.get_direct_award_project.return_value = \
-            self._get_direct_award_completed_project_fixture()
+            self._get_direct_award_project_with_completed_outcome_awarded_fixture()
         self.login_as_buyer()
 
         res = self.client.get('/buyers/direct-award/g-cloud/projects/1/did-you-award-contract')
@@ -619,7 +619,7 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
 
     def test_which_service_raises_410_if_outcome_is_completed(self):
         self.data_api_client.get_direct_award_project.return_value = \
-            self._get_direct_award_completed_project_fixture()
+            self._get_direct_award_project_with_completed_outcome_awarded_fixture()
         self.login_as_buyer()
 
         res = self.client.get('/buyers/direct-award/g-cloud/projects/1/which-service-won-contract')
@@ -656,12 +656,7 @@ class TestDirectAwardTellUsAboutContract(TestDirectAwardBase):
     def setup_method(self, method):
         super().setup_method(method)
         self.data_api_client.get_direct_award_project.return_value = self._get_direct_award_lock_project_fixture()
-        self.data_api_client.get_outcome.return_value = {
-            'outcome': {
-                'result': 'awarded',
-                'completed': False,
-            },
-        }
+        self.data_api_client.get_outcome.return_value = self._get_direct_award_project_outcome_awarded_fixture()
 
     def test_tell_us_about_contract_exists(self, client):
         assert client.get(self.url).status_code == 200
@@ -803,7 +798,7 @@ class TestDirectAwardNonAwardContract(TestDirectAwardBase):
     def test_why_did_you_not_award_page_raises_410_if_outcome_is_completed(self):
         self.login_as_buyer()
         self.data_api_client.get_direct_award_project.return_value = \
-            self._get_direct_award_completed_project_fixture()
+            self._get_direct_award_project_with_completed_outcome_awarded_fixture()
 
         res = self.client.get(
             '/buyers/direct-award/g-cloud/projects/1/why-didnt-you-award-contract')

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -740,6 +740,12 @@ class TestDirectAwardTellUsAboutContract(TestDirectAwardBase):
         res = client.get(self.url)
         assert res.status_code == 410
 
+    def test_raises_404_if_outcome_is_not_assigned_to_project(self, client):
+        self.data_api_client.get_outcome.return_value['outcome']['resultOfDirectAward']['project']['id'] = 314157
+
+        res = client.get(self.url)
+        assert res.status_code == 404
+
 
 class TestDirectAwardNonAwardContract(TestDirectAwardBase):
     def setup_method(self, method):


### PR DESCRIPTION
This fixes a bug that was found in QA by @andrewchong.