### PR TITLE
Bump digitalmarketplace-utils dependency to v48.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,6 +7,6 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 lxml==4.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.0.3#egg=digitalmarketplace-utils==48.0.3
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,22 +8,22 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 lxml==4.3.3
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.0.3#egg=digitalmarketplace-utils==48.0.3
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.0#egg=digitalmarketplace-content-loader==5.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.130
-botocore==1.12.130
+boto3==1.9.134
+botocore==1.12.134
 certifi==2019.3.9
-cffi==1.12.2
+cffi==1.12.3
 chardet==3.0.4
 Click==7.0
 contextlib2==0.5.5
 cryptography==2.3.1
-defusedxml==0.5.0
+defusedxml==0.6.0
 docopt==0.6.2
 docutils==0.14
 Flask-Script==2.0.6
@@ -52,7 +52,7 @@ requests==2.21.0
 s3transfer==0.2.0
 six==1.12.0
 unicodecsv==0.14.1
-urllib3==1.24.1
+urllib3==1.24.2
 Werkzeug==0.15.2
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
Also bump digitalmarketplace-content-loader to 5.2.1 and other version bumps that come with the re-freeze.

This principally brings us the last-ditch exception logging.