### PR TITLE
Update G11 application closing date

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.0.3",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.4",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,9 +519,9 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.0.3":
-  version "15.0.3"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#5594b7390f1446088c70a18ee2cbe1e18693487f"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.4":
+  version "15.3.4"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#16edf30bc6fe544ff55ccde2b2df9a512979c52c"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v31.8.0":
   version "31.8.0"


### PR DESCRIPTION
Pulls in frameworks version 15.3.4 with the updated date (see https://github.com/alphagov/digitalmarketplace-frameworks/pull/568)

![updated-g11-homepage-message](https://user-images.githubusercontent.com/3492540/57285509-42909180-70ab-11e9-94e4-dd91f7a53d4e.png)
