### PR TITLE
Direct Award flow: combine export/download steps; add Ready to Assess

### DIFF
--- a/app/main/helpers/dm_google_analytics.py
+++ b/app/main/helpers/dm_google_analytics.py
@@ -1,0 +1,36 @@
+from enum import Enum
+
+
+class CurrentProjectStageEnum(Enum):
+    SAVED = 'save_and_refine_search'
+    ENDED = 'search_ended'
+    DOWNLOADED = 'download_results'
+    READY_TO_ASSESS = 'ready_to_assess'
+    # the following correspond with digitalmarketplace-api:app.models.outcomes.Outcome.RESULT_CHOICES
+    FAILED = 'none-suitable'
+    CANCELLED = 'cancelled'
+    AWARDED = 'awarded'
+
+
+CUSTOM_DIMENSION_IDENTIFIERS = {
+    CurrentProjectStageEnum: 8
+}
+
+
+def custom_dimension(custom_dimension_enum, value):
+    """
+    Create a custom dimension dictionary for Google Analytics.
+
+    Pass in the relevant enum from this module, and either an instance or an actual value from that enum.
+    """
+
+    if value in CurrentProjectStageEnum:
+        custom_dimension_instance = value
+    else:
+        # If we've been given a string, try to convert it to an instance of the enum - if that fails then it'll be loud.
+        custom_dimension_instance = custom_dimension_enum(value)
+
+    return {
+        "data_id": CUSTOM_DIMENSION_IDENTIFIERS[custom_dimension_enum],
+        "data_value": custom_dimension_instance.value,
+    }

--- a/app/main/helpers/search_save_helpers.py
+++ b/app/main/helpers/search_save_helpers.py
@@ -49,6 +49,10 @@ class SearchMeta(object):
             lots_by_slug
         )
 
+    @property
+    def search_count(self):
+        return int(self.search_summary.count)
+
 
 def get_saved_search_temporary_message_status(project, framework, following_framework):
     if following_framework['status'] in ['coming', 'open', 'pending']:

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -608,7 +608,7 @@ def end_search(framework_family, project_id):
 
         flash(PROJECT_ENDED_MESSAGE, 'success')
 
-        return redirect(url_for('.view_project', framework_family=framework_family, project_id=project['id']))
+        return redirect(url_for('.search_results', framework_family=framework_family, project_id=project['id']))
 
     errors = get_errors_from_wtform(form)
 

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -35,6 +35,7 @@ from ..helpers.search_helpers import (
     clean_request_args, get_request_url_without_any_filters,
 )
 from ..helpers import framework_helpers
+from ..helpers import dm_google_analytics
 from ..helpers.direct_award_helpers import is_direct_award_project_accessible, get_direct_award_projects
 from ..helpers.search_save_helpers import get_saved_search_temporary_message_status, SearchMeta
 from ..helpers.shared_helpers import get_fields_from_manifest, get_questions_from_manifest_by_id
@@ -527,25 +528,19 @@ def view_project(framework_family, project_id):
         project_outcome_label = \
             "Contract awarded to {}: {}".format(archived_service['supplierName'], archived_service['serviceName'])
 
-    # Current Project Stage
-    current_project_stage = None
-
     if project['outcome']:
         current_project_stage = project['outcome']['result']
     elif project['readyToAssessAt']:
-        current_project_stage = 'ready_to_assess'
+        current_project_stage = dm_google_analytics.CurrentProjectStageEnum.READY_TO_ASSESS
     elif project['downloadedAt']:
-        current_project_stage = 'download_results'
+        current_project_stage = dm_google_analytics.CurrentProjectStageEnum.DOWNLOADED
     elif project['lockedAt']:
-        current_project_stage = 'search_ended'
+        current_project_stage = dm_google_analytics.CurrentProjectStageEnum.ENDED
     else:
-        current_project_stage = 'save_and_refine_search'
+        current_project_stage = dm_google_analytics.CurrentProjectStageEnum.SAVED
 
