### PR TITLE
Direct award pre-project task list

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,11 +55,15 @@ def create_app(config_name):
 
     from .main import main as main_blueprint
     from .main import direct_award as direct_award_blueprint
+    from .main import direct_award_public as direct_award_public_blueprint
     from .status import status as status_blueprint
 
     application.register_blueprint(status_blueprint)
     application.register_blueprint(main_blueprint)
     application.register_blueprint(direct_award_blueprint)
+    # direct_award_blueprint and direct_award_public_blueprint cover the same url prefix - direct_award_blueprint takes
+    # precedence
+    application.register_blueprint(direct_award_public_blueprint)
 
     # Must be registered last so that any routes declared in the app are registered first (i.e. take precedence over
     # the external NotImplemented routes in the dm-utils external blueprint).

--- a/app/assets/scss/_text.scss
+++ b/app/assets/scss/_text.scss
@@ -3,3 +3,12 @@
 body {
   @include core-19;
 }
+
+.lede {
+  font-size: 100%;
+  margin-bottom: 2em;
+
+  @include media(desktop) {
+    width: 66%;
+  }
+}

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -4,6 +4,7 @@ import flask_featureflags
 
 main = Blueprint('main', __name__)
 direct_award = Blueprint('direct_award', __name__, url_prefix='/buyers/direct-award')
+direct_award_public = Blueprint('direct_award_public', __name__, url_prefix='/buyers/direct-award')
 
 LOGIN_REQUIRED_MESSAGE = "You must log in with a buyer account to see this page."
 

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -1,6 +1,6 @@
 {% extends "toolkit/layouts/_base_page.html" %}
 
-{% block page_title %}{{ project.name }} - Digital Marketplace{% endblock %}
+{% block page_title %}{{ project.name|default("Find cloud hosting, software and support") }} - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -9,7 +9,8 @@
       {
           "link": url_for('main.index'),
           "label": "Digital Marketplace"
-      },
+      }
+    ] + ([
       {
           "link": url_for('external.buyer_dashboard'),
           "label": "Your account"
@@ -18,7 +19,11 @@
           "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
           "label": "Your saved searches"
       }
-    ]
+    ] if project else [
+      {
+          "label": "Find cloud hosting, software and support"
+      }
+    ])
   %}
     {% include "toolkit/breadcrumb.html" %}
   {% endwith %}
