### PR TITLE
"End search" becomes "before you export"

### DIFF
--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 
-from wtforms.fields import DecimalField, RadioField
+from wtforms.fields import DecimalField, RadioField, BooleanField
 from wtforms.validators import DataRequired, Length, NumberRange, Optional, InputRequired
 
 from dmutils.forms.fields import DateField
@@ -28,6 +28,13 @@ class DMRadioField(RadioField):
     def options(self):
         """The RadioField choices in a format suitable for the frontend toolkit"""
         return [{"label": label, "value": value} for value, label in self.choices]
+
+
+class DMBooleanField(BooleanField):
+    @property
+    def options(self):
+        # Even single boolean fields are expected to be in an 'options' list
+        return [{"label": self.label.text, "value": self.data}]
 
 
 class DidYouAwardAContractForm(FlaskForm):
@@ -125,3 +132,10 @@ class WhyDidYouNotAwardForm(FlaskForm):
 
         self.why_did_you_not_award_the_contract.choices = [(option['value'], option['label']) for option in options]
         self.why_did_you_not_award_the_contract.options = options
+
+
+class BeforeYouDownloadForm(FlaskForm):
+    user_understands = DMBooleanField(
+        "I understand that I cannot edit my search again after I export my results",
+        validators=[InputRequired(message="Please confirm that you understand before you continue.")]
+    )

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -581,7 +581,7 @@ def end_search(framework_family, project_id):
 
         flash(PROJECT_ENDED_MESSAGE, 'success')
 
-        return redirect(url_for('.search_results', framework_family=framework_family, project_id=project['id']))
+        return redirect(url_for('.view_project', framework_family=framework_family, project_id=project['id']))
 
     errors = get_errors_from_wtform(form)
 

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -1,6 +1,6 @@
 {% extends "toolkit/layouts/_base_page.html" %}
 
-{% block page_title %}End your search - Digital Marketplace{% endblock %}
+{% block page_title %}Export your results - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -29,49 +29,61 @@
 {% endblock %}
 
 {% block main_content %}
+{% if errors %}
+  <div class="validation-masthead" aria-labelledby="validation-masthead-heading" aria-role="group" tabindex="-1">
+    <p class="validation-masthead-description">
+      You need to <a href="#user_understands">confirm that you’ve finished editing your search</a> before you
+      continue.
+    </p>
+  </div>
+{% endif %}
+
 
 <div class="end-search-page">
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-two-thirds dmspeak">
       <header class="page-heading">
         <h1>
-          End your search
+          Before you export your results
         </h1>
       </header>
       
-      <div class="dmspeak">
-        <h2 class="heading-xmedium">Before you end your search</h2>
-      </div>
-      <p>You should only continue when you have finished searching for cloud services.</p>
+      <p>Export your search results to keep a record of the services you’ve found.</p>
 
-      <br>
-      <p>You cannot edit your search once it has ended.</p>
-      <br>
+      <p>
+        You can download exported results as a spreadsheet or comma-separated values (CSV). Both file types include
+        suppliers’ service descriptions and contact details.
+      </p>
 
-      <div class="dmspeak">
-        <h2 class="heading-xmedium">After your search has ended</h2>
-      </div>
-      <p>Ending your search will create a spreadsheet of your search results.</p>
-      
-      <br>
-      <p>You can download the spreadsheet and use it to help you review or compare services.</p>
+      <p>Do not export your results if you still need to edit your search.</p>
 
-      <br>
       <form
         action="{{ url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id) }}"
         method="POST"
         >
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+
+        {%
+          with
+          name = form.user_understands.name,
+          type = "checkbox",
+          value = form.user_understands.value,
+          error = errors.get('user_understands', {}).get('message', None),
+          options = form.user_understands.options
+        %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
+
         <button class="button-save end-your-search-button"
           data-analytics="trackEvent"
           data-analytics-category="Direct Award"
           data-analytics-action="End search"
           data-analytics-label="{{ search_count }}"
           {% if disable_end_search_btn %}disabled="disabled"{% endif %}
-          >End search and continue</button>
+          >Export results and continue</button>
       </form>
       
-      <p><a href="{{ url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id) }}">Return to overview</a></p>
+      <p><a href="{{ url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id) }}">Return to your task list</a></p>
     </div>
   </div>
 

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -32,7 +32,7 @@
 {% if errors %}
   <div class="validation-masthead" aria-labelledby="validation-masthead-heading" aria-role="group" tabindex="-1">
     <p>
-      You need to <a href="#user_understands">confirm that you’ve finished editing your search</a> before you
+      You need to <a href="#{{ form.user_understands.id }}">confirm that you’ve finished editing your search</a> before you
       export your results.
     </p>
   </div>

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -15,11 +15,11 @@
         "label": "Your account"
       },
       {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
+        "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
         "label": "Your saved searches"
       },
       {
-        "link": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
         "label": project.name
       }
     ]