-    # custom dimension for google analytics
-    custom_dimensions = [{
-        "data_id": 8,
-        "data_value": current_project_stage
-    }]
+    custom_dimensions = [dm_google_analytics.custom_dimension(dm_google_analytics.CurrentProjectStageEnum,
+                                                              current_project_stage)]
 
     try:
         following_framework = framework_helpers.get_framework_or_500(

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -532,6 +532,8 @@ def view_project(framework_family, project_id):
 
     if project['outcome']:
         current_project_stage = project['outcome']['result']
+    elif project['readyToAssessAt']:
+        current_project_stage = 'ready_to_assess'
     elif project['downloadedAt']:
         current_project_stage = 'download_results'
     elif project['lockedAt']:

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -493,7 +493,7 @@ def view_project(framework_family, project_id):
         search_meta = SearchMeta(search_api_client, search['searchUrl'], frameworks_by_slug)
 
         search_summary_sentence = search_meta.search_summary.markup()
-        search_results_count = int(search_meta.search_summary.count)
+        can_end_search = search_meta.search_count <= END_SEARCH_LIMIT
         framework = frameworks_by_slug[search_meta.framework_slug]
         buyer_search_page_url = search_meta.url
 
@@ -502,7 +502,7 @@ def view_project(framework_family, project_id):
 
         search = None
         buyer_search_page_url = None
-        search_results_count = None
+        can_end_search = None
         search_summary_sentence = None
 
     content_loader.load_messages(framework['slug'], ['urls'])
@@ -559,7 +559,7 @@ def view_project(framework_family, project_id):
         following_framework=following_framework,
         project=project,
         custom_dimensions=custom_dimensions,
-        search_results_count=search_results_count,
+        can_end_search=can_end_search,
         search=search,
         buyer_search_page_url=buyer_search_page_url,
         search_summary_sentence=search_summary_sentence,
@@ -589,7 +589,7 @@ def end_search(framework_family, project_id):
     search_count = search_meta.search_summary.count
     disable_end_search_btn = False
 
-    if int(search_count) > END_SEARCH_LIMIT:
+    if search_count > END_SEARCH_LIMIT:
         flash(TOO_MANY_RESULTS_MESSAGE, 'error')
         disable_end_search_btn = True
 
@@ -600,7 +600,7 @@ def end_search(framework_family, project_id):
         abort(400)
 
     form = BeforeYouDownloadForm()
-    if form.validate_on_submit() and int(search_count) <= END_SEARCH_LIMIT:
+    if form.validate_on_submit() and search_count <= END_SEARCH_LIMIT:
         try:
             data_api_client.lock_direct_award_project(user_email=current_user.email_address, project_id=project_id)
         except HTTPError as e:

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -133,7 +133,7 @@ negotiate with them.'|safe},
                                                  data-analytics="trackEvent"
                                                  data-analytics-category="Direct Award"
                                                  data-analytics-action="Internal Link">Confirm you have read and
-understood how to assess services</button>'|safe} if project and not project.readyToAssessAt else {},
+understood how to assess services</button>'|safe} if project and not project.readyToAssessAt and not project.outcome else {},
               {"type": "box", "style": "complete", "label": "Completed"} if project and project.readyToAssessAt else {}
             ]
           },
