### PR TITLE
Use framework family in apps

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -135,7 +135,7 @@ def get_brief_by_id(framework_family, brief_id):
     briefs = data_api_client.get_brief(brief_id)
     brief = briefs.get('briefs')
 
-    if brief['status'] not in PUBLISHED_BRIEF_STATUSES or brief['frameworkFramework'] != framework_family:
+    if brief['status'] not in PUBLISHED_BRIEF_STATUSES or brief['framework']['family'] != framework_family:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
 
     brief_responses = data_api_client.find_brief_responses(
@@ -152,7 +152,7 @@ def get_brief_by_id(framework_family, brief_id):
 
     brief_responses_stats = count_brief_responses_by_size_and_status(brief_responses)
 
-    if brief['status'] not in PUBLISHED_BRIEF_STATUSES or brief['frameworkFramework'] != framework_family:
+    if brief['status'] not in PUBLISHED_BRIEF_STATUSES or brief['framework']['family'] != framework_family:
         abort(404, "Opportunity '{}' can not be found".format(brief_id))
     try:
         has_supplier_responded_to_brief = (

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -12,7 +12,7 @@
           "label": "Digital Marketplace"
       },
       {
-          "link": url_for('.list_opportunities', framework_family=brief.frameworkFramework),
+          "link": url_for('.list_opportunities', framework_family=brief.framework.family),
           "label": "Supplier opportunities"
       }
     ]

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -38,7 +38,7 @@
         {% include 'toolkit/page-heading.html' %}
       {% endwith %}
 
-      <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id) }}">
+      <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
         {%
@@ -65,7 +65,7 @@
         {% endwith %}
       </form>
 
-      <p><a href="{{ url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id) }}">Return to your task list</a></p>
+      <p><a href="{{ url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id) }}">Return to your task list</a></p>
     </div>
   </div>
 

--- a/app/templates/direct-award/index.html
+++ b/app/templates/direct-award/index.html
@@ -41,7 +41,7 @@
       field_headings_visible=True
     ) %}
       {% call summary.row() %}
-        {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_family=framework.framework, project_id=item.id)) }}
+        {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_family=framework.family, project_id=item.id)) }}
         {{ summary.text(item.createdAt | datetimeformat ) }}
       {% endcall %}
     {% endcall %}
@@ -58,14 +58,14 @@
       field_headings_visible=True
     ) %}
       {% call summary.row() %}
-        {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_family=framework.framework, project_id=item.id), wide=False) }}
+        {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_family=framework.family, project_id=item.id), wide=False) }}
         {{ summary.text(item.lockedAt | datetimeformat ) }}
         {{ 
           summary.text("Awarded") if item.outcome and item.outcome.result == "awarded"
           else summary.text("The work has been cancelled") if item.outcome and item.outcome.result == "cancelled"
           else summary.text("No suitable services found") if item.outcome and item.outcome.result == "none-suitable"
-          else summary.service_link("Download results", url_for('direct_award.search_results', framework_family=framework.framework, project_id=item.id), wide=False) if not item.downloadedAt
-          else summary.service_link("Tell us the outcome", url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=item.id), wide=False) }}
+          else summary.service_link("Download results", url_for('direct_award.search_results', framework_family=framework.family, project_id=item.id), wide=False) if not item.downloadedAt
+          else summary.service_link("Tell us the outcome", url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=item.id), wide=False) }}
       {% endcall %}
     {% endcall %}
     

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -15,19 +15,19 @@
         "label": "Your account"
       },
       {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
+        "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
         "label": "Your saved searches"
       },
       {
-        "link": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
         "label": project.name
       },
       {
-        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
         "label": "Did you award a contract?"
       },
       {
-        "link": url_for('direct_award.which_service_won_contract', framework_family=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id),
         "label": "Which service won the contract?"
       }
     ]
@@ -47,7 +47,7 @@
         {% include "toolkit/page-heading.html" %}
       {% endwith %}
 
