### PR TITLE
Pull in v19.0.0 of apiclient

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,4 +9,4 @@ lxml==3.8.0
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@40.8.0#egg=digitalmarketplace-utils==40.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.11.0#egg=digitalmarketplace-content-loader==4.11.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@18.1.0#egg=digitalmarketplace-apiclient==18.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,11 +10,10 @@ lxml==3.8.0
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 git+https://github.com/alphagov/digitalmarketplace-utils.git@40.8.0#egg=digitalmarketplace-utils==40.8.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.11.0#egg=digitalmarketplace-content-loader==4.11.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@18.1.0#egg=digitalmarketplace-apiclient==18.1.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
-backoff==1.0.7
 boto3==1.4.8
 botocore==1.8.50
 certifi==2018.4.16


### PR DESCRIPTION
See [this PR on the apiclient for more details on what this brings in.](https://github.com/alphagov/digitalmarketplace-apiclient/pull/152)

It adds retries to the base apiclient. Hopefully to catch those pesky 503s.