### PR TITLE
Bump utils to pull in external route fix

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,6 +7,6 @@ Flask-WTF==0.14.2
 itsdangerous==0.24
 lxml==4.2.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@45.1.0#egg=digitalmarketplace-utils==45.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.14.2
 itsdangerous==0.24
 lxml==4.2.5
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@45.0.2#egg=digitalmarketplace-utils==45.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@45.1.0#egg=digitalmarketplace-utils==45.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.0.0#egg=digitalmarketplace-content-loader==5.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digitalmarketplace-apiclient==19.7.0
 
@@ -16,7 +16,7 @@ git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.7.0#egg=digi
 asn1crypto==0.24.0
 boto3==1.7.83
 botocore==1.10.84
-certifi==2018.10.15
+certifi==2018.11.29
 cffi==1.11.5
 chardet==3.0.4
 Click==7.0


### PR DESCRIPTION
Trello: https://trello.com/c/2DHLpeo3/263-external-routes-raising-notimplementederror-when-they-should-404

Pulls in the fix from https://github.com/alphagov/digitalmarketplace-utils/pull/480.