### PR TITLE
487-metrics-on-buyer-and-supplier-we-need-to-find-evidence-of-what-is-causing-the-slow-requests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -46,11 +46,13 @@ def create_app(config_name):
                 content_loader.load_manifest(framework_data['slug'], 'briefs', 'display_brief')
                 try_load_manifest(content_loader, application, framework_data, 'briefs', 'briefs_search_filters')
 
+    from .metrics import metrics as metrics_blueprint, gds_metrics
     from .main import main as main_blueprint
     from .main import direct_award as direct_award_blueprint
     from .main import direct_award_public as direct_award_public_blueprint
     from .status import status as status_blueprint
 
+    application.register_blueprint(metrics_blueprint)
     application.register_blueprint(status_blueprint)
     application.register_blueprint(main_blueprint)
     application.register_blueprint(direct_award_blueprint)
@@ -64,6 +66,7 @@ def create_app(config_name):
 
     login_manager.login_view = '/user/login'
     login_manager.login_message_category = "must_login"
+    gds_metrics.init_app(application)
     csrf.init_app(application)
 
     @application.before_request

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,9 @@
+from flask import Blueprint
+from dmutils.metrics import DMGDSMetrics
+
+
+metrics = Blueprint('metrics', __name__)
+
+gds_metrics = DMGDSMetrics()
+
+metrics.add_url_rule(gds_metrics.metrics_path, 'metrics', gds_metrics.metrics_endpoint)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -119,8 +119,11 @@ class BaseApplicationTest(object):
          - the .find_frameworks() return value will need to be provided separately in those tests, as the import
            path will (hopefully!) be different there.
         """
+        self.app_env_var_mock = mock.patch.dict('gds_metrics.os.environ', {'PROMETHEUS_METRICS_PATH': '/_metrics'})
+        self.app_env_var_mock.start()
         data_api_client.find_frameworks = mock.Mock()
         data_api_client.find_frameworks.return_value = self._get_frameworks_list_fixture_data()
+
         self.app = create_app('test')
         self.app.register_blueprint(login_for_tests)
         self.client = self.app.test_client()
@@ -128,6 +131,7 @@ class BaseApplicationTest(object):
 
     def teardown_method(self, method):
         self.teardown_login()
+        self.app_env_var_mock.stop()
 
     @staticmethod
     def user(id, email_address, supplier_id, supplier_name, name,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import re
+from mock import patch
+
+from tests.helpers import BaseApplicationTest
+
+
+def load_prometheus_metrics(response_bytes):
+    return dict(re.findall(rb"(\w+{.+?}) (\d+)", response_bytes))
+
+
+class BaseMetricsTest(BaseApplicationTest):
+
+    def setup_method(self, *args, **kwargs):
+        self.app_env_var_mock = patch.dict('gds_metrics.os.environ', {'PROMETHEUS_METRICS_PATH': '/_metrics'})
+        self.app_env_var_mock.start()
+        super(BaseMetricsTest, self).setup_method(args, **kwargs)
+
+    def teardown_method(self, *args, **kwargs):
+        super(BaseMetricsTest, self).teardown_method(args, **kwargs)
+        self.app_env_var_mock.stop()
+
+
+class TestMetricsPage(BaseMetricsTest):
+
+    def test_metrics_page_accessible(self):
+        metrics_response = self.client.get('/_metrics')
+
+        assert metrics_response.status_code == 200
+
+    def test_metrics_page_contents(self):
+        metrics_response = self.client.get('/_metrics')
+        results = load_prometheus_metrics(metrics_response.data)
+        assert (
+            b'http_server_requests_total{code="200",host="localhost",method="GET",path="/_metrics"}'
+        ) in results
+
+
+class TestMetricsPageRegistersPageViews(BaseMetricsTest):
+
+    def test_metrics_page_registers_page_views(self):
+        expected_metric_name = (
+            b'http_server_requests_total{code="200",host="localhost",method="GET",path="/"}'
+        )
+
+        res = self.client.get('/')
+        assert res.status_code == 200
+
+        metrics_response = self.client.get('/_metrics')
+        results = load_prometheus_metrics(metrics_response.data)
+        assert expected_metric_name in results
+
+    def test_metrics_page_registers_multiple_page_views(self):
+        expected_metric_name = (
+            b'http_server_requests_total{code="200",host="localhost",method="GET",path="/"}'
+        )
+
+        initial_metrics_response = self.client.get('/_metrics')
+        initial_results = load_prometheus_metrics(initial_metrics_response.data)
+        initial_metric_value = int(initial_results.get(expected_metric_name, 0))
+
+        for _ in range(3):
+            res = self.client.get('/')
+            assert res.status_code == 200
+
+        metrics_response = self.client.get('/_metrics')
+        results = load_prometheus_metrics(metrics_response.data)
+        metric_value = int(results.get(expected_metric_name, 0))
+
+        assert expected_metric_name in results
+        assert metric_value - initial_metric_value == 3

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import re
-from mock import patch
 
 from tests.helpers import BaseApplicationTest
 
@@ -9,19 +8,7 @@ def load_prometheus_metrics(response_bytes):
     return dict(re.findall(rb"(\w+{.+?}) (\d+)", response_bytes))
 
 
-class BaseMetricsTest(BaseApplicationTest):
-
-    def setup_method(self, *args, **kwargs):
-        self.app_env_var_mock = patch.dict('gds_metrics.os.environ', {'PROMETHEUS_METRICS_PATH': '/_metrics'})
-        self.app_env_var_mock.start()
-        super(BaseMetricsTest, self).setup_method(args, **kwargs)
-
-    def teardown_method(self, *args, **kwargs):
-        super(BaseMetricsTest, self).teardown_method(args, **kwargs)
-        self.app_env_var_mock.stop()
-
-
-class TestMetricsPage(BaseMetricsTest):
+class TestMetricsPage(BaseApplicationTest):
 
     def test_metrics_page_accessible(self):
         metrics_response = self.client.get('/_metrics')
@@ -36,7 +23,7 @@ class TestMetricsPage(BaseMetricsTest):
         ) in results
 
 
-class TestMetricsPageRegistersPageViews(BaseMetricsTest):
+class TestMetricsPageRegistersPageViews(BaseApplicationTest):
 
     def test_metrics_page_registers_page_views(self):
         expected_metric_name = (


### PR DESCRIPTION
https://trello.com/c/7NhpkDWC/487-metrics-on-buyer-and-supplier-we-need-to-find-evidence-of-what-is-causing-the-slow-requests


* Add metrics
* Add tests