### PR TITLE
digitalmarketplace-utils dependency: bump to 43.0.0, remove featureflags references

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,7 @@ from flask_login import LoginManager
 from flask_wtf.csrf import CSRFProtect, CSRFError
 
 import dmapiclient
-from dmutils import init_app, flask_featureflags
+from dmutils import init_app
 from dmcontent.content_loader import ContentLoader
 from dmcontent.utils import try_load_manifest, try_load_metadata, try_load_messages
 from dmutils.user import User
@@ -15,7 +15,6 @@ from config import configs
 login_manager = LoginManager()
 data_api_client = dmapiclient.DataAPIClient()
 search_api_client = dmapiclient.SearchAPIClient()
-feature_flags = flask_featureflags.FeatureFlag()
 csrf = CSRFProtect()
 
 content_loader = ContentLoader('app/content')
@@ -30,9 +29,8 @@ def create_app(config_name):
         application,
         configs[config_name],
         data_api_client=data_api_client,
-        feature_flags=feature_flags,
         login_manager=login_manager,
-        search_api_client=search_api_client
+        search_api_client=search_api_client,
     )
 
     frameworks = data_api_client.find_frameworks().get('frameworks')

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, flash, Markup, current_app
 from flask_login import login_required, current_user
-import flask_featureflags
 
 main = Blueprint('main', __name__)
 direct_award = Blueprint('direct_award', __name__, url_prefix='/buyers/direct-award')

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 import os
 import jinja2
-from dmutils.status import enabled_since, get_version_label
+from dmutils.status import get_version_label
 from dmutils.asset_fingerprint import AssetFingerprinter
 
 basedir = os.path.abspath(os.path.dirname(__file__))
@@ -55,10 +55,6 @@ class Config(object):
         'asset_fingerprinter': AssetFingerprinter(asset_root=ASSET_PATH)
     }
 
-    # Feature Flags
-    RAISE_ERROR_ON_MISSING_FEATURES = True
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = False
-
     # LOGGING
     DM_LOG_LEVEL = 'DEBUG'
     DM_PLAIN_TEXT_LOGS = False
@@ -111,8 +107,6 @@ class Test(Config):
     SHARED_EMAIL_KEY = "KEY"
     SECRET_KEY = "KEY"
 
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
-
     GOOGLE_SITE_VERIFICATION = "NotARealVerificationKey"
 
 
@@ -130,8 +124,6 @@ class Development(Config):
     DM_MANDRILL_API_KEY = "not_a_real_key"
     SECRET_KEY = "verySecretKey"
     SHARED_EMAIL_KEY = "very_secret"
-
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2016-11-29')
 
     GOOGLE_SITE_VERIFICATION = "NotARealVerificationKey"
 
@@ -151,17 +143,14 @@ class Live(Config):
 
 
 class Preview(Live):
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-06')
     DM_PATCH_FRONTEND_URL = 'https://www.preview.marketplace.team/'
 
 
 class Staging(Live):
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-07')
     DM_PATCH_FRONTEND_URL = 'https://www.staging.marketplace.team/'
 
 
 class Production(Live):
-    FEATURE_FLAGS_NEW_SUPPLIER_FLOW = enabled_since('2017-02-08')
     DM_PATCH_FRONTEND_URL = 'https://www.digitalmarketplace.service.gov.uk/'
 
     GOOGLE_SITE_VERIFICATION = "TKGSGZnfHpx1-lKOthI17ANtwk7fz3F4Sbr77I0ppO0"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,12 +1,11 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
+Flask==0.12.4
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@42.6.0#egg=digitalmarketplace-utils==42.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.11.0#egg=digitalmarketplace-content-loader==4.11.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,12 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
+Flask==0.12.4
 Flask-Login==0.2.11
 Flask-WTF==0.14.2
 lxml==3.8.0
 
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
-git+https://github.com/alphagov/digitalmarketplace-utils.git@42.6.0#egg=digitalmarketplace-utils==42.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@4.11.0#egg=digitalmarketplace-content-loader==4.11.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.0.0#egg=digitalmarketplace-apiclient==19.0.0
 
@@ -19,6 +18,7 @@ botocore==1.8.50
 certifi==2018.8.13
 cffi==1.11.5
 chardet==3.0.4
+click==6.7
 contextlib2==0.4.0
 cryptography==2.3
 docopt==0.4.0


### PR DESCRIPTION
Trello https://trello.com/c/ZH9trgjH/419-snyk-alert-for-flask-010x-vulnerability

https://github.com/alphagov/digitalmarketplace-utils/pull/447

Another unremarkable conversion. Had `FEATURE_FLAGS_NEW_SUPPLIER_FLOW` defined but didn't seem to use it anymore.