### PR TITLE
Pull in latest frameworks for new dos3 roles

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,7 @@ from flask_wtf.csrf import CSRFProtect, CSRFError
 import dmapiclient
 from dmutils import init_app, flask_featureflags
 from dmcontent.content_loader import ContentLoader
-from dmcontent.utils import try_load_metadata, try_load_messages
+from dmcontent.utils import try_load_manifest, try_load_metadata, try_load_messages
 from dmutils.user import User
 from dmutils.external import external as external_blueprint
 
@@ -46,12 +46,7 @@ def create_app(config_name):
                 try_load_metadata(content_loader, application, framework_data, ['following_framework'])
             elif framework_data['framework'] == 'digital-outcomes-and-specialists':
                 content_loader.load_manifest(framework_data['slug'], 'briefs', 'display_brief')
-
-    content_loader.load_manifest(
-        get_latest_live_framework(frameworks, 'digital-outcomes-and-specialists')['slug'],
-        'briefs',
-        'briefs_search_filters',
-    )
+                try_load_manifest(content_loader, application, framework_data, 'briefs', 'briefs_search_filters')
 
     from .main import main as main_blueprint
     from .main import direct_award as direct_award_blueprint

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.5.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.0.0",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.1.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.0.0":
-  version "13.0.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#496805f96eb4177106dabb21bf7eba4faad57e4d"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.1.0":
+  version "13.1.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#d51ee0b7c1751b0d08d6ddf14bd64d12b9783f57"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.5.0":
   version "31.5.0"


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/VkAyVrzT)

See [this PR on the frameworks repo.](https://github.com/alphagov/digitalmarketplace-frameworks/pull/531)

This PR will need updating to deal with the breaking change (13.0.0) of the frameworks repo that has been merged, but not pulled into the buyer FE.