### PR TITLE
Pull in DOS4 content

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v32.0.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.4",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.4.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,9 +762,9 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.3.4":
-  version "15.3.4"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#16edf30bc6fe544ff55ccde2b2df9a512979c52c"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.4.0":
+  version "15.4.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#059f663324aafc80614618342a06919e64f0d86c"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v32.0.3":
   version "32.0.3"


### PR DESCRIPTION
Trello: https://trello.com/c/kTVN6PlQ/532-clone-dos4-content

DOS4 is coming! Let's add in the content for the home page sidebar.

![dos4-is-coming](https://user-images.githubusercontent.com/3492540/58806181-87a5d600-860d-11e9-8cdf-6c883380677e.png)

Dates etc are still TBC. The message above is displayed in place of the 'G11 is closed for applications' message.
