### PR TITLE
Fix 159 sub categories something seems broken

### DIFF
--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -103,7 +103,6 @@ def clean_request_args(request_args, lot_filters, lots_by_slug, for_aggregation=
 
     if not for_aggregation:
         restore_keys.append('page')
-        restore_keys.append('parentCategory')
 
     if request_args.get('lot') in lots_by_slug:
         restore_keys.append('lot')

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -205,7 +205,6 @@ def build_lots_and_categories_link_tree(
     # and category).
     keys_to_remove = _get_category_filter_key_set(category_filter_group)
     keys_to_remove.add('page')
-    keys_to_remove.add('parentCategory')
     preserved_request_args = MultiDict(
         (k, v) for (k, v) in request.args.items(multi=True) if k not in keys_to_remove
     )

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -243,9 +243,16 @@ def build_lots_and_categories_link_tree(
 
         if lot_selected:
             selected_categories = _annotate_categories_with_selection(
-                lot['slug'], categories, cleaned_request_args, url_args_for_lot, content_manifest, framework,
-                aggregations_by_lot[lot['slug']], keys_to_remove, search_link_builder,
-                parent_category=request.args.get('parentCategory', None)
+                lot['slug'],
+                categories,
+                cleaned_request_args,
+                url_args_for_lot,
+                content_manifest,
+                framework,
+                aggregations_by_lot[lot['slug']],
+                keys_to_remove,
+                search_link_builder,
+                parent_category=request.args.get('parentCategory', None),
             )
             selected_filters.append(lot_filter)
             selected_filters.extend(selected_categories)

--- a/app/main/presenters/search_presenters.py
+++ b/app/main/presenters/search_presenters.py
@@ -205,6 +205,7 @@ def build_lots_and_categories_link_tree(
     # and category).
     keys_to_remove = _get_category_filter_key_set(category_filter_group)
     keys_to_remove.add('page')
+    keys_to_remove.add('parentCategory')
     preserved_request_args = MultiDict(
         (k, v) for (k, v) in request.args.items(multi=True) if k not in keys_to_remove
     )
@@ -241,10 +242,11 @@ def build_lots_and_categories_link_tree(
         categories = category_filter_group['filters'] if category_filter_group else []
 
         if lot_selected:
-            selected_categories = _annotate_categories_with_selection(lot['slug'], categories, cleaned_request_args,
-                                                                      url_args_for_lot, content_manifest, framework,
-                                                                      aggregations_by_lot[lot['slug']], keys_to_remove,
-                                                                      search_link_builder)
+            selected_categories = _annotate_categories_with_selection(
+                lot['slug'], categories, cleaned_request_args, url_args_for_lot, content_manifest, framework,
+                aggregations_by_lot[lot['slug']], keys_to_remove, search_link_builder,
+                parent_category=request.args.get('parentCategory', None)
+            )
             selected_filters.append(lot_filter)
             selected_filters.extend(selected_categories)
 
@@ -304,7 +306,7 @@ def _annotate_categories_with_selection(lot_slug, category_filters, cleaned_requ
             # If a parentCategory has been sent as a url query param, and it's this category...
             # (Note: `get` fallback is for if there are selected descendants but no parent category is set, which is
             # not expected, but could happen if constructing URLs by hand.)
-            if cleaned_request_args.get('parentCategory', category['value']) == category['value']:
+            if (parent_category or category['value']) == category['value']:
                 # ... then ensure this choice survives as a hidden field for the filters form
                 parent_category_filter = dict()
                 parent_category_filter['name'] = 'parentCategory'
@@ -325,11 +327,13 @@ def _annotate_categories_with_selection(lot_slug, category_filters, cleaned_requ
         # If we're showing it as 'selected' because one of its children is selected, then the link is
         # useful as a kind of breadcrumb, to return to showing all services in that overall category.
         if not directly_selected:
-            url_args = _update_base_url_args_for_lot_and_category(url_args_for_lot,
-                                                                  keys_to_remove,
-                                                                  lot_slug=lot_slug,
-                                                                  category=category,
-                                                                  parent_category=parent_category)
+            url_args = _update_base_url_args_for_lot_and_category(
+                url_args_for_lot,
+                keys_to_remove,
+                lot_slug=lot_slug,
+                category=category,
+                parent_category=parent_category if parent_category != category['value'] else None
+            )
             category['link'] = search_link_builder(url_args)
 
     # When there's a selection, and the selected category has children, remove sibling subcategories,

--- a/app/main/presenters/search_summary.py
+++ b/app/main/presenters/search_summary.py
@@ -131,7 +131,7 @@ class SearchSummary(object):
 
         groups = defaultdict(list)
         for filter_name, filter_values in request_args.lists():
-            if filter_name in ('lot', 'q', 'page', 'parentCategory'):
+            if filter_name in ('lot', 'q', 'page'):
                 continue
 
             for filter_value in filter_values:

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -251,18 +251,10 @@ def search_services():
     except ValueError:
         abort(404)
 
-    search_query_kwargs = build_search_query(
-        clean_request_query_params,
-        filters.values(),
-        content_manifest,
-        lots_by_slug,
-        for_aggregation=True
-    )
-
     search_api_response = search_api_client.search(
         index=framework['slug'],
         doc_type=doc_type,
-        **search_query_kwargs
+        **build_search_query(clean_request_query_params, filters.values(), content_manifest, lots_by_slug)
     )
     search_results_obj = SearchResults(
         search_api_response,

--- a/tests/main/helpers/test_search_helpers.py
+++ b/tests/main/helpers/test_search_helpers.py
@@ -184,7 +184,6 @@ class TestBuildSearchQueryHelpers(BaseApplicationTest):
             'question2': 'true',
             'question3': ['option1', 'option2'],
             'q': 'email',
-            'parentCategory': 'collaborative working',
             'lot': 'saas',
             'page': 9,
         })


### PR DESCRIPTION
## The commits here are best to look at separately.

One backs out the original fix. The other adds a new version of the fix that works with the same tests.

The below shows the diff of master _before the previous breaking PR was merged_ up to here.

https://github.com/alphagov/digitalmarketplace-buyer-frontend/compare/d864e9260c9d837ac57fb39dbaae709c30b02907...be81d6ab2fc2e937799934cd55fa2362bd45c402

Looking at the above comparison we:

* Remove the `parentCategory` from the list of args used to generate the URL for the _root_ of the tree. The root has no parent...
* We pass `parentCategory` from the request args to `_annotate_categories_with_selection`.
* We use the passed `parentCategory` instead of the `cleaned_request_args` one. `cleaned_request_args` will never contain `parentCategory`. It's stripped in `clean_request_args`.
* In `_annotate_categories_with_selection` we only use `parentCategory` to generate the url of child branches of the tree


And all the tests still work.