### PR TITLE
More meaningful caption and making it consistent.

### DIFF
--- a/app/templates/direct-award/index.html
+++ b/app/templates/direct-award/index.html
@@ -30,10 +30,10 @@
   </header>
 
   <div class="grid">
-    
+
     {{ summary.heading("Searching", id="searching_table") }}
     {% call(item) summary.list_table(open_projects,
-      caption="Summary table",
+      caption="Searching",
       empty_message="You have no saved searches",
       field_headings=[
         "Name",
@@ -48,7 +48,7 @@
 
     {{ summary.heading("Search ended", id="search_ended_table") }}
     {% call(item) summary.list_table(closed_projects,
-      caption="Summary table",
+      caption="Search ended",
       empty_message="You have no saved searches",
       field_headings=[
         "Name",
@@ -62,6 +62,6 @@
     {% endcall %}
 
   </div>
-  
+
 </div>
 {% endblock %}


### PR DESCRIPTION
Change sub summary table caption to be consistent with other similar pages and be more meaningful.
Summary table > Searching
Summary table > Search ended