@@ -58,7 +58,7 @@
       <p>Do not export your results if you still need to edit your search.</p>
 
       <form
-        action="{{ url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id) }}"
+        action="{{ url_for('direct_award.end_search', framework_family=framework.family, project_id=project.id) }}"
         method="POST"
         >
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
@@ -83,7 +83,7 @@
           >Export results and continue</button>
       </form>
       
-      <p><a href="{{ url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id) }}">Return to your task list</a></p>
+      <p><a href="{{ url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id) }}">Return to your task list</a></p>
     </div>
   </div>
 

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -31,9 +31,9 @@
 {% block main_content %}
 {% if errors %}
   <div class="validation-masthead" aria-labelledby="validation-masthead-heading" aria-role="group" tabindex="-1">
-    <p class="validation-masthead-description">
+    <p>
       You need to <a href="#user_understands">confirm that you’ve finished editing your search</a> before you
-      continue.
+      export your results.
     </p>
   </div>
 {% endif %}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.4.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.5.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#12.2.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -601,7 +601,7 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
         doc = html.fromstring(res.get_data(as_text=True))
         assert doc.get_element_by_id('error-user_understands') is not None
 
-    def test_end_search_redirects_to_results_page(self):
+    def test_end_search_redirects_to_project_page(self):
         self.login_as_buyer()
 
         self.data_api_client.lock_direct_award_project.return_value = self._get_direct_award_lock_project_fixture()
@@ -609,7 +609,7 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
         res = self.client.post('/buyers/direct-award/g-cloud/projects/1/end-search', data={'user_understands': 'True'})
 
         assert res.status_code == 302
-        assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1/results')
+        assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1')
 
 
 class TestDirectAwardAwardContract(TestDirectAwardBase):

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -569,7 +569,7 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
         assert res.status_code == 200
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//h1[contains(normalize-space(), "End your search")]')) == 1
+        assert len(doc.xpath('//h1[contains(normalize-space(), "Before you export your results")]')) == 1
 
     def test_end_search_page_renders_error_when_results_more_than_limit(self):
         self.login_as_buyer()
@@ -589,15 +589,27 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
         assert res.status_code == 200
         assert TOO_MANY_RESULTS_MESSAGE in res.get_data(as_text=True)
 
-    def test_end_search_redirects_to_project_page(self):
+    def test_must_confirm_understanding(self):
         self.login_as_buyer()
 
         self.data_api_client.lock_direct_award_project.return_value = self._get_direct_award_lock_project_fixture()
 
         res = self.client.post('/buyers/direct-award/g-cloud/projects/1/end-search')
 
+        assert res.status_code == 400
+
+        doc = html.fromstring(res.get_data(as_text=True))
+        assert doc.get_element_by_id('error-user_understands') is not None
+
+    def test_end_search_redirects_to_results_page(self):
+        self.login_as_buyer()
+
+        self.data_api_client.lock_direct_award_project.return_value = self._get_direct_award_lock_project_fixture()
+
+        res = self.client.post('/buyers/direct-award/g-cloud/projects/1/end-search', data={'user_understands': 'True'})
+
         assert res.status_code == 302
-        assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1')
+        assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1/results')
 
 
 class TestDirectAwardAwardContract(TestDirectAwardBase):

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "12.2.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#81056e447a8f28075f46a39b52e11cf22ea6ea2e"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.4.0":
-  version "31.4.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#559e18e9feac27ef7076e1c2392598e60ce56c79"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.5.0":
+  version "31.5.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#68e382b09898840e3843ca196ea414bd2ab9b52a"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
"End search" is now cast in terms "being ready to download".

* This is more a content change rather than new functionality, but there is a small form with a tick box that must be ticked.

https://trello.com/c/Z1a3weIe/131-replace-end-search-with-before-you-export-your-results