@@ -157,8 +157,8 @@ understood how to assess services</button>'|safe} if project and not project.rea
                                         >publish the details on Contracts Finder</a>.
                  Whether or not you award a contract, tell us the outcome. This information helps us improve the Digital Marketplace."|safe},
             ] + ([
-              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not project.readyToAssessAt
-              else {"type": "box", "style": "complete", "label": project_outcome_label } if project.outcome
+              {"type": "box", "style": "complete", "label": project_outcome_label } if project.outcome
+              else {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not project.readyToAssessAt
               else {"type": "action", "label": "Tell us the outcome", "href": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"}
             ] if project else [])
           },

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -104,7 +104,7 @@ assess services. Keep a copy for your records.'},
    data-analytics="trackEvent"
    data-analytics-category="Direct Award"
    data-analytics-action="Internal Link"
->Download your results again</a>'])|safe} if project else {},
+>Download your results</a>'])|safe} if project else {},
               {"type": "box", "style": "complete", "label": "Completed"} if project and search.searchedAt else {}
             ]
           },

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -95,7 +95,7 @@
           {
             "body": "Download and assess your results",
             "custom_body_list": [
-              {"type": "text", "text": ''.join(["Download a spreadsheet of suppliers’ service descriptions and contact details. Follow the <a href=\"", framework_urls.buyers_guide_compare_services_url|e, "\" target=\"_blank\" rel=\"external noopener noreferrer\"
+              {"type": "text", "text": ''.join(["Download a spreadsheet of suppliers’ service descriptions and contact details. Follow the <a href=\"https://www.gov.uk/guidance/g-cloud-buyers-guide#review-and-compare-services\" target=\"_blank\" rel=\"external noopener noreferrer\"
                 data-analytics=\"trackEvent\"
                 data-analytics-category=\"Direct Award\"
                 data-analytics-action=\"External Link\"

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -83,7 +83,7 @@
             ] if not search_summary_sentence else [
               {"type": "text", "class": ["search-summary", "application-notice", "info-notice"], "text": search_summary_sentence},
               {"type": "text", "text": ''.join(["<a href=\"", buyer_search_page_url|e, "\">Edit your search and view results</a>"])|safe} if not search.searchedAt else {},
-              {"type": "box", "style": "complete", "label": "Completed"} if search.searchedAt or (search_results_count and search_results_count < 30) else {}
+              {"type": "box", "style": "complete", "label": "Completed"} if search.searchedAt or can_end_search else {}
             ])
           },
           {
@@ -92,19 +92,22 @@
               {"type": "text", "text": '
 Export a list of the services you’ve found. Download suppliers’ service descriptions and contact details to help you
 assess services. Keep a copy for your records.'},
-              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if project and not search.createdAt
+              {"type": "text", "text": '<p class="browse-list-item-status-angry"><strong>You have too many services to
+assess. Refine your search until you have no more than 30 results.</strong></p>'} if project and not can_end_search else {},
+              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if project and not (search.searchedAt
+              or can_end_search)
                 else
               {"type": "action", "label": "Export your results",
                "href": url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id),
                "analytics": "trackEvent", "analytics_category": "Direct Award",
-               "analytics_action": "Internal Link"} if project and not search.searchedAt
+               "analytics_action": "Internal Link"} if project and not search.searchedAt and can_end_search
                 else
               {"type": "text", "text": ''.join(['
 <a href="', url_for('direct_award.search_results', framework_family=framework.framework, project_id=project.id)|e, '"
    data-analytics="trackEvent"
    data-analytics-category="Direct Award"
    data-analytics-action="Internal Link"
->Download your results</a>'])|safe} if project else {},
+>Download your results</a>'])|safe} if project and search.searchedAt else {},
               {"type": "box", "style": "complete", "label": "Completed"} if project and search.searchedAt else {}
             ]
           },

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -65,7 +65,9 @@
   {% endif %}
   <div class="grid-row direct-award-project-overview-page">
     <div class="column-two-thirds">
-      {% block before_sections %}{% endblock %}
+      {% if project %}<form action="{{url_for('direct_award.update_project', framework_family=framework.framework, project_id=project.id)}}" method="post">{% endif %}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        {% block before_sections %}{% endblock %}
         {% with items = [
           {
             "body": "Save a search",
@@ -81,33 +83,56 @@
             ] if not search_summary_sentence else [
               {"type": "text", "class": ["search-summary", "application-notice", "info-notice"], "text": search_summary_sentence},
               {"type": "text", "text": ''.join(["<a href=\"", buyer_search_page_url|e, "\">Edit your search and view results</a>"])|safe} if not search.searchedAt else {},
-              {"type": "box", "style": "complete", "label": "Completed"} if search.searchedAt or (search_summary_sentence and search_results_count < 30) else {}
+              {"type": "box", "style": "complete", "label": "Completed"} if search.searchedAt or (search_results_count and search_results_count < 30) else {}
             ])
           },
           {
             "body": "Export your results",
             "custom_body_list": [
-              {"type": "text", "text": "Export your search results to keep a record of the services you’ve found. You should only complete this step when you're ready to start assessing services."}
-            ] + ([
-              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not search.createdAt else {"type": "action", "label": "Export your results", "href": url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"} if not search.searchedAt else {"type": "box", "style": "complete", "label": "Completed"}
-            ] if project else [])
+              {"type": "text", "text": '
+Export a list of the services you’ve found. Download suppliers’ service descriptions and contact details to help you
+assess services. Keep a copy for your records.'},
+              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if project and not search.createdAt
+                else
+              {"type": "action", "label": "Export your results",
+               "href": url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id),
+               "analytics": "trackEvent", "analytics_category": "Direct Award",
+               "analytics_action": "Internal Link"} if project and not search.searchedAt
+                else
+              {"type": "text", "text": ''.join(['
+<a href="', url_for('direct_award.search_results', framework_family=framework.framework, project_id=project.id)|e, '"
+   data-analytics="trackEvent"
+   data-analytics-category="Direct Award"
+   data-analytics-action="Internal Link"
+>Download your results again</a>'])|safe} if project else {},
+              {"type": "box", "style": "complete", "label": "Completed"} if project and search.searchedAt else {}
+            ]
           },
           {
-            "body": "Download and assess your results",
+            "body": "Start assessing services",
             "custom_body_list": [
-              {"type": "text", "text": ''.join(["Download a spreadsheet of suppliers’ service descriptions and contact details. Follow the <a href=\"https://www.gov.uk/guidance/g-cloud-buyers-guide#review-and-compare-services\" target=\"_blank\" rel=\"external noopener noreferrer\"
-                data-analytics=\"trackEvent\"
-                data-analytics-category=\"Direct Award\"
-                data-analytics-action=\"External Link\"
-                >guidance for assessing services</a>. Do not hold a competition to decide the winner."])|safe},
-              {"type": "text", "text": ''.join(["<a href=\"", url_for('direct_award.search_results', framework_family=framework.framework, project_id=project.id)|e, "\"
-                data-analytics=\"trackEvent\"
-                data-analytics-category=\"Direct Award\"
-                data-analytics-action=\"Internal Link\"
-              >Download your results again</a>"])|safe} if project.downloadedAt else {}
-            ] + ([
-              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not search.searchedAt else {"type": "action", "label": "Download search results", "href": url_for('direct_award.search_results', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"} if not project.downloadedAt else {"type": "box", "style": "complete", "label": "Completed"}
-            ] if project else [])
+              {"type": "text", "text": '
+Follow the <a href="https://www.gov.uk/guidance/g-cloud-buyers-guide#review-and-compare-services"
+              target="_blank" rel="external noopener noreferrer"
+              data-analytics="trackEvent"
+              data-analytics-category="Direct Award"
+              data-analytics-action="External Link">guidance for assessing services</a>. Choose the one that best meets
+your budget and requirements.Do not hold a competition to decide the winner. You can
+<a href="https://www.gov.uk/guidance/g-cloud-buyers-guide#what-to-do-if-you-have-a-question-for-the-suppliers
+   data-analytics="trackEvent"
+   data-analytics-category="Direct Award"
+   data-analytics-action="External Link">contact suppliers to ask clarification questions</a>, but you must not
+negotiate with them.'|safe},
+              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if project and not search.searchedAt
+                else
+              {"type": "text", "text": '<button class="instruction-list-item-action button-save" id="ready-to-assess-button" name="readyToAssess"
+                                                value="true"
+                                                 data-analytics="trackEvent"
+                                                 data-analytics-category="Direct Award"
+                                                 data-analytics-action="Internal Link">Confirm you have read and
+understood how to assess services</button>'|safe} if project and not project.readyToAssessAt else {},
+              {"type": "box", "style": "complete", "label": "Completed"} if project and project.readyToAssessAt else {}
+            ]
           },
           {
             "body": "Award a contract",
@@ -129,7 +154,7 @@
                                         >publish the details on Contracts Finder</a>.
                  Whether or not you award a contract, tell us the outcome. This information helps us improve the Digital Marketplace."|safe},
             ] + ([
-              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not project.downloadedAt
+              {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not project.readyToAssessAt
               else {"type": "box", "style": "complete", "label": project_outcome_label } if project.outcome
               else {"type": "action", "label": "Tell us the outcome", "href": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"}
             ] if project else [])
@@ -164,6 +189,7 @@
         %}
           {% include "toolkit/instruction-list.html" %}
         {% endwith %}
+      {% if project %}</form>{% endif %}
     </div>
     {% include "direct-award/_saved-search-not-locked-project-temp-message.html" %}
   </div>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.5.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#12.2.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.0.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   },
   "scripts": {

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.6.0#egg=digitalmarketplace-utils==39.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.11.0#egg=digitalmarketplace-content-loader==4.11.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@18.0.0#egg=digitalmarketplace-apiclient==18.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@18.1.0#egg=digitalmarketplace-apiclient==18.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==3.8.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@39.6.0#egg=digitalmarketplace-utils==39.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.11.0#egg=digitalmarketplace-content-loader==4.11.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@18.0.0#egg=digitalmarketplace-apiclient==18.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@18.1.0#egg=digitalmarketplace-apiclient==18.1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0

--- a/tests/fixtures/direct_award_project_fixture.json
+++ b/tests/fixtures/direct_award_project_fixture.json
@@ -6,6 +6,7 @@
     "id": 1,
     "lockedAt": null,
     "name": "My procurement project <",
+    "readyToAssessAt": null,
     "outcome": null,
     "users": [
       {

--- a/tests/fixtures/direct_award_project_list_fixture.json
+++ b/tests/fixtures/direct_award_project_list_fixture.json
@@ -13,6 +13,7 @@
             "id": 731851428862851,
             "lockedAt": null,
             "name": "gfgffd",
+            "readyToAssessAt": null,
             "outcome": null
         },
         {
@@ -21,6 +22,7 @@
             "downloadedAt": "2018-06-19T13:37:30.849304Z",
             "id": 272774709812396,
             "lockedAt": "2018-06-19T13:37:03.176398Z",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "name": "22",
             "outcome": {
                 "award": {
@@ -56,6 +58,7 @@
             "id": 775976891996651,
             "lockedAt": "2018-06-18T13:31:32.964841Z",
             "name": "ffsdfds",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "completed": true,
                 "completedAt": "2018-06-22T10:44:51.794561Z",
@@ -75,6 +78,7 @@
             "id": 815142480189020,
             "lockedAt": "2018-06-18T13:25:57.345574Z",
             "name": "test",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "award": {
                     "awardValue": "12321312.00",
@@ -109,6 +113,7 @@
             "id": 268606220191818,
             "lockedAt": "2018-06-18T11:36:22.884927Z",
             "name": "tests",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": null
         },
         {
@@ -152,6 +157,7 @@
             "id": 593972053423021,
             "lockedAt": "2018-06-13T12:04:07.847282Z",
             "name": "fsdfdsf",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "completed": true,
                 "completedAt": "2018-06-13T12:04:20.827236Z",
@@ -171,6 +177,7 @@
             "id": 227095350451575,
             "lockedAt": "2018-06-13T10:51:51.523409Z",
             "name": "www",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "completed": true,
                 "completedAt": "2018-06-13T10:52:52.685831Z",
@@ -190,6 +197,7 @@
             "id": 730286113278571,
             "lockedAt": "2018-06-13T10:25:14.193930Z",
             "name": "Show case",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "completed": true,
                 "completedAt": "2018-06-13T10:40:27.093719Z",
@@ -209,6 +217,7 @@
             "id": 144042085826852,
             "lockedAt": "2018-06-13T10:21:08.400577Z",
             "name": "test demo",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "completed": true,
                 "completedAt": "2018-06-13T10:21:43.672052Z",
@@ -228,6 +237,7 @@
             "id": 165117951600742,
             "lockedAt": "2018-06-13T12:05:16.496730Z",
             "name": "test",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "completed": true,
                 "completedAt": "2018-06-13T12:05:27.620283Z",
@@ -247,6 +257,7 @@
             "id": 574178156337956,
             "lockedAt": "2018-06-13T10:10:19.994795Z",
             "name": "tests",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "award": {
                     "awardValue": "30000.00",
@@ -281,6 +292,7 @@
             "id": 926231560227386,
             "lockedAt": "2018-06-13T10:06:42.204796Z",
             "name": "test demo",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "completed": true,
                 "completedAt": "2018-06-13T10:08:43.750329Z",
@@ -300,6 +312,7 @@
             "id": 238699020615674,
             "lockedAt": "2018-06-13T11:38:55.352146Z",
             "name": "fdsfs",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "award": {
                     "awardValue": "312321.00",
@@ -334,6 +347,7 @@
             "id": 883222647744645,
             "lockedAt": "2018-06-11T13:34:43.351200Z",
             "name": "testeste",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "completed": true,
                 "completedAt": "2018-06-12T13:21:17.003408Z",
@@ -353,6 +367,7 @@
             "id": 322775348397661,
             "lockedAt": "2018-06-13T12:05:40.515822Z",
             "name": "test",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "award": {
                     "awardValue": "1234.00",
@@ -406,6 +421,7 @@
             "id": 255107990746615,
             "lockedAt": "2018-06-07T11:25:32.884392Z",
             "name": "dfsfdsfda",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": null
         },
         {
@@ -415,6 +431,7 @@
             "id": 606869699839590,
             "lockedAt": "2018-06-07T14:09:16.255121Z",
             "name": "fdsfs",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "outcome": {
                 "award": {
                     "awardValue": "123.00",
@@ -448,6 +465,7 @@
             "downloadedAt": "2018-05-24T12:08:25.251541Z",
             "id": 207198828251156,
             "lockedAt": "2018-05-24T12:08:21.207534Z",
+            "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
             "name": "test",
             "outcome": null
         }

--- a/tests/fixtures/direct_award_project_outcome_awarded_fixture.json
+++ b/tests/fixtures/direct_award_project_outcome_awarded_fixture.json
@@ -3,6 +3,9 @@
     "result": "awarded",
     "completed": false,
     "resultOfDirectAward": {
+      "archivedService" : {
+        "id": 123456789
+      },
       "project": {
         "id": 1
       }

--- a/tests/main/helpers/test_dm_google_analytics.py
+++ b/tests/main/helpers/test_dm_google_analytics.py
@@ -1,0 +1,19 @@
+import pytest
+
+from app.main.helpers.dm_google_analytics import custom_dimension, CurrentProjectStageEnum
+
+
+def test_custom_dimension_create_with_enum_instance():
+    dimension_dict = custom_dimension(CurrentProjectStageEnum, CurrentProjectStageEnum.AWARDED)
+    assert dimension_dict == {'data_id': 8, 'data_value': 'awarded'}
+
+
+def test_custom_dimension_create_with_string():
+    dimension_dict = custom_dimension(CurrentProjectStageEnum, 'awarded')
+    assert dimension_dict == {'data_id': 8, 'data_value': 'awarded'}
+
+
+def test_custom_dimension_fail():
+    with pytest.raises(ValueError) as excinfo:
+        custom_dimension(CurrentProjectStageEnum, 'fubar')
+    assert "'fubar' is not a valid CurrentProjectStageEnum" in str(excinfo)

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -393,6 +393,25 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
         assert self._task_has_link(tasklist, 4,
                                    '/buyers/direct-award/g-cloud/projects/1/did-you-award-contract')
 
+    def test_assess_button_not_present_if_outcome_awarded(self):
+        searches = self._get_direct_award_project_searches_fixture()
+        for search in searches['searches']:
+            search['searchedAt'] = search['createdAt']
+
+        self.data_api_client.get_direct_award_project.return_value = \
+            self._get_direct_award_project_with_completed_outcome_awarded_fixture()
+
+        self.data_api_client.find_direct_award_project_searches.return_value = searches
+
+        res = self.client.get("/buyers/direct-award/g-cloud/projects/1")
+        assert res.status_code == 200
+
+        body = res.get_data(as_text=True)
+        doc = html.fromstring(body)
+        tasklist = doc.xpath('//li[contains(@class, "instruction-list-item")]')
+
+        assert not self._task_has_button(tasklist, 3, 'readyToAssess', 'true')
+
     @pytest.mark.parametrize(
         ('framework_status', 'following_framework_status', 'locked_at', 'position', 'heading'),
         (

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -630,7 +630,7 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
         doc = html.fromstring(res.get_data(as_text=True))
         assert doc.get_element_by_id('error-user_understands') is not None
 
-    def test_end_search_redirects_to_project_page(self):
+    def test_end_search_redirects_to_results_page(self):
         self.login_as_buyer()
 
         self.data_api_client.lock_direct_award_project.return_value = self._get_direct_award_lock_project_fixture()
@@ -638,7 +638,7 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
         res = self.client.post('/buyers/direct-award/g-cloud/projects/1/end-search', data={'user_understands': 'True'})
 
         assert res.status_code == 302
-        assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1')
+        assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1/results')
 
 
 class TestDirectAwardAwardContract(TestDirectAwardBase):

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -272,8 +272,8 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
         assert self._task_has_link(tasklist, 1, 'https://www.gov.uk/guidance/g-cloud-buyers-guide#fairness')
 
         # Step 3 should link to guidance on comparing services.
-        buyer_guide_compare_services_url = self.content_loader.get_message('g9', 'urls',
-                                                                           'buyers_guide_compare_services_url')
+        buyer_guide_compare_services_url = \
+            "https://www.gov.uk/guidance/g-cloud-buyers-guide#review-and-compare-services"
         assert self._task_has_link(tasklist, 3, buyer_guide_compare_services_url)
 
         # Step 5 has a link to framework customer benefits form and customer benefits form email address.

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -13,7 +13,8 @@ from dmcontent.content_loader import ContentLoader, ContentNotFoundError
 from dmutils.api_stubs import framework
 
 from app import search_api_client, content_loader
-from app.main.views.g_cloud import DownloadResultsView, END_SEARCH_LIMIT, TOO_MANY_RESULTS_MESSAGE
+from app.main.views.g_cloud import (DownloadResultsView, END_SEARCH_LIMIT, TOO_MANY_RESULTS_MESSAGE,
+                                    CONFIRM_START_ASSESSING_MESSAGE, )
 from ...helpers import BaseApplicationTest
 
 
@@ -200,6 +201,13 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
 
         return len(anchors) == 1
 
+    def _task_has_button(self, tasklist, task, name, value):
+        """Task here refers to the tasklist item number rather than the zero-indexed python array. This feels easier to
+        understand and amend in the context of the tasklist."""
+        anchors = tasklist[task - 1].xpath('.//button[@name="{}" and @value="{}"]'.format(name, value))
+
+        return len(anchors) == 1
+
     def _task_has_box(self, tasklist, task, style, text):
         if task <= 0:
             raise ValueError()
@@ -251,7 +259,7 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
         body = res.get_data(as_text=True)
         doc = html.fromstring(body)
 
-        item_headings = ['Save a search', 'Export your results', 'Download and assess your results',
+        item_headings = ['Save a search', 'Export your results', 'Start assessing',
                          'Award a contract', 'Complete the Customer Benefits Record form']
 
         tasklist = doc.xpath('//li[contains(@class, "instruction-list-item")]')
@@ -352,19 +360,19 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
 
         assert self._task_has_link(tasklist, 1, '/g-cloud/search?q=accelerator') is False
         assert self._task_completed(tasklist, 2)
-        assert self._task_has_link(tasklist, 3,
+        assert self._task_has_link(tasklist, 2,
                                    '/buyers/direct-award/g-cloud/projects/1/results')
-
+        assert self._task_has_button(tasklist, 3, 'readyToAssess', 'true')
         assert self._task_has_link(tasklist, 4,
                                    '/buyers/direct-award/g-cloud/projects/1/did-you-award-contract') is False
 
-    def test_overview_renders_specific_elements_for_search_downloaded_state(self):
+    def test_overview_renders_specific_elements_once_assessing_started(self):
         searches = self._get_direct_award_project_searches_fixture()
         for search in searches['searches']:
             search['searchedAt'] = search['createdAt']
 
         project = self._get_direct_award_project_fixture()
-        project['project']['downloadedAt'] = project['project']['createdAt']
+        project['project']['readyToAssessAt'] = project['project']['createdAt']
         self.data_api_client.get_direct_award_project.return_value = project
 
         self.data_api_client.find_direct_award_project_searches.return_value = searches
@@ -378,11 +386,12 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
         tasklist = doc.xpath('//li[contains(@class, "instruction-list-item")]')
 
         assert self._task_has_link(tasklist, 1, '/g-cloud/search?q=accelerator') is False
-        assert self._task_completed(tasklist, 3)
-        assert self._task_has_link(tasklist, 3,
+        assert self._task_completed(tasklist, 2)
+        assert self._task_has_link(tasklist, 2,
                                    '/buyers/direct-award/g-cloud/projects/1/results')
-
-        assert self._cannot_start_from_task(tasklist, 5)
+        assert self._task_completed(tasklist, 3)
+        assert self._task_has_link(tasklist, 4,
+                                   '/buyers/direct-award/g-cloud/projects/1/did-you-award-contract')
 
     @pytest.mark.parametrize(
         ('framework_status', 'following_framework_status', 'locked_at', 'position', 'heading'),
@@ -639,6 +648,26 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
 
         assert res.status_code == 302
         assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1/results')
+
+
+class TestDirectAwardReadyToAssess(TestDirectAwardBase):
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.data_api_client.get_direct_award_project.return_value = self._get_direct_award_lock_project_fixture()
+        self.data_api_client.find_direct_award_project_services.return_value = \
+            self._get_direct_award_project_services_fixture()
+
+        self.data_api_client.get_direct_award_project.return_value = self._get_direct_award_lock_project_fixture()
+
+    def test_ready_button_does_something(self):
+        self.login_as_buyer()
+        res = self.client.post('/buyers/direct-award/g-cloud/projects/1', data={"readyToAssess": "true"})
+
+        assert res.status_code == 302
+        assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1')
+        self.data_api_client.update_direct_award_project.assert_called_once_with(
+            project_data={'readyToAssess': True}, project_id=1, user_email='buyer@email.com')
+        self.assert_flashes(html_escape(CONFIRM_START_ASSESSING_MESSAGE))
 
 
 class TestDirectAwardAwardContract(TestDirectAwardBase):

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -539,6 +539,10 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
 
         tasklist = doc.xpath('//li[contains(@class, "instruction-list-item")]')
         assert not self._task_completed(tasklist, 1)
+        assert self._cannot_start_from_task(tasklist, 2)
+        assert len(doc.xpath(
+            '(//li[contains(@class, "instruction-list-item")])[2]/p[contains(normalize-space(),'
+            ' "You have too many services to assess.")]')) == 1
 
 
 class TestDirectAwardURLGeneration(BaseApplicationTest):

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#12.2.0":
-  version "12.2.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#81056e447a8f28075f46a39b52e11cf22ea6ea2e"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.0.0":
+  version "13.0.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#496805f96eb4177106dabb21bf7eba4faad57e4d"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.5.0":
   version "31.5.0"


### PR DESCRIPTION
We're combining the _export_ (=='end search') step and the _download_ step, and we're adding a new _start assessing_ step, which in terms of actions just requires a single button press on the task list.

Probably loads of stuff wrong with this, but feels like I might as well get the PR up there already...

There's also a little tidy-up / deduplication of the logic for determining whether a search can be "ended" (which for users we are now calling "exporting").

<img width="492" alt="screen shot 2018-07-04 at 11 21 14" src="https://user-images.githubusercontent.com/190828/42271984-ad046a80-7f7c-11e8-8012-e66bc10de760.png">
<img width="516" alt="screen shot 2018-07-04 at 11 22 20" src="https://user-images.githubusercontent.com/190828/42271986-ad46d104-7f7c-11e8-85d0-fa04308ddd13.png">
<img width="618" alt="screen shot 2018-07-04 at 11 22 39" src="https://user-images.githubusercontent.com/190828/42271985-ad26f7da-7f7c-11e8-9e8e-1c12140f504a.png">

Depends on:
* https://github.com/alphagov/digitalmarketplace-api/pull/814
* https://github.com/alphagov/digitalmarketplace-apiclient/pull/150
* https://github.com/alphagov/digitalmarketplace-frameworks/pull/530