### PR TITLE
Change the layout of the search page

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -1,5 +1,9 @@
 @import "search/_search-summary.scss";
 
+#search-page-heading .page-heading {
+  margin-bottom: 10px;
+}
+
 .search-summary {
   padding: 0 0 $gutter-half;
 
@@ -9,10 +13,23 @@
   }
 }
 
+.column-one-whole .search-summary {
+  @include core-19;
+
+  .search-summary-count {
+    font-size: 30px;
+
+    margin-right: 2px;
+    padding: 0;
+
+    @include media(mobile) {
+      margin-right: 0;
+      font-size: inherit;
+    }
+  }
+}
+
 .button-save-wrapper {
-  border-top: 1px solid $border-colour;
-  border-bottom: 1px solid $border-colour;
-  padding-top: 20px;
   margin: 0px 0px 20px;
 
   .save-summary-text {
@@ -24,9 +41,10 @@
   }
 
   .save-button {
+    padding: 0;
+
     .button-save {
-      @include core-16;
-      width: 100%;
+      @include core-19;
     }
   }
 }

--- a/app/templates/search/_search_layout.html
+++ b/app/templates/search/_search_layout.html
@@ -7,15 +7,20 @@
 
 {% block main_content %}
 
+<section id="search-page-heading">
 {% block page_heading %}{% endblock %}
+</section>
 
 <div id="js-dm-live-search-wrapper" class="grid-row search-results-page">
+  {% block post_heading %}{% endblock %}
+
   <form action="{{ form_action }}" method="get" id="js-dm-live-search-form">
     <section class="column-one-third search-page-filters" aria-label="Search filters">
           {% include 'search/_filters_and_categories_wrapper.html' %}
           {% block post_filters %}{% endblock %}
     </section>
   </form>
+
   <section class="column-two-thirds" aria-label="Search results">
     {#
       the element referenced by an `aria-controls=` seems to need to be persistent -
@@ -29,8 +34,9 @@
     <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="additions text">
       {% include 'search/_summary_accessible_hint.html' %}
     </div>
-    {% include 'search/_summary.html' %}
-    {% block post_summary %}{% endblock %}
+    {% block pre_results %}
+      {% include 'search/_summary.html' %}
+    {% endblock %}
     {% include 'search/_results_wrapper.html' %}
   </section>
 

--- a/app/templates/search/_services_save_search.html
+++ b/app/templates/search/_services_save_search.html
@@ -2,16 +2,13 @@
   <form action="{{ url_for('direct_award.save_search', framework_family=framework_family) }}">
     <input type="hidden" name="search_query" value="{{ search_query_url }}">
     <div class="button-save-wrapper grid-row">
-      <div class="save-summary-text column-three-quarters">
-        Save details of your search and download your search results.
-      </div>
       <div class="save-button column-one-quarter">
         <button id="save-search" class="button-save" role="button" type="submit"
           data-analytics="trackEvent"
           data-analytics-category="Direct Award"
           data-analytics-action="Save search"
           data-analytics-label="{{ search_count }}">
-          Save search
+          Save your search
         </button>
       </div>
     </div>

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -40,6 +40,11 @@
 </header>
 {% endblock %}
 
-{% block post_summary %}
-  {% include 'search/_services_save_search.html' %}
+{% block post_heading %}
+  <section class="column-one-whole" aria-label="Search summary">
+    {% include 'search/_summary.html' %}
+    {% include 'search/_services_save_search.html' %}
+  </section>
 {% endblock %}
+
+{% block pre_results %}{% endblock %}


### PR DESCRIPTION
Ticket: [trello]

Our designers @kubabartwicki and Karl Chillmaid have changed the layout
of the services search page to try and encourage users to notice and use
the 'Save your search' feature.

This PR implements those changes, which are described in detail [in the ticket][trello].
In summary, the search summary and save button are moved to the top of
the page, and the styling of the text for both is tweaked.

This commit also touches the briefs search page slightly, reducing the
margin between the page heading and subheading.

![services search page changes](https://user-images.githubusercontent.com/503614/41776804-0c7464bc-7621-11e8-946b-3bdef148580d.png)
![briefs search page changes](https://user-images.githubusercontent.com/503614/41776850-38a8b25e-7621-11e8-9980-6699bfc35067.png)

[trello]: https://trello.com/c/4ETdzfOe/