### PR TITLE
Mark application.py as not executable

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 from app import create_app
 from dmutils import init_manager


### PR DESCRIPTION
This is a workaround for a change in Werkzeug 0.15.x (see pallets/werkzeug#1242).
The reloading server used by `make run-app` won't preserve the Python
executable if the running Python script is executable; this is a problem
if you want to use a specific version of Python (say if you are in a
venv).