@@ -29,12 +34,21 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       {% with
-        heading = project.name
+        heading = project.name|default("Find cloud hosting, software and support")
       %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
     </div>
   </div>
+  {% if not project %}
+    <p class="lede">
+      Before you start you should
+      <a href="https://www.gov.uk/guidance/g-cloud-buyers-guide#requirements">write a list of requirements</a>
+      and
+      <a href="https://www.gov.uk/service-manual/agile-delivery/spend-controls-check-if-you-need-approval-to-spend-money-on-a-service">check if you need approval</a>
+      to spend money on a service.
+    </p>
+  {% endif %}
   <div class="grid-row direct-award-project-overview-page">
     <div class="column-two-thirds">
       {% block before_sections %}{% endblock %}
@@ -48,7 +62,8 @@
                 data-analytics-action=\"External Link\"
                 >buy fairly</a> and assess all the services that you find. Do not combine the results of more than one search."|safe}
             ] + ([
-              {"type": "action", "label": "Start a new search", "href": url_for('main.search_services'), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"}
+              {"type": "action", "label": "Start a new search", "href": url_for('direct_award_public.choose_lot', framework_family=framework.family), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"},
+              {"type": "text", "text": ''.join(["<a href=\"", url_for('direct_award.saved_search_overview', framework_family=framework.family)|e, "\">See a list of your saved searches</a>"])|safe}
             ] if not search_summary_sentence else [
               {"type": "text", "class": ["search-summary", "application-notice", "info-notice"], "text": search_summary_sentence},
               {"type": "text", "text": ''.join(["<a href=\"", buyer_search_page_url|e, "\">Edit your search and view results</a>"])|safe} if not search.searchedAt else {},
@@ -58,9 +73,10 @@
           {
             "body": "Export your results",
             "custom_body_list": [
-              {"type": "text", "text": "Export your search results to keep a record of the services you’ve found. You should only complete this step when you're ready to start assessing services."},
-            {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not search.createdAt else {"type": "action", "label": "Export your results", "href": url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"} if not search.searchedAt else {"type": "box", "style": "complete", "label": "Completed"}
-            ]
+              {"type": "text", "text": "Export your search results to keep a record of the services you’ve found. You should only complete this step when you're ready to start assessing services."}
+            ] + ([
+              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not search.createdAt else {"type": "action", "label": "Export your results", "href": url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"} if not search.searchedAt else {"type": "box", "style": "complete", "label": "Completed"}
+            ] if project else [])
           },
           {
             "body": "Download and assess your results",
@@ -74,9 +90,10 @@
                 data-analytics=\"trackEvent\"
                 data-analytics-category=\"Direct Award\"
                 data-analytics-action=\"Internal Link\"
-              >Download your results again</a>"])|safe} if project.downloadedAt else {},
+              >Download your results again</a>"])|safe} if project.downloadedAt else {}
+            ] + ([
               {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not search.searchedAt else {"type": "action", "label": "Download search results", "href": url_for('direct_award.search_results', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"} if not project.downloadedAt else {"type": "box", "style": "complete", "label": "Completed"}
-            ]
+            ] if project else [])
           },
           {
             "body": "Award a contract",
@@ -97,10 +114,11 @@
                                          data-analytics-action=\"External Link\"
                                         >publish the details on Contracts Finder</a>.
                  Whether or not you award a contract, tell us the outcome. This information helps us improve the Digital Marketplace."|safe},
+            ] + ([
               {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not project.downloadedAt
               else {"type": "box", "style": "complete", "label": project_outcome_label } if project.outcome
               else {"type": "action", "label": "Tell us the outcome", "href": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"}
-            ]
+            ] if project else [])
           },
           {
             "body": "Complete the Customer Benefits Record form",
@@ -121,9 +139,10 @@
                                                                   "<!-- use non-breaking dash TODO: do this in a better way -->",
                  " They will contact you if they find any issues with the supplier."]
                 )
-              },
+              }
+            ] + ([
               {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not project.outcome else {}
-            ]
+            ] if project else [])
           }
 
         ],

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -1,6 +1,8 @@
 {% extends "toolkit/layouts/_base_page.html" %}
 
-{% block page_title %}{{ project.name|default("Find cloud hosting, software and support") }} - Digital Marketplace{% endblock %}
+{% set page_title = project.name|default("Find cloud hosting, software and support") %}
+
+{% block page_title %}{{ page_title }} - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -21,7 +23,7 @@
       }
     ] if project else [
       {
-          "label": "Find cloud hosting, software and support"
+          "label": page_title
       }
     ])
   %}
@@ -34,7 +36,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       {% with
-        heading = project.name|default("Find cloud hosting, software and support")
+        heading = page_title
       %}
         {% include "toolkit/page-heading.html" %}
       {% endwith %}