-      <form method="POST" action="{{ url_for('direct_award.tell_us_about_contract', framework_family=framework.framework, project_id=project.id, outcome_id=outcome_id) }}" class="tell-us-about-contract-form">
+      <form method="POST" action="{{ url_for('direct_award.tell_us_about_contract', framework_family=framework.family, project_id=project.id, outcome_id=outcome_id) }}" class="tell-us-about-contract-form">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
         {%
@@ -111,7 +111,7 @@
 
       </form>
 
-      <p><a href="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.framework, project_id=project.id) }}">Previous page</a></p>
+      <p><a href="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id) }}">Previous page</a></p>
 
     </div>
   </div>

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -18,7 +18,7 @@
           "label": "Your account"
       },
       {
-          "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
+          "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
           "label": "Your saved searches"
       }
     ] if project else [
@@ -65,7 +65,7 @@
   {% endif %}
   <div class="grid-row direct-award-project-overview-page">
     <div class="column-two-thirds">
-      {% if project %}<form action="{{url_for('direct_award.update_project', framework_family=framework.framework, project_id=project.id)}}" method="post">{% endif %}
+      {% if project %}<form action="{{url_for('direct_award.update_project', framework_family=framework.family, project_id=project.id)}}" method="post">{% endif %}
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         {% block before_sections %}{% endblock %}
         {% with items = [
@@ -98,12 +98,12 @@ assess. Refine your search until you have no more than 30 results.</strong></p>'
               or can_end_search)
                 else
               {"type": "action", "label": "Export your results",
-               "href": url_for('direct_award.end_search', framework_family=framework.framework, project_id=project.id),
+               "href": url_for('direct_award.end_search', framework_family=framework.family, project_id=project.id),
                "analytics": "trackEvent", "analytics_category": "Direct Award",
                "analytics_action": "Internal Link"} if project and not search.searchedAt and can_end_search
                 else
               {"type": "text", "text": ''.join(['
-<a href="', url_for('direct_award.search_results', framework_family=framework.framework, project_id=project.id)|e, '"
+<a href="', url_for('direct_award.search_results', framework_family=framework.family, project_id=project.id)|e, '"
    data-analytics="trackEvent"
    data-analytics-category="Direct Award"
    data-analytics-action="Internal Link"
@@ -159,7 +159,7 @@ understood how to assess services</button>'|safe} if project and not project.rea
             ] + ([
               {"type": "box", "style": "complete", "label": project_outcome_label } if project.outcome
               else {"type": "box", "style": "inactive", "label": "Can’t start yet"} if not project.readyToAssessAt
-              else {"type": "action", "label": "Tell us the outcome", "href": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"}
+              else {"type": "action", "label": "Tell us the outcome", "href": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id), "analytics": "trackEvent", "analytics_category": "Direct Award", "analytics_action": "Internal Link"}
             ] if project else [])
           },
           {

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -15,15 +15,15 @@
         "label": "Your account"
       },
       {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
+        "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
         "label": "Your saved searches"
       },
       {
-        "link": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
         "label": project.name
       },
       {
-        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
         "label": "Did you award a contract?"
       }
     ]
@@ -46,7 +46,7 @@
 
         {% if form.which_service_won_the_contract.options %}
 
-        <form method="POST" action="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.framework, project_id=project.id) }}">
+        <form method="POST" action="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
           {%
             with
@@ -74,7 +74,7 @@
           </div>
         {% endif %}
 
-        <p><a href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id) }}">Previous page</a></p>
+        <p><a href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">Previous page</a></p>
       </div>
     </div>
   </div>

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -15,15 +15,15 @@
         "label": "Your account"
       },
       {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
+        "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
         "label": "Your saved searches"
       },
       {
-        "link": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
         "label": project.name
       },
       {
-        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id),
+        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
         "label": "Did you award a contract?"
       }
     ]
@@ -42,7 +42,7 @@
         {% include 'toolkit/page-heading.html' %}
       {% endwith %}
 
-      <form method="POST" action="{{ url_for('direct_award.why_did_you_not_award_the_contract', framework_family=framework.framework, project_id=project.id) }}">
+      <form method="POST" action="{{ url_for('direct_award.why_did_you_not_award_the_contract', framework_family=framework.family, project_id=project.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         {%
           with
@@ -68,7 +68,7 @@
         {% endwith %}
       </form>
 
-      <p><a href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.framework, project_id=project.id) }}">Previous page</a></p>
+      <p><a href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">Previous page</a></p>
     </div>
   </div>
 

