### PR TITLE
Create a base template for search results

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -279,6 +279,7 @@ def search_services():
         doc_type=doc_type,
         filters=filters.values(),
         filter_form_hidden_fields=filter_form_hidden_fields_by_name.values(),
+        form_action=url_for('.search_services'),
         framework_family=framework['framework'],
         gcloud_framework_description=framework_helpers.get_framework_description(data_api_client, 'g-cloud'),
         lots=lots,

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -297,6 +297,7 @@ def list_opportunities(framework_family):
         doc_type=doc_type,
         filters=filters.values(),
         filter_form_hidden_fields=filter_form_hidden_fields_by_name.values(),
+        form_action=url_for('.list_opportunities', framework_family=framework_family),
         framework=framework,
         framework_family=framework['framework'],
         framework_family_name='Digital Outcomes and Specialists',

--- a/app/templates/search/_search_layout.html
+++ b/app/templates/search/_search_layout.html
@@ -1,0 +1,38 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+{% block head %}
+  <meta name="robots" content="noindex">
+  {{ super() }}
+{% endblock %}
+
+{% block main_content %}
+
+{% block page_heading %}{% endblock %}
+
+<div id="js-dm-live-search-wrapper" class="grid-row search-results-page">
+  <form action="{{ form_action }}" method="get" id="js-dm-live-search-form">
+    <section class="column-one-third search-page-filters" aria-label="Search filters">
+          {% include 'search/_filters_and_categories_wrapper.html' %}
+          {% block post_filters %}{% endblock %}
+    </section>
+  </form>
+  <section class="column-two-thirds" aria-label="Search results">
+    {#
+      the element referenced by an `aria-controls=` seems to need to be persistent -
+      at least I wasn't able to get it to work by just re-using a fragment of the
+      existing search summary text, as it gets removed and replaced wholesale by
+      the javascript when a new set of results is fetched.
+
+      instead, we have this dedicated (and more importantly, persistent) wrapper
+      element, which itself can be the target of `aria-controls=`
+    #}
+    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="additions text">
+      {% include 'search/_summary_accessible_hint.html' %}
+    </div>
+    {% include 'search/_summary.html' %}
+    {% block post_summary %}{% endblock %}
+    {% include 'search/_results_wrapper.html' %}
+  </section>
+
+</div>
+{% endblock %}

--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -1,12 +1,7 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "search/_search_layout.html" %}
 
 {% block page_title %}
   Supplier opportunities – {{ framework_family_name }} – Digital Marketplace
-{% endblock %}
-
-{% block head %}
-  <meta name="robots" content="noindex">
-  {{ super() }}
 {% endblock %}
 
 {% block breadcrumb %}
@@ -41,7 +36,7 @@
   {% endwith %}
 {% endblock %}
 
-{% block main_content %}
+{% block page_heading %}
 <div class="grid-row">
   <div class="column-two-thirds">
     {% with heading="{} opportunities".format(framework_family_name) %}
@@ -52,30 +47,8 @@
     </div>
   </div>
 </div>
+{% endblock %}
 
-<div id="js-dm-live-search-wrapper" class="grid-row search-results-page">
-  <form action="{{ url_for('.list_opportunities', framework_family=framework_family) }}" method="get" id="js-dm-live-search-form">
-    <section class="column-one-third search-page-filters" aria-label="Search filters">
-          {% include 'search/_filters_and_categories_wrapper.html' %}
-          {% include 'search/_opportunity_data.html' %}
-    </section>
-  </form>
-  <section class="column-two-thirds" aria-label="Search results">
-    {#
-      the element referenced by an `aria-controls=` seems to need to be persistent -
-      at least I wasn't able to get it to work by just re-using a fragment of the
-      existing search summary text, as it gets removed and replaced wholesale by
-      the javascript when a new set of results is fetched.
-
-      instead, we have this dedicated (and more importantly, persistent) wrapper
-      element, which itself can be the target of `aria-controls=`
-    #}
-    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="additions text">
-      {% include 'search/_summary_accessible_hint.html' %}
-    </div>
-    {% include 'search/_summary.html' %}
-    {% include 'search/_results_wrapper.html' %}
-  </section>
-
-</div>
+{% block post_filters %}
+  {% include 'search/_opportunity_data.html' %}
 {% endblock %}

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -1,11 +1,6 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "search/_search_layout.html" %}
 
 {% block page_title %}Search - Digital Marketplace{% endblock %}
-
-{% block head %}
-  <meta name="robots" content="noindex">
-  {{ super() }}
-{% endblock %}
 
 {% block breadcrumb %}
   {% with %}
@@ -39,33 +34,12 @@
   {% endwith %}
 {% endblock %}
 
-{% block main_content %}
+{% block page_heading %}
 <header class="page-heading">
         <h1>Search results</h1>
 </header>
-<div id="js-dm-live-search-wrapper" class="grid-row search-results-page">
-  <form action="{{ url_for('.search_services') }}" method="get" id="js-dm-live-search-form">
-    <section class="column-one-third search-page-filters" aria-label="Search filters">
-          {% include 'search/_filters_and_categories_wrapper.html' %}
-    </section>
-  </form>
-  <section class="column-two-thirds" aria-label="Search results">
-    {#
-      the element referenced by an `aria-controls=` seems to need to be persistent -
-      at least I wasn't able to get it to work by just re-using a fragment of the
-      existing search summary text, as it gets removed and replaced wholesale by
-      the javascript when a new set of results is fetched.
+{% endblock %}
 
-      instead, we have this dedicated (and more importantly, persistent) wrapper
-      element, which itself can be the target of `aria-controls=`
-    #}
-    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="additions text">
-      {% include 'search/_summary_accessible_hint.html' %}
-    </div>
-    {% include 'search/_summary.html' %}
-    {% include 'search/_services_save_search.html' %}
-    {% include 'search/_results_wrapper.html' %}
-  </section>
-
-</div>
+{% block post_summary %}
+  {% include 'search/_services_save_search.html' %}
 {% endblock %}


### PR DESCRIPTION
In preparation for changing the layout of the search page (see [this Trello ticket][ticket]), 
the templates for briefs and services searches have had their commonalities pulled out into a new template,`_search_layout.html`. 

This should prevent the page layouts from diverging as the new changes are made.

[ticket]: https://trello.com/c/4ETdzfOe/