### PR TITLE
Format links in briefs clarification questions

### DIFF
--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -25,7 +25,7 @@
   {% call summary.row() %}
     {% call summary.field(first=True, wide=False) -%}
       <span aria-label="question">{{ question.number }}.</span>
-      {{ question.question | preserve_line_breaks }}
+      {{ question.question | format_links | preserve_line_breaks }}
     {%- endcall %}
     {{ summary.text(question.answer | format_links | preserve_line_breaks) }}
   {% endcall %}


### PR DESCRIPTION
@louzoid-gds noticed that clarification questions with URLs in them do 
not render well on mobile (see [this 2nd line ticket][trello]).

This commit adds the `format_links` filter to the text of clarification 
questions, which as well as turning URLs into links, gives them 
line-breaking CSS properties that alleviate this issue.

[trello]: https://trello.com/c/y55PPcJ8

---

### Before

![A screenshot of a table rendered in a mobile viewport where a long URL has caused the content in the left cell to overflow and push the right cell out of the viewport](https://user-images.githubusercontent.com/503614/43199808-1d0ca808-900b-11e8-9cab-3f186655088a.png)

### After

![A screenshot of the same content as above, except the long URL is now a link and is wrapped in several places allowing the content in the left cell to remain within its boundaries](https://user-images.githubusercontent.com/503614/43199822-28f97f60-900b-11e8-90ac-d770c1686de3.png)
