### PR TITLE
direct award views: gracefully 404 when supplied with invalid framework families in path

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -70,6 +70,8 @@ def index_g_cloud():
 
 @direct_award_public.route("/<string:framework_family>/start", methods=("GET",))
 def pre_project_task_list(framework_family):
+    if framework_family != "g-cloud":
+        abort(404)
     frameworks_by_slug = framework_helpers.get_frameworks_by_slug(data_api_client)
     framework = framework_helpers.get_latest_live_framework(frameworks_by_slug.values(), "g-cloud")
 
@@ -90,7 +92,7 @@ def pre_project_task_list(framework_family):
 def choose_lot(framework_family):
     # if there are multiple live g-cloud frameworks, assume they all have the same lots
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
+    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
 
     content_loader.load_messages(framework['slug'], ['advice', 'descriptions'])
     gcloud_lot_messages = content_loader.get_message(framework['slug'], 'advice', 'lots')
@@ -384,10 +386,7 @@ def search_services():
 @direct_award.route('/<string:framework_family>', methods=['GET'])
 def saved_search_overview(framework_family):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
-
-    if not framework:
-        abort(404)
+    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
 
     content_loader.load_messages(framework['slug'], ['descriptions', 'urls'])
     framework_short_description = content_loader.get_message(framework['slug'], 'descriptions', 'framework_short')
@@ -413,7 +412,7 @@ def view_projects(framework_family):
 def save_search(framework_family):
     # Get core data
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
+    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
     lots_by_slug = framework_helpers.get_lots_by_slug(framework)
 
     search_query = url_decode(request.values.get('search_query'))
@@ -577,7 +576,7 @@ def view_project(framework_family, project_id):
 @direct_award.route('/<string:framework_family>/projects/<int:project_id>/end-search', methods=['GET', 'POST'])
 def end_search(framework_family, project_id):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
+    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
     frameworks_by_slug = framework_helpers.get_frameworks_by_slug(data_api_client)
 
     # Get the requested Direct Award Project.
@@ -659,7 +658,7 @@ def update_project(framework_family, project_id):
 )
 def did_you_award_contract(framework_family, project_id):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
+    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
 
     # Get the requested Direct Award Project.
     project = data_api_client.get_direct_award_project(project_id=project_id)['project']
@@ -726,7 +725,7 @@ def which_service_won_contract(framework_family, project_id):
         abort(410)
 
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(
+    framework = framework_helpers.get_latest_live_framework_or_404(
         all_frameworks, framework_family)
 
     search = data_api_client.find_direct_award_project_searches(user_id=current_user.id,
@@ -775,7 +774,7 @@ def which_service_won_contract(framework_family, project_id):
 )
 def tell_us_about_contract(framework_family, project_id, outcome_id):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(all_frameworks, framework_family)
+    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
 
     # Get the requested Direct Award Project.
     project = data_api_client.get_direct_award_project(project_id=project_id)['project']
@@ -831,7 +830,7 @@ def tell_us_about_contract(framework_family, project_id, outcome_id):
 )
 def why_did_you_not_award_the_contract(framework_family, project_id):
     all_frameworks = data_api_client.find_frameworks().get('frameworks')
-    framework = framework_helpers.get_latest_live_framework(
+    framework = framework_helpers.get_latest_live_framework_or_404(
         all_frameworks, framework_family)
 
     project = data_api_client.get_direct_award_project(project_id=project_id)['project']

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -57,6 +57,11 @@ class TestDirectAward(TestDirectAwardBase):
             cls.SAVE_SEARCH_URL, quote_plus(cls.SIMPLE_SEARCH_PARAMS))
         cls.SEARCH_API_URL = 'g-cloud-9/services/search'
 
+    def test_invalid_framework_family(self):
+        self.login_as_buyer()
+        res = self.client.get("/buyers/direct-award/shakespeare")
+        assert res.status_code == 404
+
     def test_renders_saved_search_overview(self):
         self.login_as_buyer()
         res = self.client.get(self.SAVE_SEARCH_OVERVIEW_URL)
@@ -175,6 +180,12 @@ class TestDirectAward(TestDirectAwardBase):
     def test_save_search_submit_name_too_long(self):
         res = self._save_search('x' * 101)
         self._asserts_for_create_project_failure(res)
+
+    @pytest.mark.parametrize("method", ("GET", "POST"))
+    def test_save_search_invalid_framework_family(self, method):
+        self.login_as_buyer()
+        res = self.client.open("/buyers/direct-award/shakespeare/save-search", method=method)
+        assert res.status_code == 404
 
 
 class TestDirectAwardProjectOverview(TestDirectAwardBase):
@@ -643,6 +654,12 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
         doc = html.fromstring(res.get_data(as_text=True))
         assert len(doc.xpath('//h1[contains(normalize-space(), "Before you export your results")]')) == 1
 
+    @pytest.mark.parametrize("method", ("GET", "POST"))
+    def test_invalid_framework_family(self, method):
+        self.login_as_buyer()
+        res = self.client.open('/buyers/direct-award/shakespeare/projects/1/end-search', method=method)
+        assert res.status_code == 404
+
     def test_end_search_page_renders_error_when_results_more_than_limit(self):
         self.login_as_buyer()
 
