### PR TITLE
FE-2. Which service won the contract? page

### DIFF
--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -61,7 +61,7 @@ class WhichServiceWonTheContractForm(FlaskForm):
         self.which_service_won_the_contract.options = [{
             "label": service["data"]["serviceName"],
             "value": service["id"],
-            "description": service["supplier"]["name"]
+            "hint": service["supplier"]["name"],
         } for service in services['services']]
 
 
@@ -114,12 +114,12 @@ class WhyDidYouNotAwardForm(FlaskForm):
             {
                 "label": "The work has been cancelled",
                 "value": "work_cancelled",
-                "description": "For example, because you no longer have the budget",
+                "hint": "For example, because you no longer have the budget",
             },
             {
                 "label": "There were no suitable services",
                 "value": "no_suitable_services",
-                "description": "The services in your search results did not meet your requirements",
+                "hint": "The services in your search results did not meet your requirements",
             },
         ]
 

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -104,7 +104,7 @@
                 data-analytics-action=\"External Link\"
                 >how to award a contract when you buy services</a>."])|safe},
               {"type": "text", "text": ''.join(["The buyer and supplier must both sign a copy of the contract before the service can be used."])|safe},
-              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not search.searchedAt
+              {"type": "box", "style": "inactive", "label": "Can't start yet"} if not project.downloadedAt
               else {"type": "box", "style": "complete", "label": project_outcome_label } if project.outcome
               else {"type": "action", "label": "Tell us the outcome", "href": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"}
             ]

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -37,41 +37,45 @@
 
 <div class="which-service-won-contract-page">
   <div class="grid-row">
-    {% with heading = 'Which service won the contract?' %}
-      {% include 'toolkit/page-heading.html' %}
-    {% endwith %}
+    <div class="column-two-thirds">
 
-      {% if form.which_service_won_the_contract.options %}
+    
+      {% with heading = 'Which service won the contract?' %}
+        {% include 'toolkit/page-heading.html' %}
+      {% endwith %}
 
-      <form method="POST" action="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.framework, project_id=project.id) }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        {%
-          with
-          name = "which_service_won_the_contract",
-          type = "radio",
-          value = form.which_service_won_the_contract.value,
-          error = errors.get('which_service_won_the_contract', {}).get('message', None),
-          options = form.which_service_won_the_contract.options
-        %}
-          {% include "toolkit/forms/selection-buttons.html" %}
-        {% endwith %}
+        {% if form.which_service_won_the_contract.options %}
 
-        {%
-          with
-          type = "save",
-          label = "Save and continue"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
-      </form>
+        <form method="POST" action="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.framework, project_id=project.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          {%
+            with
+            name = "which_service_won_the_contract",
+            type = "radio",
+            value = form.which_service_won_the_contract.value,
+            error = errors.get('which_service_won_the_contract', {}).get('message', None),
+            options = form.which_service_won_the_contract.options
+          %}
+            {% include "toolkit/forms/selection-buttons.html" %}
+          {% endwith %}
 
-      {% else %}
-        <div class="dmspeak">
-          <p>You cannot award this contract as there were no services matching your requirements.</p>
-        </div>
-      {% endif %}
+          {%
+            with
+            type = "save",
+            label = "Save and continue"
+          %}
+            {% include "toolkit/button.html" %}
+          {% endwith %}
+        </form>
 
-      <p><a href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id) }}">Previous page</a></p>
+        {% else %}
+          <div class="dmspeak">
+            <p>You cannot award this contract as there were no services matching your requirements.</p>
+          </div>
+        {% endif %}
+
+        <p><a href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id) }}">Previous page</a></p>
+      </div>
     </div>
   </div>
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.3.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#11.5.5",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -341,7 +341,7 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
                                    '/buyers/direct-award/g-cloud/projects/1/results') is True
 
         assert self._task_has_link(tasklist, 6,
-                                   '/buyers/direct-award/g-cloud/projects/1/did-you-award-contract') is True
+                                   '/buyers/direct-award/g-cloud/projects/1/did-you-award-contract') is False
 
     def test_overview_renders_specific_elements_for_search_downloaded_state(self):
         searches = self._get_direct_award_project_searches_fixture()
@@ -571,7 +571,7 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
         assert len(doc.xpath(
             '//input[@type="radio"][contains(following-sibling::label, "Service name")]')) == 1
         assert len(doc.xpath(
-            '//p[contains(normalize-space(text()), "Supplier name")][contains(parent::label, "Service name")]')) == 1
+            '//span[contains(normalize-space(text()), "Supplier name")][contains(parent::label, "Service name")]')) == 1
         assert len(
             doc.xpath('//input[@type="submit"][@value="Save and continue"]')) == 1
 
@@ -769,12 +769,12 @@ class TestDirectAwardNonAwardContract(TestDirectAwardBase):
         assert len(doc.xpath(
             '//input[@type="radio"][contains(following-sibling::label, "The work has been cancelled")]')) == 1
         assert len(doc.xpath(
-            '//p[contains(normalize-space(text()), "For example, because you no longer have the budget")]\
+            '//span[contains(normalize-space(text()), "For example, because you no longer have the budget")]\
             [contains(parent::label, "The work has been cancelled")]')) == 1
         assert len(doc.xpath(
             '//input[@type="radio"][contains(following-sibling::label, "The work has been cancelled")]')) == 1
         assert len(doc.xpath(
-            '//p[contains(normalize-space(text()), "The services in your search results did not meet your requirements")]\
+            '//span[contains(normalize-space(text()), "The services in your search results did not meet your requirements")]\
             [contains(parent::label, "There were no suitable services")]')) == 1
         assert len(
             doc.xpath('//input[@type="submit"][@value="Save and continue"]')) == 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "11.5.5"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#a8cd0937a73adfb3498a70ae02135ac2691f8c20"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.0.1":
-  version "31.0.1"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b34e87bf0c1910f6c8d4ef86f1db9b6533423902"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.3.0":
+  version "31.3.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b6fc6061db5e9e0be09e5c7d1c6d489aea46e9aa"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
Changes to fix the following comments:
- The list of radios is not using form-hint to display supplier names but instead uses question-description. This has a smaller font than form-hint and a different colour. Could we change please? Attached is a screen grab of how it should look like.
- The content is shifted left from the left so it's misaligned with headers and footers. Other pages are fine.


Ticket: https://trello.com/c/hHyDVwFZ/72-fe-2-which-service-won-the-contract-page