--- a/tests/fixtures/dos_brief_fixture.json
+++ b/tests/fixtures/dos_brief_fixture.json
@@ -8,7 +8,6 @@
     "clarificationQuestionsAreClosed": true,
     "clarificationQuestionsClosedAt": "2016-12-07T11:09:28.054129Z",
     "clarificationQuestionsPublishedBy": "2017-06-10T23:59:59.000000Z",
-    "contractLength": "Up to 24 months or completion of the services.",
     "contractLength": "4 weeks",
     "createdAt": "2016-11-25T10:47:23.126761Z",
     "culturalFitCriteria": [
@@ -24,6 +23,12 @@
       "provide a case study or evidence of previous work"
     ],
     "existingTeam": "Key stakeholders within Border Force",
+    "framework": {
+      "family": "digital-outcomes-and-specialists",
+      "name": "Digital Outcomes and Specialists 2",
+      "slug": "digital-outcomes-and-specialists-2",
+      "status": "live"
+    },
     "frameworkFramework": "digital-outcomes-and-specialists",
     "frameworkName": "Digital Outcomes and Specialists 2",
     "frameworkSlug": "digital-outcomes-and-specialists-2",

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -15,6 +15,12 @@
       "evaluationType": [
         "Interview"
       ],
+      "framework": {
+      "family": "digital-outcomes-and-specialists",
+      "name": "Digital Outcomes and Specialists",
+      "slug": "digital-outcomes-and-specialists",
+      "status": "live"
+    },
       "frameworkFramework":"digital-outcomes-and-specialists",
       "frameworkName":"Digital Outcomes and Specialists",
       "frameworkSlug":"digital-outcomes-and-specialists",
@@ -70,6 +76,12 @@
         "provide a case study or evidence of previous work",
         "presentation"
       ],
+      "framework": {
+        "family": "digital-outcomes-and-specialists",
+        "name": "Digital Outcomes and Specialists 2",
+        "slug": "digital-outcomes-and-specialists-2",
+        "status": "live"
+      },
       "frameworkFramework":"digital-outcomes-and-specialists",
       "frameworkName":"Digital Outcomes and Specialists 2",
       "frameworkSlug":"digital-outcomes-and-specialists-2",
@@ -117,6 +129,12 @@
       "evaluationType": [
         "Interview"
       ],
+      "framework": {
+        "family": "digital-outcomes-and-specialists",
+        "name": "Digital Outcomes and Specialists",
+        "slug": "digital-outcomes-and-specialists",
+        "status": "live"
+      },
       "frameworkFramework":"digital-outcomes-and-specialists",
       "frameworkName":"Digital Outcomes and Specialists",
       "frameworkSlug":"digital-outcomes-and-specialists",
@@ -157,6 +175,12 @@
       "evaluationType": [
         "Interview"
       ],
+      "framework": {
+        "family": "digital-outcomes-and-specialists",
+        "name": "Digital Outcomes and Specialists",
+        "slug": "digital-outcomes-and-specialists",
+        "status": "live"
+      },
       "frameworkFramework":"digital-outcomes-and-specialists",
       "frameworkName":"Digital Outcomes and Specialists",
       "frameworkSlug":"digital-outcomes-and-specialists",
@@ -197,6 +221,12 @@
       "evaluationType": [
         "Interview"
       ],
+      "framework": {
+        "family": "digital-outcomes-and-specialists",
+        "name": "Digital Outcomes and Specialists",
+        "slug": "digital-outcomes-and-specialists",
+        "status": "live"
+      },
       "frameworkFramework":"digital-outcomes-and-specialists",
       "frameworkName":"Digital Outcomes and Specialists",
       "frameworkSlug":"digital-outcomes-and-specialists",
@@ -237,6 +267,12 @@
       "evaluationType": [
         "Interview"
       ],
+      "framework": {
+        "family": "digital-outcomes-and-specialists",
+        "name": "Digital Outcomes and Specialists",
+        "slug": "digital-outcomes-and-specialists",
+        "status": "live"
+      },
       "frameworkFramework":"digital-outcomes-and-specialists",
       "frameworkName":"Digital Outcomes and Specialists",
       "frameworkSlug":"digital-outcomes-and-specialists",


### PR DESCRIPTION
Trello: https://trello.com/c/R3DsCXFa/22-use-frameworkfamily-frameworkfamily-in-apps-apiclient-rather-than-frameworkframework-frameworkframework

Views, template urls and fixtures to update. 

Out of scope: using api_stubs instead of fixtures for these briefs.