### PR TITLE
Add "Completed" to step 1 in task list when saved search has fewer than 30 results

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -492,6 +492,7 @@ def view_project(framework_family, project_id):
         search_meta = SearchMeta(search['searchUrl'], frameworks_by_slug)
 
         search_summary_sentence = search_meta.search_summary.markup()
+        search_results_count = int(search_meta.search_summary.count)
         framework = frameworks_by_slug[search_meta.framework_slug]
         buyer_search_page_url = search_meta.url
 
@@ -500,6 +501,7 @@ def view_project(framework_family, project_id):
 
         search = None
         buyer_search_page_url = None
+        search_results_count = None
         search_summary_sentence = None
 
     content_loader.load_messages(framework['slug'], ['urls'])
@@ -556,6 +558,7 @@ def view_project(framework_family, project_id):
         following_framework=following_framework,
         project=project,
         custom_dimensions=custom_dimensions,
+        search_results_count=search_results_count,
         search=search,
         buyer_search_page_url=buyer_search_page_url,
         search_summary_sentence=search_summary_sentence,

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -69,7 +69,7 @@
             ] if not search_summary_sentence else [
               {"type": "text", "class": ["search-summary", "application-notice", "info-notice"], "text": search_summary_sentence},
               {"type": "text", "text": ''.join(["<a href=\"", buyer_search_page_url|e, "\">Edit your search and view results</a>"])|safe} if not search.searchedAt else {},
-              {"type": "box", "style": "complete", "label": "Completed"} if search.searchedAt else {}
+              {"type": "box", "style": "complete", "label": "Completed"} if search.searchedAt or (search_summary_sentence and search_results_count < 30) else {}
             ])
           },
           {

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -517,6 +517,31 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
 
         assert date in doc.xpath(xpath)[index].text
 
+    def test_search_completed_if_less_than_30_results(self):
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1')
+        assert res.status_code == 200
+
+        body = res.get_data(as_text=True)
+        doc = html.fromstring(body)
+
+        tasklist = doc.xpath('//li[contains(@class, "instruction-list-item")]')
+        assert self._task_completed(tasklist, 1)
+
+    def test_search_not_completed_if_more_than_30_results(self):
+        search_results = self.g9_search_results
+        search_results['meta']['total'] = 100
+
+        self._search_api_client._get.return_value = search_results
+
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1')
+        assert res.status_code == 200
+
+        body = res.get_data(as_text=True)
+        doc = html.fromstring(body)
+
+        tasklist = doc.xpath('//li[contains(@class, "instruction-list-item")]')
+        assert not self._task_completed(tasklist, 1)
+
 
 class TestDirectAwardURLGeneration(BaseApplicationTest):
     """This class has been separated out from above because we only want to mock a couple of methods on the API clients,


### PR DESCRIPTION
@kubabartwicki [noticed][ticket] that there was no completed button on step 1 of the task list when the search has been saved but not locked.

This PR fixes it so that the box is shown, but only when the saved search has fewer than 30 results.

[ticket]: https://trello.com/c/JDIYkGdG

---

## When the search has fewer than 30 results
<img width="663" alt="screen shot 2018-07-03 at 13 07 40" src="https://user-images.githubusercontent.com/503614/42218955-2799b43c-7ec2-11e8-8d11-7c8538a6f146.png">

## When the search has more than 30 results
<img width="682" alt="screen shot 2018-07-03 at 13 06 22" src="https://user-images.githubusercontent.com/503614/42218973-341edd72-7ec2-11e8-9fc8-964c2e758557.png">
