### PR TITLE
159-sub-categories-something-seems-broken

### DIFF
--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -103,6 +103,7 @@ def clean_request_args(request_args, lot_filters, lots_by_slug, for_aggregation=
 
     if not for_aggregation:
         restore_keys.append('page')
+        restore_keys.append('parentCategory')
 
     if request_args.get('lot') in lots_by_slug:
         restore_keys.append('lot')

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -205,6 +205,7 @@ def build_lots_and_categories_link_tree(
     # and category).
     keys_to_remove = _get_category_filter_key_set(category_filter_group)
     keys_to_remove.add('page')
+    keys_to_remove.add('parentCategory')
     preserved_request_args = MultiDict(
         (k, v) for (k, v) in request.args.items(multi=True) if k not in keys_to_remove
     )

--- a/app/main/presenters/search_summary.py
+++ b/app/main/presenters/search_summary.py
@@ -131,7 +131,7 @@ class SearchSummary(object):
 
         groups = defaultdict(list)
         for filter_name, filter_values in request_args.lists():
-            if filter_name in ('lot', 'q', 'page'):
+            if filter_name in ('lot', 'q', 'page', 'parentCategory'):
                 continue
 
             for filter_value in filter_values:

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -251,10 +251,18 @@ def search_services():
     except ValueError:
         abort(404)
 
+    search_query_kwargs = build_search_query(
+        clean_request_query_params,
+        filters.values(),
+        content_manifest,
+        lots_by_slug,
+        for_aggregation=True
+    )
+
     search_api_response = search_api_client.search(
         index=framework['slug'],
         doc_type=doc_type,
-        **build_search_query(clean_request_query_params, filters.values(), content_manifest, lots_by_slug)
+        **search_query_kwargs
     )
     search_results_obj = SearchResults(
         search_api_response,

--- a/tests/main/helpers/test_search_helpers.py
+++ b/tests/main/helpers/test_search_helpers.py
@@ -175,6 +175,7 @@ class TestBuildSearchQueryHelpers(BaseApplicationTest):
             'lot': 'saas',
             'q': 'email',
             'page': 9,
+            'parentCategory': 'collaborative working',
             'unknown': 'key',
         })
 
@@ -183,9 +184,36 @@ class TestBuildSearchQueryHelpers(BaseApplicationTest):
             'question2': 'true',
             'question3': ['option1', 'option2'],
             'q': 'email',
+            'parentCategory': 'collaborative working',
             'lot': 'saas',
             'page': 9,
         })
+
+    def test_clean_request_args_strips_args_for_aggregation(self):
+        """With the for_aggregation kwarg set the clean_request_args method should strip parentCategory and page keys"""
+
+        filters = MultiDict({
+            'question1': 'true',
+            'question2': ['true', 'false', 1],
+            'question3': ['option1', 'true', 'option5', 'option2', 2, None],
+            'question6': '',
+            'question4': 'false',
+            'lot': 'saas',
+            'q': 'email',
+            'page': 9,
+            'parentCategory': 'collaborative working',
+            'unknown': 'key',
+        })
+
+        results = search_helpers.clean_request_args(filters, self.lot_filters, self._lots_by_slug, for_aggregation=True)
+        assert results == MultiDict({
+            'question1': 'true',
+            'question2': 'true',
+            'question3': ['option1', 'option2'],
+            'q': 'email',
+            'lot': 'saas',
+        })
+
 
     def test_clean_request_args_incorrect_lot(self):
         filters = MultiDict({

--- a/tests/main/helpers/test_search_helpers.py
+++ b/tests/main/helpers/test_search_helpers.py
@@ -214,7 +214,6 @@ class TestBuildSearchQueryHelpers(BaseApplicationTest):
             'lot': 'saas',
         })
 
