### PR TITLE
Refactoring helper functions that use the search API client

### DIFF
--- a/app/main/helpers/search_save_helpers.py
+++ b/app/main/helpers/search_save_helpers.py
@@ -3,7 +3,7 @@ from enum import Enum
 from flask import abort, current_app, url_for
 from werkzeug.datastructures import MultiDict
 
-from app import search_api_client, content_loader
+from app import content_loader
 from app.main.helpers.framework_helpers import get_lots_by_slug
 from app.main.helpers.search_helpers import clean_request_args
 from app.main.presenters.search_presenters import filters_for_lot
@@ -21,7 +21,7 @@ class SavedSearchStateEnum(Enum):
 
 
 class SearchMeta(object):
-    def __init__(self, search_api_url, frameworks_by_slug, include_markup=False):
+    def __init__(self, search_api_client, search_api_url, frameworks_by_slug, include_markup=False):
         # Get core data
         self.framework_slug = search_api_client.get_index_from_search_api_url(search_api_url)
         framework = frameworks_by_slug[self.framework_slug]

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 
 from werkzeug.datastructures import MultiDict
 
-from app import search_api_client
 from ..helpers.framework_helpers import get_lots_by_slug
 from ..helpers.search_helpers import (
     get_filters_from_request,
@@ -113,7 +112,9 @@ def _get_category_filter_key_set(category_filter_group):
     return keys
 
 
-def _get_aggregations_for_lot_with_filters(lot, content_manifest, framework, cleaned_request_args, doc_type, index):
+def _get_aggregations_for_lot_with_filters(
+    lot, content_manifest, framework, cleaned_request_args, doc_type, index, search_api_client
+):
     filters = filters_for_lot(lot, content_manifest, all_lots=framework['lots'])
     lots_by_slug = get_lots_by_slug(framework)
 
@@ -177,7 +178,7 @@ def _update_base_url_args_for_lot_and_category(url_args, keys_to_remove, lot_slu
 
 def build_lots_and_categories_link_tree(
     framework, lots, category_filter_group, request, cleaned_request_args,
-    content_manifest, doc_type, index, search_link_builder
+    content_manifest, doc_type, index, search_link_builder, search_api_client
 ):
     """
     Equivalent of set_filter_states but for where we are creating a tree of links i.e. the
@@ -221,7 +222,7 @@ def build_lots_and_categories_link_tree(
 
     aggregations_by_lot = {
         lot['slug']: _get_aggregations_for_lot_with_filters(
-            lot['slug'], content_manifest, framework, cleaned_request_args, doc_type, index
+            lot['slug'], content_manifest, framework, cleaned_request_args, doc_type, index, search_api_client
         ) for lot in lots
     }
 

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -490,7 +490,7 @@ def view_project(framework_family, project_id):
     if searches:
         # A Direct Award project has one 'active' search which is what we will display on this overview page.
         search = list(filter(lambda x: x['active'], searches))[0]
-        search_meta = SearchMeta(search['searchUrl'], frameworks_by_slug)
+        search_meta = SearchMeta(search_api_client, search['searchUrl'], frameworks_by_slug)
 
         search_summary_sentence = search_meta.search_summary.markup()
         search_results_count = int(search_meta.search_summary.count)
@@ -585,7 +585,7 @@ def end_search(framework_family, project_id):
                                                                   project_id=project['id'],
                                                                   only_active=True)['searches']
     search = searches[0]
-    search_meta = SearchMeta(search['searchUrl'], frameworks_by_slug)
+    search_meta = SearchMeta(search_api_client, search['searchUrl'], frameworks_by_slug)
     search_count = search_meta.search_summary.count
     disable_end_search_btn = False
 
@@ -945,7 +945,7 @@ class DownloadResultsView(SimpleDownloadFileView):
 
             all_services.append(service)
 
-        search_meta = SearchMeta(search['searchUrl'], frameworks_by_slug)
+        search_meta = SearchMeta(search_api_client, search['searchUrl'], frameworks_by_slug)
 
         file_context = {
             'framework': frameworks_by_slug[framework_slug]['name'],

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -274,6 +274,7 @@ def search_services():
         doc_type,
         framework['slug'],
         Href(url_for('.{}'.format(view_name))),
+        search_api_client
     )
 
     filter_form_hidden_fields_by_name = {

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -270,6 +270,7 @@ def list_opportunities(framework_family):
         doc_type,
         index,
         Href(url_for('.{}'.format(view_name), framework_family=framework['framework'])),
+        search_api_client
     )
 
     filter_form_hidden_fields_by_name = {

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -311,7 +311,7 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
         # in these tests, the key 'category' key is 'checkboxTreeExample'
 
         self.search_api_client_patch = mock.patch(
-            'app.main.presenters.search_presenters.search_api_client', autospec=True
+            'app.main.views.g_cloud.search_api_client', autospec=True
         )
         self.search_api_client = self.search_api_client_patch.start()
         self.search_api_client.aggregate.return_value = _get_g9_aggregations_fixture_data()
@@ -324,10 +324,18 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
         url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&filterExample=option+1" \
               "&checkboxTreeExample=option+1&page=2"
         with self.app.test_request_context(url):
-            selection = build_lots_and_categories_link_tree(self.framework, self.framework['lots'],
-                                                            self.category_filter_group, flask.request,
-                                                            flask.request.args, g9_builder, 'services', 'g-cloud-9',
-                                                            Href(flask.url_for('.search_services')))
+            selection = build_lots_and_categories_link_tree(
+                self.framework,
+                self.framework['lots'],
+                self.category_filter_group,
+                flask.request,
+                flask.request.args,
+                g9_builder,
+                'services',
+                'g-cloud-9',
+                Href(flask.url_for('.search_services')),
+                self.search_api_client
+            )
             assert len(selection) == 3  # all -> software -> option1
 
             tree_root = selection[0]
@@ -360,10 +368,18 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
     def test_sub_category_selection(self):
         url = "/g-cloud/search?q=&lot=cloud-software&otherfilter=somevalue&checkboxTreeExample=option+2.2"
         with self.app.test_request_context(url):
-            selection = build_lots_and_categories_link_tree(self.framework, self.framework['lots'],
-                                                            self.category_filter_group, flask.request,
-                                                            flask.request.args, g9_builder, 'services', 'g-cloud-9',
-                                                            Href(flask.url_for('.search_services')))
+            selection = build_lots_and_categories_link_tree(
+                self.framework,
+                self.framework['lots'],
+                self.category_filter_group,
+                flask.request,
+                flask.request.args,
+                g9_builder,
+                'services',
+                'g-cloud-9',
+                Href(flask.url_for('.search_services')),
+                self.search_api_client
+            )
             assert len(selection) == 5  # all -> software -> option2 -> option2.2; option2 as a parent category filter
 
             tree_root = selection[0]
@@ -383,10 +399,18 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
     def test_build_lots_and_categories_link_tree_with_no_categories_or_filters(self):
         url = "/g-cloud/search"
         with self.app.test_request_context(url):
-            tree = build_lots_and_categories_link_tree(self.framework, self.framework['lots'],
-                                                       self.category_filter_group, flask.request,
-                                                       flask.request.args, g9_builder, 'services', 'g-cloud-9',
-                                                       Href(flask.url_for('.search_services')))
+            tree = build_lots_and_categories_link_tree(
+                self.framework,
+                self.framework['lots'],
+                self.category_filter_group,
+                flask.request,
+                flask.request.args,
+                g9_builder,
+                'services',
+                'g-cloud-9',
+                Href(flask.url_for('.search_services')),
+                self.search_api_client
+            )
 
             assert tree == [
                 {
@@ -422,10 +446,18 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
     def test_build_lots_and_categories_link_tree_with_lot(self):
         url = "/g-cloud/search?lot=cloud-software"
         with self.app.test_request_context(url):
-            tree = build_lots_and_categories_link_tree(self.framework, self.framework['lots'],
-                                                       self.category_filter_group, flask.request,
-                                                       flask.request.args, g9_builder, 'services', 'g-cloud-9',
-                                                       Href(flask.url_for('.search_services')))
+            tree = build_lots_and_categories_link_tree(
+                self.framework,
+                self.framework['lots'],
+                self.category_filter_group,
+                flask.request,
+                flask.request.args,
+                g9_builder,
+                'services',
+                'g-cloud-9',
+                Href(flask.url_for('.search_services')),
+                self.search_api_client
+            )
 
             assert tree == [
                 {
@@ -606,10 +638,18 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
     def test_build_lots_and_categories_link_tree_with_lot_and_no_category_filters_has_all_lots_in_root_node(self):
         url = "/g-cloud/search?lot=cloud-software"
         with self.app.test_request_context(url):
-            tree = build_lots_and_categories_link_tree(self.framework, self.framework['lots'],
-                                                       None, flask.request,
-                                                       flask.request.args, g9_builder, 'services', 'g-cloud-9',
-                                                       Href(flask.url_for('.search_services')))
+            tree = build_lots_and_categories_link_tree(
+                self.framework,
+                self.framework['lots'],
+                None,
+                flask.request,
+                flask.request.args,
+                g9_builder,
+                'services',
+                'g-cloud-9',
+                Href(flask.url_for('.search_services')),
+                self.search_api_client
+            )
 
             assert tree[0] == {
                 'label': 'All categories',

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -27,10 +27,6 @@ class TestDirectAwardBase(BaseApplicationTest):
 
         self._search_api_client.get_index_from_search_api_url.return_value = 'g-cloud-9'
 
-        self._search_api_client_helpers_patch = \
-            mock.patch('app.main.helpers.search_save_helpers.search_api_client', new=self._search_api_client)
-        self._search_api_client_helpers = self._search_api_client_helpers_patch.start()
-
         self.g9_search_results = self._get_g9_search_results_fixture_data()
 
         self.data_api_client_patch = mock.patch('app.main.views.g_cloud.data_api_client', autospec=True)
@@ -46,8 +42,6 @@ class TestDirectAwardBase(BaseApplicationTest):
 
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
-        self._search_api_client_helpers_patch.stop()
-
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
@@ -609,7 +603,7 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
     def test_end_search_page_renders_error_when_results_more_than_limit(self):
         self.login_as_buyer()
 
-        self._search_api_client_helpers._get.return_value = {
+        self._search_api_client._get.return_value = {
             "services": [],
             "meta": {
                 "query": {},

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -27,10 +27,6 @@ class TestDirectAwardBase(BaseApplicationTest):
 
         self._search_api_client.get_index_from_search_api_url.return_value = 'g-cloud-9'
 
-        self._search_api_client_presenters_patch = mock.patch('app.main.presenters.search_presenters.search_api_client',
-                                                              new=self._search_api_client)
-        self._search_api_client_presenters = self._search_api_client_presenters_patch.start()
-
         self._search_api_client_helpers_patch = \
             mock.patch('app.main.helpers.search_save_helpers.search_api_client', new=self._search_api_client)
         self._search_api_client_helpers = self._search_api_client_helpers_patch.start()
@@ -50,7 +46,6 @@ class TestDirectAwardBase(BaseApplicationTest):
 
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
-        self._search_api_client_presenters_patch.stop()
         self._search_api_client_helpers_patch.stop()
 
         self.data_api_client_patch.stop()

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1146,11 +1146,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
         self._view_search_api_client = self._view_search_api_client_patch.start()
         self._view_search_api_client.search.return_value = self._get_dos_brief_search_api_response_fixture_data()
 
-        self._presenters_search_api_client_patch = mock.patch(
-            'app.main.presenters.search_presenters.search_api_client', autospec=True
-        )
-        self._presenters_search_api_client = self._presenters_search_api_client_patch.start()
-        self._presenters_search_api_client.aggregate.side_effect = [
+        self._view_search_api_client.aggregate.side_effect = [
             self._get_dos_brief_search_api_aggregations_response_outcomes_fixture_data(),
             self._get_dos_brief_search_api_aggregations_response_specialists_fixture_data(),
             self._get_dos_brief_search_api_aggregations_response_user_research_fixture_data(),
@@ -1181,7 +1177,6 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
         self._view_search_api_client_patch.stop()
-        self._presenters_search_api_client_patch.stop()
         super().teardown_method(method)
 
     def normalize_qs(self, qs):
@@ -1721,7 +1716,7 @@ class TestCatalogueOfBriefsPage(BaseApplicationTest):
     def test_lot_with_no_briefs_is_not_a_link(self):
         specialists_aggregation = self._get_dos_brief_search_api_aggregations_response_specialists_fixture_data()
         specialists_aggregation['aggregations']['lot']['digital-specialists'] = 0
-        self._presenters_search_api_client.aggregate.side_effect = [
+        self._view_search_api_client.aggregate.side_effect = [
             self._get_dos_brief_search_api_aggregations_response_outcomes_fixture_data(),
             specialists_aggregation,
             self._get_dos_brief_search_api_aggregations_response_user_research_fixture_data(),
@@ -1756,11 +1751,7 @@ class TestCatalogueOfBriefsFilterOnClick(BaseApplicationTest):
         self._view_search_api_client = self._view_search_api_client_patch.start()
         self._view_search_api_client.search.return_value = self._get_dos_brief_search_api_response_fixture_data()
 
-        self._presenters_search_api_client_patch = mock.patch(
-            'app.main.presenters.search_presenters.search_api_client', autospec=True
-        )
-        self._presenters_search_api_client = self._presenters_search_api_client_patch.start()
-        self._presenters_search_api_client.aggregate.side_effect = [
+        self._view_search_api_client.aggregate.side_effect = [
             self._get_dos_brief_search_api_aggregations_response_outcomes_fixture_data(),
             self._get_dos_brief_search_api_aggregations_response_specialists_fixture_data(),
             self._get_dos_brief_search_api_aggregations_response_user_research_fixture_data(),
@@ -1779,7 +1770,6 @@ class TestCatalogueOfBriefsFilterOnClick(BaseApplicationTest):
     def teardown_method(self, method):
         self.data_api_client_patch.stop()
         self._view_search_api_client_patch.stop()
-        self._presenters_search_api_client_patch.stop()
         super().teardown_method(method)
 
     @pytest.mark.parametrize('query_string, content_type',

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -44,10 +44,7 @@ class TestSearchResults(BaseApplicationTest):
         self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
         self._search_api_client = self._search_api_client_patch.start()
 
-        self._search_api_client_presenters_patch = mock.patch('app.main.presenters.search_presenters.search_api_client',
-                                                              autospec=True)
-        self._search_api_client_presenters = self._search_api_client_presenters_patch.start()
-        self._search_api_client_presenters.aggregate.return_value = \
+        self._search_api_client.aggregate.return_value = \
             self._get_fixture_data('g9_aggregations_fixture.json')
 
         self.search_results = self._get_search_results_fixture_data()
@@ -56,7 +53,6 @@ class TestSearchResults(BaseApplicationTest):
 
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
-        self._search_api_client_presenters_patch.stop()
         self.data_api_client_patch.stop()
         super().teardown_method(method)
 
@@ -458,7 +454,7 @@ class TestSearchResults(BaseApplicationTest):
         res = self.client.get('/g-cloud/search?page=2')
         assert res.status_code == 200
 
-        self._search_api_client_presenters.aggregate.assert_called_with(
+        self._search_api_client.aggregate.assert_called_with(
             index='g-cloud-9',
             doc_type='services',
             lot='cloud-support',
@@ -589,10 +585,7 @@ class TestSearchFilterOnClick(BaseApplicationTest):
         self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
         self._search_api_client = self._search_api_client_patch.start()
 
-        self._search_api_client_presenters_patch = mock.patch('app.main.presenters.search_presenters.search_api_client',
-                                                              autospec=True)
-        self._search_api_client_presenters = self._search_api_client_presenters_patch.start()
-        self._search_api_client_presenters.aggregate.return_value = \
+        self._search_api_client.aggregate.return_value = \
             self._get_fixture_data('g9_aggregations_fixture.json')
 
         self.search_results = self._get_search_results_fixture_data()
@@ -603,7 +596,6 @@ class TestSearchFilterOnClick(BaseApplicationTest):
 
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
-        self._search_api_client_presenters_patch.stop()
         super().teardown_method(method)
 
     @pytest.mark.parametrize('query_string, content_type',


### PR DESCRIPTION
Helpers should take an instance of the `search_api_client` as an argument, rather than importing directly from the app level. 

In this case it's only two helpers: `SearchMeta` and `build_lots_and_categories_link_tree`.

Advantages:
- consistent with how our helpers use the `data_api_client`
- simplifies patching setup in tests
- (in my opinion) helper functions shouldn't care about app-level objects, and certainly shouldn't need to deal them separately from the view
- it'll play nicely with the test helper base class I'm working on 😸 
