### PR TITLE
Following framework content for Buyer FE

### DIFF
--- a/app/main/helpers/framework_helpers.py
+++ b/app/main/helpers/framework_helpers.py
@@ -68,27 +68,14 @@ def get_framework_or_500(client, framework_slug, logger=None):
 
 def get_following_framework(client, current_framework, logger):
     """
-    Check for 1) a database entry for the following framework 2) the content metadata for the following framework
+    1) Fetch the 'following_framework' metadata for the current framework
+    2) Look up the 'following_framework' in the database
     Return None if either or both are missing.
     """
     try:
         following_framework_content = content_loader.get_metadata(
             current_framework['slug'], 'following_framework', 'framework'
         )
-        if following_framework_content:
-            try:
-                return client.get_framework(following_framework_content['slug'])['frameworks']
-            except HTTPError as e:
-                if e.status_code == 404:
-                    if logger:
-                        logger.info(
-                            "Framework not found: {error}, framework_slug: {framework_slug}",
-                            extra={'error': str(e), 'framework_slug': following_framework_content['slug']}
-                        )
-                    return None
-                else:
-                    raise
-
     except ContentNotFoundError as e:
         if logger:
             logger.info(
@@ -96,3 +83,18 @@ def get_following_framework(client, current_framework, logger):
                 extra={'error': str(e), 'framework_slug': current_framework['slug']}
             )
         return None
+
+    if following_framework_content:
+        try:
+            return client.get_framework(following_framework_content['slug'])['frameworks']
+        except HTTPError as e:
+            if e.status_code == 404:
+                if logger:
+                    logger.info(
+                        "Framework not found: {error}, framework_slug: {framework_slug}",
+                        extra={'error': str(e), 'framework_slug': following_framework_content['slug']}
+                    )
+                return None
+            raise
+
+    return None

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -8,7 +8,6 @@ from flask_login import current_user
 from werkzeug.urls import Href, url_encode, url_decode
 
 from dmapiclient import HTTPError
-from dmcontent.errors import ContentNotFoundError
 from dmcontent.formats import format_service_price
 from dmcontent.questions import Pricing
 from dmutils.flask import timed_render_template as render_template
@@ -543,15 +542,9 @@ def view_project(framework_family, project_id):
     custom_dimensions = [dm_google_analytics.custom_dimension(dm_google_analytics.CurrentProjectStageEnum,
                                                               current_project_stage)]
 
-    try:
-        following_framework = framework_helpers.get_framework_or_500(
-            data_api_client,
-            content_loader.get_metadata(framework['slug'], 'following_framework', 'slug'),
-            current_app.logger,
-        )
-    except ContentNotFoundError:
-        following_framework = None
-
+    following_framework = framework_helpers.get_following_framework(
+        data_api_client, framework, current_app.logger
+    )
     temporary_message_status = get_saved_search_temporary_message_status(
         project, framework, following_framework
     ) if following_framework else None

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.6.2",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#13.7.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   },
   "scripts": {

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -506,6 +506,14 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
         assert not doc.xpath("//div[@class='temporary-message']")
         assert not doc.xpath("//div[@class='temporary-message-banner']")
 
+    @mock.patch('app.main.helpers.framework_helpers.content_loader')
+    def test_following_framework_still_raises_on_api_error(self, content_loader_mock):
+        self.data_api_client.get_framework.side_effect = HTTPError(response=mock.Mock(status_code=500))
+        content_loader_mock.get_metadata.return_value = {'slug': 'g-cloud-11'}
+
+        res = self.client.get('/buyers/direct-award/g-cloud/projects/1')
+        assert res.status_code == 500
+
     @pytest.mark.parametrize(
         ('framework_status', 'following_framework_status'),
         (

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.6.2":
-  version "13.6.2"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#6522745d6bb66192de1af51bfcde9505a663de1e"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#13.7.0":
+  version "13.7.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#30c13434a1cbbf73f76d98c51fb64cce43a8c829"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0":
   version "31.8.0"


### PR DESCRIPTION
Trello: https://trello.com/c/JPSjopsY/337-create-g11-framework-on-preview-and-set-to-coming

![screenshot-localhost-2019 01 25-17-48-08](https://user-images.githubusercontent.com/3492540/51763048-67976080-20c9-11e9-8faa-49273fb7d421.png)

Pulls in the new G11 content ready for use on the Buyer FE. I've tested the home page locally with G11 framework statuses of coming, open, pending, standstill and live.

Also includes a fix for the new metadata structure (used on DOS3 but not G10). This is needed in the Direct Award saved search projects to alert buyers that any searches containing G10 services they are evaluating will be suspended on a certain date, and that they might want to start a new search with G11 services instead.

There are two checks happening: whether the `following_framework` content is present, and whether there's an associated database object for that following framework. Flake8 decided this was 'too complex' and I agreed, so it's been moved out into a helper function.