### PR TITLE
APIClientMixin test class for patching data_api_client and search_api_client

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -64,10 +64,15 @@ class BaseAPIClientMixin:
 
 class BaseApplicationTest(object):
     def setup_method(self, method):
-        # We need to mock the API client in create_app, however we can't use patch the constructor,
-        # as the DataAPIClient instance has already been created; nor can we temporarily replace app.data_api_client
-        # with a mock, because then the shared instance won't have been configured (done in create_app). Instead,
-        # just mock the one function that would make an API call in this case.
+        """
+        A data_api_client instance is required for `create_app`, so we need some careful patching to initialise
+        the Flask test client:
+         - patch the .find_frameworks() method of `app.data_api_client` with the fixture
+         - initialise the app with `create_app('test')`
+         - in the tests, use a subclass of `BaseAPIClientMixin` above, with the path to the imported data_api_client
+         - the .find_frameworks() return value will need to be provided separately in those tests, as the import
+           path will (hopefully!) be different there.
+        """
         data_api_client.find_frameworks = mock.Mock()
         data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
         self.app = create_app('test')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,6 +14,48 @@ from app import create_app, data_api_client
 from tests import login_for_tests
 
 
+def get_frameworks_list_fixture_data():
+    old_gcloud_lots = [api_stubs.lot(lot_id=1, slug='saas', name='Software as a Service'),
+                       api_stubs.lot(lot_id=2, slug='paas', name='Platform as a Service'),
+                       api_stubs.lot(lot_id=3, slug='iaas', name='Infrastructure as a Service'),
+                       api_stubs.lot(lot_id=4, slug='scs', name='Specialist Cloud Services')]
+
+    new_gcloud_lots = [api_stubs.lot(lot_id=1, slug='cloud-hosting', name='Cloud hosting'),
+                       api_stubs.lot(lot_id=2, slug='cloud-software', name='Cloud software'),
+                       api_stubs.lot(lot_id=3, slug='cloud-support', name='Cloud support')]
+
+    dos_lots = [api_stubs.lot(lot_id=5, slug='digital-outcomes', name='Digital outcomes', allows_brief=True),
+                api_stubs.lot(lot_id=6, slug='digital-specialists', name='Digital specialists', allows_brief=True),
+                api_stubs.lot(lot_id=7, slug='user-research-studios', name='User research studios'),
+                api_stubs.lot(lot_id=8, slug='user-research-participants', name='User research participants',
+                              allows_brief=True)]
+
+    g_cloud_8_variation = {
+        "1": {
+            "countersignedAt": "2016-10-05T11:00:00.000000Z",
+            "countersignerName": "Dan Saxby",
+            "countersignerRole": "Category Director",
+            "createdAt": "2016-08-19T15:31:00.000000Z"
+        }
+    }
+
+    frameworks = [
+        api_stubs.framework(framework_id=4, slug='g-cloud-7', status='live', lots=old_gcloud_lots),
+        api_stubs.framework(framework_id=1, slug='g-cloud-6', status='expired', lots=old_gcloud_lots),
+        api_stubs.framework(framework_id=6, slug='g-cloud-8', status='live', lots=old_gcloud_lots,
+                            framework_agreement_version='v1.0', framework_variations=g_cloud_8_variation),
+        api_stubs.framework(framework_id=3, slug='g-cloud-5', status='expired', lots=old_gcloud_lots),
+        api_stubs.framework(framework_id=2, slug='g-cloud-4', status='expired', lots=old_gcloud_lots),
+        api_stubs.framework(framework_id=7, slug='digital-outcomes-and-specialists-2', status='live',
+                            lots=dos_lots, framework_agreement_version='v1.0', has_further_competition=True),
+        api_stubs.framework(framework_id=5, slug='digital-outcomes-and-specialists', status='live',
+                            lots=dos_lots, framework_agreement_version='v1.0', has_further_competition=True),
+        api_stubs.framework(framework_id=8, slug='g-cloud-9', status='live', lots=new_gcloud_lots),
+    ]
+
+    return {'frameworks': [framework['frameworks'] for framework in frameworks]}
+
+
 class BaseAPIClientMixin:
     """
     Mixin for patching the API clients when imported for each view module.
@@ -51,6 +93,8 @@ class BaseAPIClientMixin:
         super().setup_method(method)
         if self.data_api_client_patch:
             self.data_api_client = self.data_api_client_patch.start()
+            # Default return values - can be overwritten at test level
+            self.data_api_client.find_frameworks.return_value = get_frameworks_list_fixture_data()
         if self.search_api_client_patch:
             self.search_api_client = self.search_api_client_patch.start()
 
@@ -143,45 +187,7 @@ class BaseApplicationTest(object):
 
     @staticmethod
     def _get_frameworks_list_fixture_data():
-        old_gcloud_lots = [api_stubs.lot(lot_id=1, slug='saas', name='Software as a Service'),
-                           api_stubs.lot(lot_id=2, slug='paas', name='Platform as a Service'),
-                           api_stubs.lot(lot_id=3, slug='iaas', name='Infrastructure as a Service'),
-                           api_stubs.lot(lot_id=4, slug='scs', name='Specialist Cloud Services')]
-
-        new_gcloud_lots = [api_stubs.lot(lot_id=1, slug='cloud-hosting', name='Cloud hosting'),
-                           api_stubs.lot(lot_id=2, slug='cloud-software', name='Cloud software'),
-                           api_stubs.lot(lot_id=3, slug='cloud-support', name='Cloud support')]
-
-        dos_lots = [api_stubs.lot(lot_id=5, slug='digital-outcomes', name='Digital outcomes', allows_brief=True),
-                    api_stubs.lot(lot_id=6, slug='digital-specialists', name='Digital specialists', allows_brief=True),
-                    api_stubs.lot(lot_id=7, slug='user-research-studios', name='User research studios'),
-                    api_stubs.lot(lot_id=8, slug='user-research-participants', name='User research participants',
-                                  allows_brief=True)]
-
-        g_cloud_8_variation = {
-            "1": {
-                "countersignedAt": "2016-10-05T11:00:00.000000Z",
-                "countersignerName": "Dan Saxby",
-                "countersignerRole": "Category Director",
-                "createdAt": "2016-08-19T15:31:00.000000Z"
-            }
-        }
-
-        frameworks = [
-            api_stubs.framework(framework_id=4, slug='g-cloud-7', status='live', lots=old_gcloud_lots),
-            api_stubs.framework(framework_id=1, slug='g-cloud-6', status='expired', lots=old_gcloud_lots),
-            api_stubs.framework(framework_id=6, slug='g-cloud-8', status='live', lots=old_gcloud_lots,
-                                framework_agreement_version='v1.0', framework_variations=g_cloud_8_variation),
-            api_stubs.framework(framework_id=3, slug='g-cloud-5', status='expired', lots=old_gcloud_lots),
-            api_stubs.framework(framework_id=2, slug='g-cloud-4', status='expired', lots=old_gcloud_lots),
-            api_stubs.framework(framework_id=7, slug='digital-outcomes-and-specialists-2', status='live',
-                                lots=dos_lots, framework_agreement_version='v1.0', has_further_competition=True),
-            api_stubs.framework(framework_id=5, slug='digital-outcomes-and-specialists', status='live',
-                                lots=dos_lots, framework_agreement_version='v1.0', has_further_competition=True),
-            api_stubs.framework(framework_id=8, slug='g-cloud-9', status='live', lots=new_gcloud_lots),
-        ]
-
-        return {'frameworks': [framework['frameworks'] for framework in frameworks]}
+        return get_frameworks_list_fixture_data()
 
     @staticmethod
     def _get_g4_service_fixture_data():

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -32,7 +32,6 @@ class TestDirectAwardBase(APIClientMixin, BaseApplicationTest):
 
         self.g9_search_results = self._get_g9_search_results_fixture_data()
 
-        self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
         self.data_api_client.get_framework.return_value = self._get_framework_fixture_data('g-cloud-9')
 
         self.data_api_client.get_direct_award_project.return_value = self._get_direct_award_project_fixture()

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -15,7 +15,7 @@ from dmutils.api_stubs import framework
 from app import content_loader
 from app.main.views.g_cloud import (DownloadResultsView, END_SEARCH_LIMIT, TOO_MANY_RESULTS_MESSAGE,
                                     CONFIRM_START_ASSESSING_MESSAGE, )
-from ...helpers import BaseApplicationTest, BaseDataAPIClientMixin
+from ...helpers import BaseApplicationTest, BaseAPIClientMixin
 
 
 class APIClientMixin(BaseAPIClientMixin):

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -5,7 +5,7 @@ from lxml import html
 import mock
 import pytest
 
-from ...helpers import BaseApplicationTest
+from ...helpers import BaseApplicationTest, BaseDataAPIClientMixin
 
 
 def find_pagination_links(res_data):
@@ -32,12 +32,13 @@ def get_0_results_search_response():
     }
 
 
-class TestSearchResults(BaseApplicationTest):
+class DataAPIClientMixin(BaseDataAPIClientMixin):
+    data_api_client_patch_path = 'app.main.views.g_cloud.data_api_client'
+
+
+class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
-
-        self.data_api_client_patch = mock.patch('app.main.views.g_cloud.data_api_client', autospec=True)
-        self.data_api_client = self.data_api_client_patch.start()
 
         self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
 
@@ -53,7 +54,6 @@ class TestSearchResults(BaseApplicationTest):
 
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
-        self.data_api_client_patch.stop()
         super().teardown_method(method)
 
     def test_search_page_results_service_links(self):

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -41,8 +41,6 @@ class TestSearchResults(APIClientMixin, BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
 
-        self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
-
         self.search_api_client.aggregate.return_value = self._get_fixture_data('g9_aggregations_fixture.json')
         self.search_results = self._get_search_results_fixture_data()
         self.g9_search_results = self._get_g9_search_results_fixture_data()
@@ -573,8 +571,6 @@ class TestSearchResults(APIClientMixin, BaseApplicationTest):
 class TestSearchFilterOnClick(APIClientMixin, BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
-
-        self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
 
         self.search_api_client.aggregate.return_value = self._get_fixture_data('g9_aggregations_fixture.json')
 

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -5,7 +5,7 @@ from lxml import html
 import mock
 import pytest
 
-from ...helpers import BaseApplicationTest, BaseDataAPIClientMixin
+from ...helpers import BaseApplicationTest, BaseAPIClientMixin
 
 
 def find_pagination_links(res_data):
@@ -32,32 +32,24 @@ def get_0_results_search_response():
     }
 
 
-class DataAPIClientMixin(BaseDataAPIClientMixin):
+class APIClientMixin(BaseAPIClientMixin):
     data_api_client_patch_path = 'app.main.views.g_cloud.data_api_client'
+    search_api_client_patch_path = 'app.main.views.g_cloud.search_api_client'
 
 
-class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
+class TestSearchResults(APIClientMixin, BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
 
         self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
 
-        self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
-        self._search_api_client = self._search_api_client_patch.start()
-
-        self._search_api_client.aggregate.return_value = \
-            self._get_fixture_data('g9_aggregations_fixture.json')
-
+        self.search_api_client.aggregate.return_value = self._get_fixture_data('g9_aggregations_fixture.json')
         self.search_results = self._get_search_results_fixture_data()
         self.g9_search_results = self._get_g9_search_results_fixture_data()
         self.search_results_multiple_page = self._get_search_results_multiple_page_fixture_data()
 
-    def teardown_method(self, method):
-        self._search_api_client_patch.stop()
-        super().teardown_method(method)
-
     def test_search_page_results_service_links(self):
-        self._search_api_client.search.return_value = \
+        self.search_api_client.search.return_value = \
             self.search_results
 
         res = self.client.get('/g-cloud/search?q=email')
@@ -65,7 +57,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert '<a href="/g-cloud/services/5-G3-0279-010">CDN VDMS</a>' in res.get_data(as_text=True)
 
     def test_search_page_form(self):
-        self._search_api_client.search.return_value = \
+        self.search_api_client.search.return_value = \
             self.search_results
 
         res = self.client.get('/g-cloud/search?q=email')
@@ -73,7 +65,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert '<form action="/g-cloud/search" method="get" id="js-dm-live-search-form">' in res.get_data(as_text=True)
 
     def test_search_page_allows_non_keyword_search(self):
-        self._search_api_client.search.return_value = \
+        self.search_api_client.search.return_value = \
             self.search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
@@ -81,7 +73,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert '<a href="/g-cloud/services/5-G3-0279-010">CDN VDMS</a>' in res.get_data(as_text=True)
 
     def test_should_not_render_pagination_on_single_results_page(self):
-        self._search_api_client.search.return_value = \
+        self.search_api_client.search.return_value = \
             self.search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
@@ -90,7 +82,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert '<li class="previous">' not in res.get_data(as_text=True)
 
     def test_should_render_pagination_link_on_first_results_page(self):
-        self._search_api_client.search.return_value = \
+        self.search_api_client.search.return_value = \
             self.search_results_multiple_page
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
@@ -104,7 +96,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert 'lot=cloud-software' in next_link
 
     def test_should_render_pagination_link_on_second_results_page(self):
-        self._search_api_client.search.return_value = \
+        self.search_api_client.search.return_value = \
             self.search_results_multiple_page
 
         res = self.client.get('/g-cloud/search?lot=cloud-software&page=2')
@@ -121,7 +113,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert 'lot=cloud-software' in next_link
 
     def test_should_render_total_pages_on_pagination_links(self):
-        self._search_api_client.search.return_value = \
+        self.search_api_client.search.return_value = \
             self.search_results_multiple_page
 
         res = self.client.get('/g-cloud/search?lot=cloud-software&page=2')
@@ -131,7 +123,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert '<span class="page-numbers">3 of 200</span>' in res.get_data(as_text=True)
 
     def test_should_render_pagination_link_on_last_results_page(self):
-        self._search_api_client.search.return_value = \
+        self.search_api_client.search.return_value = \
             self.search_results_multiple_page
 
         res = self.client.get('/g-cloud/search?lot=cloud-software&page=200')
@@ -145,7 +137,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert 'lot=cloud-software' in prev_link
 
     def test_should_render_summary_for_0_results_in_all_categories_no_keywords(self):
-        self._search_api_client.search.return_value = get_0_results_search_response()
+        self.search_api_client.search.return_value = get_0_results_search_response()
 
         res = self.client.get('/g-cloud/search')
         assert res.status_code == 200
@@ -153,7 +145,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert '<span class="search-summary-count">0</span> results found in <em>All categories</em>' in summary
 
     def test_should_render_summary_for_0_results_in_cloud_software_no_keywords(self):
-        self._search_api_client.search.return_value = get_0_results_search_response()
+        self.search_api_client.search.return_value = get_0_results_search_response()
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
         assert res.status_code == 200
@@ -161,7 +153,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert '<span class="search-summary-count">0</span> results found in <em>Cloud software</em>' in summary
 
     def test_should_render_suggestions_for_0_results(self):
-        self._search_api_client.search.return_value = get_0_results_search_response()
+        self.search_api_client.search.return_value = get_0_results_search_response()
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
         assert res.status_code == 200
@@ -169,7 +161,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert len(suggestion) == 1
 
     def test_should_render_clear_all_filters_link(self):
-        self._search_api_client.search.return_value = get_0_results_search_response()
+        self.search_api_client.search.return_value = get_0_results_search_response()
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
         assert res.status_code == 200
@@ -185,7 +177,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         )
 
     def test_should_not_render_suggestions_for_when_results_are_shown(self):
-        self._search_api_client.search.return_value = {
+        self.search_api_client.search.return_value = {
             "documents": [],
             "meta": {
                 "query": {},
@@ -204,7 +196,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
         assert res.status_code == 200
@@ -215,7 +207,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get('/g-cloud/search?lot=cloud-hosting')
         assert res.status_code == 200
@@ -227,7 +219,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get('/g-cloud/search?q=email&lot=cloud-software')
         assert res.status_code == 200
@@ -240,7 +232,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&phoneSupport=true')
@@ -255,7 +247,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&phoneSupport=true&onsiteSupport=yes')
@@ -272,7 +264,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&resellingType=not_reseller')
@@ -288,7 +280,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&resellingType=not_reseller&resellingType=reseller_no_extras')
@@ -305,7 +297,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&phoneSupport=true' +
@@ -324,7 +316,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get(
             '/g-cloud/search?q=email&lot=cloud-software&phoneSupport=true' +
@@ -345,7 +337,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get(
             '/g-cloud/search?q=&lot=cloud-software' +
@@ -357,7 +349,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get('/g-cloud/search?q=<div>XSS</div>')
 
@@ -369,7 +361,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         return_value = self.search_results_multiple_page
         return_value["documents"] = [return_value["documents"][0]]
         return_value["meta"]["total"] = 1
-        self._search_api_client.search.return_value = return_value
+        self.search_api_client.search.return_value = return_value
 
         res = self.client.get(u'/g-cloud/search?q=email+\U0001f47e&lot=cloud-software')
         assert res.status_code == 200
@@ -379,7 +371,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
             u' <em>Cloud software</em>' in summary
 
     def test_should_404_on_invalid_page_param(self):
-        self._search_api_client.search.return_value = \
+        self.search_api_client.search.return_value = \
             self.search_results_multiple_page
 
         res = self.client.get('/g-cloud/search?lot=cloud-hosting&page=1')
@@ -392,7 +384,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert res.status_code == 404
 
     def test_search_results_with_invalid_lot_fall_back_to_all_categories(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?lot=bad-lot-slug')
         assert res.status_code == 200
@@ -405,7 +397,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert lots[2].text_content().startswith('Cloud support')
 
     def test_search_results_show_aggregations_by_lot(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search')
         assert res.status_code == 200
@@ -418,7 +410,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert lots[2].text_content() == 'Cloud support (500)'
 
     def test_search_results_does_not_show_aggregation_for_lot_if_category_selected(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
         assert res.status_code == 200
@@ -429,7 +421,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert lots[0].text_content() == 'Cloud software'
 
     def test_search_results_show_aggregations_by_parent_category(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-software')
         assert res.status_code == 200
@@ -449,12 +441,12 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         self.data_api_client.find_frameworks.return_value = {
             'frameworks': [self._get_framework_fixture_data('g-cloud-9')['frameworks']]
         }
-        self._search_api_client.search.return_value = self.search_results
+        self.search_api_client.search.return_value = self.search_results
 
         res = self.client.get('/g-cloud/search?page=2')
         assert res.status_code == 200
 
-        self._search_api_client.aggregate.assert_called_with(
+        self.search_api_client.aggregate.assert_called_with(
             index='g-cloud-9',
             doc_type='services',
             lot='cloud-support',
@@ -462,7 +454,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         )
 
     def test_search_results_does_not_show_aggregation_for_lot_or_parent_category_if_child_selected(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-software&serviceCategories=accounting+and+finance')
         assert res.status_code == 200
@@ -479,7 +471,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert parent_category.xpath('strong')[0].text_content() == 'Accounting and finance'
 
     def test_search_results_show_aggregations_by_child_category(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-software&serviceCategories=accounting+and+finance')
         assert res.status_code == 200
@@ -497,7 +489,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
             assert expected_lot_counts[category_name] == int(number_of_services)
 
     def test_search_results_subcategory_links_include_parent_category_param(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-software&serviceCategories=accounting+and+finance')
         assert res.status_code == 200
@@ -510,7 +502,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
             assert 'parentCategory=accounting+and+finance' in category_anchor.get('href')
 
     def test_lot_links_retain_all_category_filters(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?phoneSupport=true')
         assert res.status_code == 200
@@ -522,7 +514,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
             assert 'phoneSupport=true' in lot.get('href')
 
     def test_all_category_link_drops_lot_specific_filters(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-hosting&phoneSupport=true&scalingType=automatic')
         assert res.status_code == 200
@@ -534,7 +526,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert 'scalingType=automatic' not in lots[0].get('href')
 
     def test_subcategory_link_retains_lot_specific_filters(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-hosting&phoneSupport=true&scalingType=automatic')
         assert res.status_code == 200
@@ -547,7 +539,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
             assert 'scalingType=automatic' in category_link.get('href')
 
     def test_category_with_no_results_is_not_a_link(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?lot=cloud-support')
         assert res.status_code == 200
@@ -560,7 +552,7 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         assert len(training[0].xpath('a')) == 0
 
     def test_filter_form_given_category_selection(self):
-        self._search_api_client.search.return_value = self.g9_search_results
+        self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get('/g-cloud/search?parentCategory=electronic+document+and+records+management+%28edrm%29&'
                               'lot=cloud-software&serviceCategories=content+management+system+%28cms%29')
@@ -578,25 +570,19 @@ class TestSearchResults(DataAPIClientMixin, BaseApplicationTest):
         }
 
 
-class TestSearchFilterOnClick(BaseApplicationTest):
+class TestSearchFilterOnClick(APIClientMixin, BaseApplicationTest):
     def setup_method(self, method):
         super().setup_method(method)
 
-        self._search_api_client_patch = mock.patch('app.main.views.g_cloud.search_api_client', autospec=True)
-        self._search_api_client = self._search_api_client_patch.start()
+        self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
 
-        self._search_api_client.aggregate.return_value = \
-            self._get_fixture_data('g9_aggregations_fixture.json')
+        self.search_api_client.aggregate.return_value = self._get_fixture_data('g9_aggregations_fixture.json')
 
         self.search_results = self._get_search_results_fixture_data()
         self.g9_search_results = self._get_g9_search_results_fixture_data()
         self.search_results_multiple_page = self._get_search_results_multiple_page_fixture_data()
 
-        self._search_api_client.search.return_value = self.search_results
-
-    def teardown_method(self, method):
-        self._search_api_client_patch.stop()
-        super().teardown_method(method)
+        self.search_api_client.search.return_value = self.search_results
 
     @pytest.mark.parametrize('query_string, content_type',
                              (('', 'text/html; charset=utf-8'),

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -1,13 +1,12 @@
 import re
 
 from lxml import html
-import mock
 
 from app.main.helpers import framework_helpers
-from ...helpers import BaseApplicationTest, BaseDataAPIClientMixin
+from ...helpers import BaseApplicationTest, BaseAPIClientMixin
 
 
-class DataAPIClientMixin(BaseDataAPIClientMixin):
+class DataAPIClientMixin(BaseAPIClientMixin):
     data_api_client_patch_path = 'app.main.views.g_cloud.data_api_client'
 
 

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -37,7 +37,6 @@ class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
         self.service = self._get_g6_service_fixture_data()
 
         self.data_api_client.get_supplier.return_value = self.supplier
-        self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
         self.data_api_client.get_framework.return_value = self._get_framework_fixture_data('g-cloud-6')
         self.data_api_client.get_service.return_value = self.service
 

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -4,7 +4,11 @@ from lxml import html
 import mock
 
 from app.main.helpers import framework_helpers
-from ...helpers import BaseApplicationTest
+from ...helpers import BaseApplicationTest, BaseDataAPIClientMixin
+
+
+class DataAPIClientMixin(BaseDataAPIClientMixin):
+    data_api_client_patch_path = 'app.main.views.g_cloud.data_api_client'
 
 
 class UnavailableBanner(object):
@@ -25,16 +29,13 @@ class UnavailableBanner(object):
         return self.banner[0].xpath('p[@class="banner-message"]/text()')[0].strip()
 
 
-class TestServicePage(BaseApplicationTest):
+class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
 
     def setup_method(self, method):
         super().setup_method(method)
 
         self.supplier = self._get_supplier_fixture_data()
         self.service = self._get_g6_service_fixture_data()
-
-        self.data_api_client_patch = mock.patch('app.main.views.g_cloud.data_api_client', autospec=True)
-        self.data_api_client = self.data_api_client_patch.start()
 
         self.data_api_client.get_supplier.return_value = self.supplier
         self.data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
@@ -44,10 +45,6 @@ class TestServicePage(BaseApplicationTest):
         self.lots = framework_helpers.get_lots_by_slug(
             self._get_framework_fixture_data('g-cloud-6')['frameworks']
         )
-
-    def teardown_method(self, method):
-        self.data_api_client_patch.stop()
-        super().teardown_method(method)
 
     def _assert_contact_details(self, document):
 

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -3,10 +3,10 @@ import mock
 
 from dmapiclient import APIError
 
-from ...helpers import BaseApplicationTest, BaseDataAPIClientMixin
+from ...helpers import BaseApplicationTest, BaseAPIClientMixin
 
 
-class DataAPIClientMixin(BaseDataAPIClientMixin):
+class DataAPIClientMixin(BaseAPIClientMixin):
     data_api_client_patch_path = 'app.main.views.suppliers.data_api_client'
 
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,10 +1,15 @@
-from .helpers import BaseApplicationTest
+from .helpers import BaseApplicationTest, BaseDataAPIClientMixin
 
 
-class TestApplication(BaseApplicationTest):
+class DataAPIClientMixin(BaseDataAPIClientMixin):
+    data_api_client_patch_path = 'app.main.views.marketplace.data_api_client'
+
+
+class TestApplication(DataAPIClientMixin, BaseApplicationTest):
     def test_index(self):
         response = self.client.get('/')
         assert 200 == response.status_code
+        assert len(self.data_api_client.find_frameworks.call_args_list) == 2
 
     def test_404(self):
         response = self.client.get('/not-found')

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,7 +1,7 @@
-from .helpers import BaseApplicationTest, BaseDataAPIClientMixin
+from .helpers import BaseApplicationTest, BaseAPIClientMixin
 
 
-class DataAPIClientMixin(BaseDataAPIClientMixin):
+class DataAPIClientMixin(BaseAPIClientMixin):
     data_api_client_patch_path = 'app.main.views.marketplace.data_api_client'
 
 


### PR DESCRIPTION
Trello: https://trello.com/c/1CrEVFLP/25-dataapiclient-patching-part-2-consolidate-into-base-test-class

How it works:
- For each test module, create a subclass of the `BaseApiClientMixin` and initialise it with the client patch path for the view you want to patch (e.g. `app.main.views.marketplace.data_api_client` in `test_marketplace.py`). 
- You can potentially patch the client from two different paths in the same test module, with two different mixins.
- Add the subclassed mixin to each test class as the first argument (i.e. before `BaseApplicationTest`).
- Boom! `self.data_api_client` and `self.search_api_client` are available for use throughout the test class. The patches will be reset after every test. 

We can also now setup 'global' defaults for the client methods - I've done `data_api_client.find_frameworks` as an example. 

Also, it's optional! One class in the Buyer FE app (`TestDirectAwardURLGeneration`) requires the `search_api_client` *not* to be patched entirely, as it tests one of the client's methods that doesn't actually hit the API. Happily we can still use the previous 'patch certain methods in the setup' technique instead.
