### PR TITLE
Move search suggestions in search layout

### DIFF
--- a/app/templates/search/_results_wrapper.html
+++ b/app/templates/search/_results_wrapper.html
@@ -1,4 +1,5 @@
 <div id="js-dm-live-search-results" class="js-dm-live-search-fade">
+  {% include 'search/_suggestions.html' %}
   {% include 'search/_{}_results.html'.format(doc_type) %}
   {% include 'search/_pagination.html' %}
 </div>

--- a/app/templates/search/_suggestions.html
+++ b/app/templates/search/_suggestions.html
@@ -1,15 +1,13 @@
 {% if total == 0 %}
 
 <div class="search-suggestion">
-  <p>Suggestions:</p>
+  <p>Improve your search results by:</p>
   <ul class="list list-bullet">
-      <li>try removing filters</li>
-      <li>choose a different category</li>
-      {% if framework_family == 'g-cloud' %}
-        <li>double-check your spelling</li>
-        <li>use fewer keywords</li>
-        <li>search for something less specific, you can refine your results later</li>
-      {% endif %}
+      <li>removing filters</li>
+      <li>choosing a different category</li>
+      <li>double-checking your spelling</li>
+      <li>using fewer keywords</li>
+      <li>searching for something less specific, you can refine your results later</li>
   </ul>
 </div>
 

--- a/app/templates/search/_suggestions.html
+++ b/app/templates/search/_suggestions.html
@@ -1,0 +1,16 @@
+{% if total == 0 %}
+
+<div class="search-suggestion">
+  <p>Suggestions:</p>
+  <ul class="list list-bullet">
+      <li>try removing filters</li>
+      <li>choose a different category</li>
+      {% if framework_family == 'g-cloud' %}
+        <li>double-check your spelling</li>
+        <li>use fewer keywords</li>
+        <li>search for something less specific, you can refine your results later</li>
+      {% endif %}
+  </ul>
+</div>
+
+{% endif %}

--- a/app/templates/search/_summary.html
+++ b/app/templates/search/_summary.html
@@ -2,22 +2,4 @@
   <p class="search-summary">
     {{ summary }}
   </p>
-
-  {% if total == 0 %}
-
-  <div class="search-suggestion">
-    <p>Suggestions:</p>
-    <ul class="list list-bullet">
-        <li>try removing filters</li>
-        <li>choose a different category</li>
-        {% if framework_family == 'g-cloud' %}
-          <li>double-check your spelling</li>
-          <li>use fewer keywords</li>
-          <li>search for something less specific, you can refine your results later</li>
-        {% endif %}
-    </ul>
-  </div>
-
-  {% endif %}
-
 </div>

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1671,14 +1671,16 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
 
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')
         assert res.status_code == 200
-        suggestion = re.findall(r'<p>Suggestions:<\/p>', res.get_data(as_text=True))
-        assert len(suggestion) == 1
+
+        xpath = html.fromstring(res.get_data(as_text=True)).xpath
+        assert xpath('boolean(//div[contains(@class, "search-suggestion")])')
 
     def test_should_not_render_suggestions_when_results(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities')
         assert res.status_code == 200
-        suggestion = re.findall(r'<p>Suggestions:<\/p>', res.get_data(as_text=True))
-        assert len(suggestion) == 0
+
+        xpath = html.fromstring(res.get_data(as_text=True)).xpath
+        assert not xpath('boolean(//div[contains(@class, "search-suggestion")])')
 
     def test_should_ignore_unknown_arguments(self):
         res = self.client.get('/digital-outcomes-and-specialists/opportunities?location=my-lovely-horse')

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -16,8 +16,8 @@ def find_pagination_links(res_data):
 
 
 def find_0_results_suggestion(res_data):
-    return re.findall(
-        r'<p>Suggestions:<\/p>', res_data)
+    xpath = html.fromstring(res_data).xpath
+    return xpath('//div[contains(@class, "search-suggestion")]')
 
 
 def get_0_results_search_response():


### PR DESCRIPTION
@samuelhwilliams spotted that in the 0 results case the search suggestions look out of place since #795.

This commit fixes this by moving the search suggestions out of the search summary component to inside the search results wrapper.

The suggestions have to be inside the results wrapper so it is updated dynamically with the live search.

---

## Side by side

![screen shot 2018-07-02 at 15 49 22 2](https://user-images.githubusercontent.com/503614/42170856-97ce2872-7e0f-11e8-804d-203567ad5b11.png)