-
     def test_clean_request_args_incorrect_lot(self):
         filters = MultiDict({
             'lot': 'saaspaas',

--- a/tests/main/presenters/test_search_presenters.py
+++ b/tests/main/presenters/test_search_presenters.py
@@ -4,6 +4,7 @@ import os
 
 import flask
 import mock
+import pytest
 from werkzeug.datastructures import MultiDict
 from werkzeug.urls import Href
 
@@ -502,7 +503,7 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
                                         {
                                             'id': 'checkboxTreeExample-option-2.2',
                                             'label': 'Option 2.2',
-                                            'link': '/g-cloud/search?parentCategory=option+2&lot=cloud-software&checkboxTreeExample=option+2.2',  # NOQA
+                                            'link': '/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2.2&parentCategory=option+2',  # NOQA
                                             'name': 'checkboxTreeExample',
                                             'selected': False,
                                             'service_count': 0,
@@ -587,7 +588,7 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
                                 {
                                     'id': 'checkboxTreeExample-option-2.2',
                                     'label': 'Option 2.2',
-                                    'link': '/g-cloud/search?parentCategory=option+2&lot=cloud-software&checkboxTreeExample=option+2.2',  # NOQA
+                                    'link': '/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2.2&parentCategory=option+2',  # NOQA
                                     'name': 'checkboxTreeExample',
                                     'selected': False,
                                     'service_count': 0,
@@ -680,3 +681,256 @@ class TestLotsAndCategoriesSelection(BaseApplicationTest):
                     }
                 ]
             }
+
+    @property
+    def tree_with_cloud_software__option_2__option_2_1__selected(self):
+        return [
+            {
+                'label': 'All categories',
+                'selected': True,
+                'link': '/g-cloud/search',
+                'children': [
+                    {
+                        'label': 'Cloud software',
+                        'name': 'lot',
+                        'value': 'cloud-software',
+                        'service_count': 500,
+                        'children': [
+                            {
+                                'label': 'Option 2',
+                                'name': 'checkboxTreeExample',
+                                'id': 'checkboxTreeExample-option-2',
+                                'value': 'option 2',
+                                'children': [
+                                    {
+                                        'label': 'Option 2.1',
+                                        'name': 'checkboxTreeExample',
+                                        'id': 'checkboxTreeExample-option-2.1',
+                                        'value': 'option 2.1',
+                                        'selected': True,
+                                        'service_count': 0
+                                    }, {
+                                        'label': 'Option 2.2',
+                                        'name': 'checkboxTreeExample',
+                                        'id': 'checkboxTreeExample-option-2.2',
+                                        'value': 'option 2.2',
+                                        'selected': False,
+                                        'service_count': 0,
+                                        'link': (
+                                            '/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2.2'
+                                            '&parentCategory=option+2'
+                                        )
+                                    }
+                                ],
+                                'selected': True,
+                                'service_count': 0,
+                                'link': '/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2'
+                            }
+                        ],
+                        'selected': True,
+                        'link': '/g-cloud/search?lot=cloud-software'
+                    }
+                ]
+            }, {
+                'label': 'Cloud software',
+                'name': 'lot',
+                'value': 'cloud-software',
+                'service_count': 500,
+                'children': [
+                    {
+                        'label': 'Option 2',
+                        'name': 'checkboxTreeExample',
+                        'id': 'checkboxTreeExample-option-2',
+                        'value': 'option 2',
+                        'children': [
+                            {
+                                'label': 'Option 2.1',
+                                'name': 'checkboxTreeExample',
+                                'id': 'checkboxTreeExample-option-2.1',
+                                'value': 'option 2.1',
+                                'selected': True,
+                                'service_count': 0
+                            }, {
+                                'label': 'Option 2.2',
+                                'name': 'checkboxTreeExample',
+                                'id': 'checkboxTreeExample-option-2.2',
+                                'value': 'option 2.2',
+                                'selected': False,
+                                'service_count': 0,
+                                'link': (
+                                    '/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2.2'
+                                    '&parentCategory=option+2'
+                                )
+                            }
+                        ],
+                        'selected': True,
+                        'service_count': 0,
+                        'link': '/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2'
+                    }
+                ],
+                'selected': True,
+                'link': '/g-cloud/search?lot=cloud-software'
+            }, {
+                'name': 'parentCategory',
+                'value': 'option 2'
+            }, {
+                'label': 'Option 2',
+                'name': 'checkboxTreeExample',
+                'id': 'checkboxTreeExample-option-2',
+                'value': 'option 2',
+                'children': [
+                    {
+                        'label': 'Option 2.1',
+                        'name': 'checkboxTreeExample',
+                        'id': 'checkboxTreeExample-option-2.1',
+                        'value': 'option 2.1',
+                        'selected': True,
+                        'service_count': 0
+                    }, {
+                        'label': 'Option 2.2',
+                        'name': 'checkboxTreeExample',
+                        'id': 'checkboxTreeExample-option-2.2',
+                        'value': 'option 2.2',
+                        'selected': False,
+                        'service_count': 0,
+                        'link': (
+                            '/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2.2&parentCategory=option+2'
+                        )
+                    }
+                ],
+                'selected': True,
+                'service_count': 0,
+                'link': '/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2'
+            }, {
+                'label': 'Option 2.1',
+                'name': 'checkboxTreeExample',
+                'id': 'checkboxTreeExample-option-2.1',
+                'value': 'option 2.1',
+                'selected': True,
+                'service_count': 0
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        'url', (
+            "/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2.1",
+            "/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2.1&parentCategory=option+2"
+        )
+    )
+    def test_build_lots_and_categories_link_tree_with_lot_and_filter_selected(self, url):
+        with self.app.test_request_context(url):
+            tree = build_lots_and_categories_link_tree(
+                self.framework,
+                self.framework['lots'],
+                self.category_filter_group.copy(),
+                flask.request,
+                flask.request.args,
+                g9_builder,
+                'services',
+                'g-cloud-9',
+                Href(flask.url_for('.search_services')),
+                self.search_api_client
+            )
+
+        assert tree == self.tree_with_cloud_software__option_2__option_2_1__selected
+        # Assert, as per the url, that only our specified filter is 'selected' in the output
+        assert(
+            [(child['id'], child['selected']) for child in tree[0]['children'][0]['children'][0]['children']] ==
+            [('checkboxTreeExample-option-2.1', True), ('checkboxTreeExample-option-2.2', False)]
+        )
+
+    def test_build_lots_and_categories_link_tree_with_lot_and_filter_and_same_named_filter_in_tree(self):
+        url = "/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2.1&parentCategory=option+2"
+
+        self.category_filter_group['filters'] += [
+            {
+                'label': 'Option 7',
+                'name': 'checkboxTreeExample',
+                'id': 'checkboxTreeExample-option-7',
+                'value': 'option 7',
+                'children': [
+                    {
+                        'label': 'Option 2.1',
+                        'name': 'checkboxTreeExample',
+                        'id': 'checkboxTreeExample-option-2.1',
+                        'value': 'option 2.1'
+                    }, {
+                        'label': 'Option 7.1',
+                        'name': 'checkboxTreeExample',
+                        'id': 'checkboxTreeExample-option-7.1',
+                        'value': 'option 7.1'
+                    }
+                ]
+            }
+        ]
+        with self.app.test_request_context(url):
+            tree = build_lots_and_categories_link_tree(
+                self.framework,
+                self.framework['lots'],
+                self.category_filter_group.copy(),
+                flask.request,
+                flask.request.args,
+                g9_builder,
+                'services',
+                'g-cloud-9',
+                Href(flask.url_for('.search_services')),
+                self.search_api_client
+            )
+
+        assert tree == self.tree_with_cloud_software__option_2__option_2_1__selected
+        assert(
+            [(child['id'], child['selected']) for child in tree[0]['children'][0]['children'][0]['children']] ==
+            [('checkboxTreeExample-option-2.1', True), ('checkboxTreeExample-option-2.2', False)]
+        )
+
+        tree_child_value_lists = [[child.get('id') for child in node.get('children', [])] for node in tree]
+        tree_child_values = [item for sublist in tree_child_value_lists for item in sublist]
+
+        assert 'checkboxTreeExample-option-7.1' not in tree_child_values
+        assert tree_child_values.count('checkboxTreeExample-option-2.1') == 1
+
+    def test_build_lots_and_categories_link_tree_with_lot_and_filter_and_same_named_filter_in_tree_with_no_parent(self):
+        url = "/g-cloud/search?lot=cloud-software&checkboxTreeExample=option+2.1"
+
+        self.category_filter_group['filters'] += [
+            {
+                'label': 'Option 7',
+                'name': 'checkboxTreeExample',
+                'id': 'checkboxTreeExample-option-7',
+                'value': 'option 7',
+                'children': [
+                    {
+                        'label': 'Option 2.1',
+                        'name': 'checkboxTreeExample',
+                        'id': 'checkboxTreeExample-option-2.1',
+                        'value': 'option 2.1'
+                    }, {
+                        'label': 'Option 7.1',
+                        'name': 'checkboxTreeExample',
+                        'id': 'checkboxTreeExample-option-7.1',
+                        'value': 'option 7.1'
+                    }
+                ]
+            }
+        ]
+        with self.app.test_request_context(url):
+            tree = build_lots_and_categories_link_tree(
+                self.framework,
+                self.framework['lots'],
+                self.category_filter_group.copy(),
+                flask.request,
+                flask.request.args,
+                g9_builder,
+                'services',
+                'g-cloud-9',
+                Href(flask.url_for('.search_services')),
+                self.search_api_client
+            )
+
+        tree_child_value_selected_lists = [
+            [(child.get('id'), child['selected']) for child in node.get('children', [])] for node in tree
+        ]
+        tree_child_value_selected = [item for sublist in tree_child_value_selected_lists for item in sublist]
+
+        assert ('checkboxTreeExample-option-7.1', False) in tree_child_value_selected
+        assert tree_child_value_selected.count(('checkboxTreeExample-option-2.1', True)) == 2


### PR DESCRIPTION
Do not strip `parentCategory` in `clean_request_args` unless args are to be used in aggregation
Use `for_aggregation` output of `clean_request_args` when building search query
Do not use `parentCategory` as a filter group.

When we call `clean_request_args` it strips arguments from the request args unless they are added to a list called `restore_keys`. This is a problem because we later rely on these to determine the `parentCategory` of the selected filter (below) and if `parentCategory` isn't in the args then default it to `category['value'] == category['value']` or `True`.
https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/master/app/main/presenters/search_presenters.py#L307

This PR 
* makes it possible to preserve the expected `parentCategory` arg by ensuring the `for_aggregation` parameter is `False` in the call in the view to `clean_request_args`.
* Adds `parentCategory` to a list of skipped arguments when building groups to filter results by (we only require the `serviceCategories`)
* Supplies the `for_aggregation` kwarg set to `True` when we are filtering the request arguments for `build_search_query` (ie for aggregation)


## Before

![screen shot 2018-10-03 at 13 39 03](https://user-images.githubusercontent.com/3469840/46410757-d06d5e00-c711-11e8-9fb2-2d86fafb272d.png)



## After

![screen shot 2018-10-03 at 13 39 23](https://user-images.githubusercontent.com/3469840/46410766-d6fbd580-c711-11e8-9ab5-ffda6c1ca11d.png)