--- a/app/templates/index-g-cloud.html
+++ b/app/templates/index-g-cloud.html
@@ -7,7 +7,7 @@
     with
     items = [
       {
-          "link": url_for('.index'),
+          "link": url_for('main.index'),
           "label": "Digital Marketplace"
       },
       {
@@ -28,7 +28,7 @@
     </h1>
   </header>
   <div class="grid-row">
-    <form action="{{ url_for('.search_services') }}" method="get" class="search-box column-two-thirds">
+    <form action="{{ url_for('main.search_services') }}" method="get" class="search-box column-two-thirds">
       <input type="text" class="text-box" name="q" maxlength="200">
       <button type="submit" class="button-save">
         Show services

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,6 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.6.0#egg=digitalmarketplace-utils==39.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.11.0#egg=digitalmarketplace-content-loader==4.11.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.4.0#egg=digitalmarketplace-apiclient==17.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@39.3.0#egg=digitalmarketplace-utils==39.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@39.6.0#egg=digitalmarketplace-utils==39.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.11.0#egg=digitalmarketplace-content-loader==4.11.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@17.4.0#egg=digitalmarketplace-apiclient==17.4.0
 

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -246,7 +246,8 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
 
         doc = html.fromstring(res.get_data(as_text=True))
         project_name = self._get_direct_award_project_fixture()['project']['name']
-        assert len(doc.xpath('//h1[contains(normalize-space(text()), "{}")]'.format(project_name))) == 1
+        assert len(doc.xpath('//h1[contains(normalize-space(string()), $t)]', t=project_name)) == 1
+        assert doc.xpath('//head/title[contains(normalize-space(string()), $t)]', t=project_name)
 
     @pytest.mark.parametrize('user_id, expected_status_code', ((122, 404), (123, 200)))
     def test_view_project_checks_user_access_to_project_or_404s(self, user_id, expected_status_code):
@@ -294,6 +295,18 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
         assert self._task_has_link(tasklist, 5, customer_benefits_record_form_url)
         assert self._task_has_link(tasklist, 5, 'mailto:{}'.format(customer_benefits_record_form_email))
 
+        breadcrumbs = doc.xpath("//ol[@role='breadcrumbs']/li")
+        assert tuple(li.xpath("normalize-space(string())") for li in breadcrumbs) == (
+            "Digital Marketplace",
+            "Your account",
+            "Your saved searches",
+        )
+        assert tuple(li.xpath(".//a/@href") for li in breadcrumbs) == (
+            ["/"],
+            ["/buyers"],
+            ["/buyers/direct-award/g-cloud"],
+        )
+
     def test_overview_renders_specific_elements_for_no_search_state(self):
         searches = self._get_direct_award_project_searches_fixture()
 
@@ -313,6 +326,8 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
         assert self._task_has_link(tasklist, 2, '/buyers/direct-award/g-cloud/projects/1/end-search') is False
 
         assert self._cannot_start_from_task(tasklist, 2)
+
+        assert "Before you start you should" not in doc.xpath("normalize-space(string())")
 
     def test_overview_renders_specific_elements_for_search_created_state(self):
         res = self.client.get('/buyers/direct-award/g-cloud/projects/1')

--- a/tests/main/views/test_g_cloud.py
+++ b/tests/main/views/test_g_cloud.py
@@ -1,5 +1,7 @@
 import mock
 
+from lxml import html
+
 from ...helpers import BaseApplicationTest
 
 
@@ -19,7 +21,12 @@ class TestGCloudIndexResults(BaseApplicationTest):
     def test_renders_correct_search_links(self):
         self._search_api_client.search.return_value = self.search_results
 
-        res = self.client.get('/g-cloud')
+        res = self.client.get("/buyers/direct-award/g-cloud/choose-lot")
         assert res.status_code == 200
-        assert 'form action="/g-cloud/search' in res.get_data(as_text=True)
-        assert '/g-cloud/search?lot=' in res.get_data(as_text=True)  # at least one link into a specific lot
+
+        body = res.get_data(as_text=True)
+        doc = html.fromstring(body)
+
+        assert doc.xpath("//form[@action=$u]", u="/g-cloud/search")
+        # at least one link into a specific lot
+        assert doc.xpath("//a[starts-with(@href, $u)]", u="/g-cloud/search?lot=")


### PR DESCRIPTION
Trello https://trello.com/c/YlBpmOkZ/136-gcloud-start-on-the-task-list

 task list: add new view, pre_project_task_list, and adapt views leading into direct-award buyer journey

![pre project task list](https://user-images.githubusercontent.com/807447/42097429-074dcd22-7bb0-11e8-9b3f-3b58a9f906f4.png)

We now show this, initial, version of the task list when entering the journey and the existing lot selection view is renamed to `choose_lot` and placed at a new url. the "Start a new search" action button here now leads to that page.

This also introduces views that are under the "direct award" url path but are not login-restricted, so a new `direct_award_public` blueprint is introduced for this purpose.

The template is the existing "view project" template, which ironically seems to render relatively well if called without a `project`.