@@ -784,6 +801,13 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
             'success'
         )
 
+    @pytest.mark.parametrize("method", ("GET", "POST"))
+    def test_invalid_framework_family(self, method):
+        self.login_as_buyer()
+
+        res = self.client.open('/buyers/direct-award/shakespeare/projects/1/did-you-award-contract', method=method)
+        assert res.status_code == 404
+
     def test_award_contract_raises_404_if_project_is_not_accessible(self):
         self.data_api_client.get_direct_award_project.side_effect = NotFound()
         self.login_as_buyer()
@@ -830,6 +854,16 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
             '//span[contains(normalize-space(text()), "Supplier name")][contains(parent::label, "Service name")]')) == 1
         assert len(
             doc.xpath('//input[@type="submit"][@value="Save and continue"]')) == 1
+
+    @pytest.mark.parametrize("method", ("GET", "POST"))
+    def test_which_service_did_you_award_page_invalid_framework_family(self, method):
+        self.login_as_buyer()
+
+        res = self.client.open(
+            "/buyers/direct-award/shakespeare/projects/1/which-service-won-contract",
+            method=method,
+        )
+        assert res.status_code == 404
 
     def test_which_service_did_you_award_page_show_zero_state_message(self):
         self.login_as_buyer()
@@ -947,6 +981,16 @@ class TestDirectAwardTellUsAboutContract(TestDirectAwardBase):
         self.data_api_client.get_direct_award_project.return_value['project']['users'][0]['id'] = 321
 
         assert client.get('/buyers/direct-award/g-cloud/projects/31415/tell-us-about-contract').status_code == 404
+
+    @pytest.mark.parametrize("method", ("GET", "POST"))
+    def test_invalid_framework_family(self, method):
+        self.login_as_buyer()
+
+        res = self.client.open(
+            "/buyers/direct-award/shakespeare/projects/1/tell-us-about-contract",
+            method=method,
+        )
+        assert res.status_code == 404
 
     def test_tell_us_about_contract_successful_post_redirects_to_project_overview(self, client, data):
         res = client.post(self.url, data=data)
@@ -1066,6 +1110,16 @@ class TestDirectAwardNonAwardContract(TestDirectAwardBase):
         res = self.client.get(
             '/buyers/direct-award/g-cloud/projects/1/why-didnt-you-award-contract')
         assert res.status_code == 410
+
+    @pytest.mark.parametrize("method", ("GET", "POST"))
+    def test_invalid_framework_family(self, method):
+        self.login_as_buyer()
+
+        res = self.client.open(
+            "/buyers/direct-award/shakespeare/projects/1/why-didnt-you-award-contract",
+            method=method,
+        )
+        assert res.status_code == 404
 
 
 class TestDirectAwardResultsPage(TestDirectAwardBase):
@@ -1301,3 +1355,7 @@ class TestPreProjectTaskList(TestDirectAwardBase):
             u="/buyers/direct-award/g-cloud",
             t="See a list of your saved searches",
         )
+
+    def test_invalid_framework_family(self):
+        res = self.client.get('/buyers/direct-award/shakespeare/start')
+        assert res.status_code == 404

--- a/tests/main/views/test_g_cloud.py
+++ b/tests/main/views/test_g_cloud.py
@@ -13,16 +13,16 @@ class TestGCloudIndexResults(BaseApplicationTest):
 
         self.search_results = self._get_search_results_fixture_data()
 
+        self._search_api_client.search.return_value = self.search_results
+        self._search_api_client.aggregate.return_value = \
+            self._get_fixture_data('g9_aggregations_fixture.json')
+
     def teardown_method(self, method):
         self._search_api_client_patch.stop()
         super().teardown_method(method)
 
     @pytest.mark.parametrize('lot', ('cloud-support', 'cloud-software', 'cloud-hosting', ''))
     def test_posting_lot_redirects_to_search_with_lot(self, lot):
-        self._search_api_client.search.return_value = self.search_results
-        self._search_api_client.aggregate.return_value = \
-            self._get_fixture_data('g9_aggregations_fixture.json')
-
         res = self.client.post(
             "/buyers/direct-award/g-cloud/choose-lot",
             data={"lot": lot}
@@ -33,3 +33,14 @@ class TestGCloudIndexResults(BaseApplicationTest):
 
         redirect = self.client.get(res.location)
         assert redirect.status_code == 200
+
+    def test_invalid_framework_family_post(self):
+        res = self.client.post(
+            "/buyers/direct-award/shakespeare/choose-lot",
+            data={"lot": "cloud-hosting"}
+        )
+        assert res.status_code == 404
+
+    def test_invalid_framework_family_get(self):
+        res = self.client.get("/buyers/direct-award/shakespeare/choose-lot")
+        assert res.status_code == 404


### PR DESCRIPTION
Spawned from https://trello.com/c/wT6iM4SQ this morning

Turns out there were a bunch of views that didn't consider this case. Also add tests as this was clearly untested.