### PR TITLE
Refactor the save search template

### DIFF
--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -30,7 +30,11 @@
 <div class="single-question-page save-search-page">
   <div class="grid-row">
     <div class="column-one-whole">
-        {% if form.name.errors or save_search_selection_error %}
+        {#
+          we cannot use the toolkit/forms/validation.html template here,
+          as this page was designed with a govuk style error summary banner
+        #}
+        {% if errors %}
         <div class="error-summary" role="alert" aria-labelledby="saving-search-error" tabindex="-1">
 
           <div class="dmspeak">
@@ -38,13 +42,13 @@
           </div>
 
           <ul class="error-summary-list">
-              {% if save_search_selection_error %}
-                <li><a href="#select-where-to-save-error">{{ save_search_selection_error }}</a></li>
-              {% elif form.name.errors and not save_search_selection_error %}
-                {% for error in form.name.errors %}<li><a href="#name-your-search-error">{{ error }}</a></li>{% endfor %}
-              {% endif %}
+            {% for error in errors.values() %}
+              <li>
+                <a href="#{{ error.input_name }}-error">{{ error.message }}</a>
+              </li>
+            {% endfor %}
           </ul>
-    
+
         </div>
         {% endif %}
     </div>
@@ -67,56 +71,17 @@
           {% endwith %}
         </div>
 
-        <fieldset>
-          <div{% if save_search_selection_error %} class="validation-wrapper"{% endif %}>
-          
-              {% if save_search_selection_error %}
-              <p class="validation-message" id="select-where-to-save-error">
-                {{ save_search_selection_error }}
-              </p>
-              {% endif %}
-
-              {% if projects %}
-              {% for project in projects %}
-
-              <div class="multiple-choice">
-                <input type="radio" name="save_search_selection" value="{{ project.id }}" id="project-{{ project.id }}"{% if request.form.save_search_selection == project.id %}checked="checked"{% endif %}>
-                <label for="project-{{ project.id }}">{{ project.name or "Untitled project {}".format(project.id) }}</label>
-              </div>
-
-              {% endfor %}
-
-              <p class="form-block">or</p>
-
-              {% endif %}
-
-              <div class="multiple-choice" data-target="new-search">
-                <input type="radio" name="save_search_selection" value="new_search" id="project-new" aria-required="true" 
-                  {% if request.form.save_search_selection == 'new_search' or not projects %}checked="checked"{% endif %}>
-                <label for="project-new">Save a new search</label>
-              </div>
-              <div class="panel panel-border-narrow js-hidden" id="new-search">
-                
-                <div{% if form.name.errors and not save_search_selection_error %} class="validation-wrapper"{% endif %}>
-                  <div class="question" id="{{ form.name.name }}">
-                    {{ form.name.label(class="question-heading") }}
-                    <p>Name your search. A reference number or short description of what you want to buy makes a good name.</p>
-                    <p class="hint">
-                      100 characters maximum
-                    </p>
-                    {% if form.name.errors and not save_search_selection_error %}
-                    <p class="validation-message" id="name-your-search-error">
-                      {% for error in form.name.errors %}{{ error }}{% endfor %}
-                    </p>
-                    {% endif %}
-                    {{ form.name(class="text-box") }}
-                  </div>
-                </div>
-              </div>
-
-
-          </div>
-        </fieldset>
+        {%
+          with
+          type = "radio",
+          name = form.save_search_selection.name,
+          finally = "or",
+          value = form.save_search_selection.data,
+          options = form.save_search_selection.options,
+          error = form.save_search_selection.errors[0]
+        %}
+          {% include "toolkit/forms/selection-buttons.html" %}
+        {% endwith %}
 
         <br>
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.5.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.6.2",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.5.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/tests/fixtures/direct_award_project_list_fixture.json
+++ b/tests/fixtures/direct_award_project_list_fixture.json
@@ -17,6 +17,25 @@
             "outcome": null
         },
         {
+          "active": true,
+          "createdAt": "2017-08-29T07:49:26.677778Z",
+          "downloadedAt": null,
+          "id": 1,
+          "lockedAt": null,
+          "name": "My procurement project <",
+          "readyToAssessAt": null,
+          "outcome": null,
+          "users": [
+            {
+              "active": true,
+              "email": "buyer@example.com",
+              "id": 123,
+              "name": "A Buyer",
+              "role": "buyer"
+            }
+          ]
+        },
+        {
             "active": true,
             "createdAt": "2018-06-19T13:36:37.557144Z",
             "downloadedAt": "2018-06-19T13:37:30.849304Z",

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,9 +523,9 @@ detect-file@^1.0.0:
   version "13.5.0"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#2180697c690a7b871e2a61a899b14c4784168f92"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.5.0":
-  version "31.5.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#68e382b09898840e3843ca196ea414bd2ab9b52a"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.6.2":
+  version "31.6.2"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#13b48593a5d200cb8fa634a74c1a2591d11b1cc1"
   dependencies:
     del "^2.2.2"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
This PR refactors the save search template, which was highlighted in a [tech debt ticket](https://trello.com/c/wlfBF5J0/51-buyer-fe-save-searchhtml-page-uses-blend-of-wtforms-raw-html-fe-toolkit-templates) from Sam as being a bit messy.

That assessment was I think borne out by how long this refactor took... I took this refactoring on because it was blocking my work to use WTForms more widely in the frontend apps (see alphagov/digitalmarketplace-frontend-toolkit#400).

I used WTForms to move most of the validation logic out of the view and into the `CreateProjectForm`, so overall the number of lines is fairly static; however with alphagov/digitalmarketplace-frontend-toolkit#400 the new emphasis on convenience methods for WTForms will mean a future reduction in lines.

When making changes I made sure that unit tests and functional tests remained green, and there should be as few visual regressions as possible, so some peculiarities remain in the design of this page:

  1. The validation banner that appears at the top of the page when there is a form error is different to almost every other banner on this site; instead of showing the question name it shows the validation error message.

  2. The search query is passed to the view both as a URL query string and (when POSTing) as a form field. As far as I could tell the `search_query` form field was never used in the view, but I did not remove it because doing so would mean that the tests would diverge from the code, and I didn't want to touch the tests.

  3. Previously the form validation did not check whether the POSTed project was present in the list presented to the user in the selection box. It turned out that all the unit tests had been exercising this "feature" because the global project fixture was not in the global project list fixture. This is the one area where I did touch the tests, because whilst this might seem like a feature it is also a clear bug.