### PR TITLE
Bump lxml to v4.2.5

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -5,7 +5,7 @@ Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24
-lxml==3.8.0
+lxml==4.2.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask==1.0.2
 Flask-Login==0.4.1
 Flask-WTF==0.14.2
 itsdangerous==0.24
-lxml==3.8.0
+lxml==4.2.5
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0


### PR DESCRIPTION
Trello: https://trello.com/c/KPmFEiW3/525-lxml-vulnerabilities-showing-on-github-repos

requires.io was showing a vulnerability for `lxml`. This bump should get rid of the nasty red warning.

lxml changelog: https://github.com/lxml/lxml/blob/master/CHANGES.txt
The major bump refers to a backwards incompatible fix on the `html5parser`, which we don't use in this repo.