### PR TITLE
Include declaration documents on service page

### DIFF
--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -12,9 +12,9 @@ DECLARATION_DOCUMENT_KEYS = [
     ('modernSlaveryStatementOptional', 'modernSlaveryStatementURL')
 ]
 DOCUMENT_NAMES = OrderedDict([
-    ('pricingDocumentURL', 'Pricing'),
-    ('sfiaRateDocumentURL', 'SFIA rate card'),
-    ('serviceDefinitionDocumentURL', 'Service definition'),
+    ('pricingDocumentURL', 'Pricing document'),
+    ('sfiaRateDocumentURL', 'Skills Framework for the Information Age rate card'),
+    ('serviceDefinitionDocumentURL', 'Service definition document'),
     ('termsAndConditionsDocumentURL', 'Terms and conditions'),
     ('modernSlaveryStatementURL', 'Modern Slavery statement')
 ])

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -178,12 +178,14 @@ def get_service_by_id(service_id):
         if framework['framework'] != 'g-cloud':
             abort(404)
 
+        # Get declaration info (including Modern Slavery statement document URL, if present)
+        supplier_framework = data_api_client.get_supplier_framework_info(service_data['supplierId'], framework_slug)
+
         service_view_data = Service(
             service_data,
-            content_loader.get_manifest(framework_slug, 'display_service').filter(
-                service_data
-            ),
-            framework_helpers.get_lots_by_slug(framework)
+            content_loader.get_manifest(framework_slug, 'display_service').filter(service_data),
+            framework_helpers.get_lots_by_slug(framework),
+            declaration=supplier_framework['frameworkInterest'].get('declaration', {})
         )
 
         try:

--- a/app/templates/_service_documents.html
+++ b/app/templates/_service_documents.html
@@ -1,0 +1,17 @@
+{% import "toolkit/summary-table.html" as summary %}
+{{ summary.heading("Service documents", id="service-documents") }}
+
+{% call(document) summary.list_table(
+    service.meta.documents,
+    caption="Service documents",
+    field_headings_visible=False
+  ) %}
+
+  {% call summary.row() %}
+    <a href="{{ document.url }}" class="document-link-with-icon">
+        <span class='document-icon'>{{ document.extension }}<span> document:</span></span>
+        {{ document.name }}
+    </a>
+  {% endcall %}
+
+{% endcall %}

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -76,7 +76,9 @@
 <div class="grid-row service-attributes">
   <div class="column-one-whole">
     {% include '_service_attributes.html' %}
+    {% include '_service_documents.html' %}
     <a href="#content" class="return-to-top">Return to top ↑</a>
   </div>
 </div>
+
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "hogan.js": "3.0.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
-    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#15.4.5",
+    "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.0",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   },
   "scripts": {

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -128,21 +128,21 @@ class TestMeta:
     def test_get_documents_returns_the_correct_document_information(self):
         expected_information = [
             {
-                'name': 'Pricing',
+                'name': 'Pricing document',
                 'url': (
                     'https://assets.digitalmarketplace.service.gov.uk/' +
                     'documents/123456/1234567890123456-pricing-document.pdf'
                 )
             },
             {
-                'name': 'SFIA rate card',
+                'name': 'Skills Framework for the Information Age rate card',
                 'url': (
                     'https://assets.digitalmarketplace.service.gov.uk/' +
                     'documents/123456/1234567890123456-sfia-rate-card.pdf'
                 )
             },
             {
-                'name': 'Service definition',
+                'name': 'Service definition document',
                 'url': (
                     'https://assets.digitalmarketplace.service.gov.uk/' +
                     'documents/' +

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -82,6 +82,17 @@ class TestService(BaseApplicationTest):
         assert hasattr(self.service, 'benefits')
         assert len(self.service.benefits) == 6
 
+    @pytest.mark.parametrize('declaration, expected', [(None, {}), ({'foo': 'bar'}, {'foo': 'bar'})])
+    def test_declaration_attribute_is_correctly_set_on_meta(self, declaration, expected):
+        service = Service(
+            self.fixture,
+            content_loader.get_manifest('g-cloud-6', 'display_service'),
+            self._lots_by_slug,
+            declaration=declaration
+        )
+        assert hasattr(service.meta, 'declaration')
+        assert service.meta.declaration == expected
+
     def test_service_properties_available_via_summary_manifest(self):
         service = Service(
             self.fixture,
@@ -163,6 +174,19 @@ class TestMeta:
             assert documents[idx]['name'] == expected_information[idx]['name']
             assert documents[idx]['url'] == expected_information[idx]['url']
             assert documents[idx]['extension'] == 'pdf'
+
+    @pytest.mark.parametrize("document_key", ['modernSlaveryStatement', 'modernSlaveryStatementOptional'])
+    def test_get_documents_includes_declaration_documents(self, document_key):
+        meta = Meta(
+            self.fixture,
+            declaration={
+                document_key: "https://www.digitalmarketplace.service.gov.uk/suppliers/assets/not/a/real/path.pdf"
+            }
+        )
+        documents = meta.get_documents(self.fixture)
+        assert documents[4]['name'] == 'Modern Slavery statement'
+        assert documents[4]['url'] == 'https://assets.digitalmarketplace.service.gov.uk/not/a/real/path.pdf'
+        assert documents[4]['extension'] == 'pdf'
 
     def test_get_documents_raises_error_if_no_file_extension(self):
         bad_document_url = "https://assets.digitalmarketplace.service.gov.uk/documents/123456/noextension"

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,9 +762,9 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
-"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#15.4.5":
-  version "15.4.5"
-  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#1f4fe5f6ecfbbeb50b8d4af53a2c7604a5518065"
+"digitalmarketplace-frameworks@https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.0":
+  version "16.0.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#2b4d034f0c9377071dbe8754df6b838c5073f975"
 
 "digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v33.0.0":
   version "33.0.0"


### PR DESCRIPTION
https://trello.com/c/h3dtJytJ/882-display-modern-slavery-document-uploads-on-service-page

![modern-slavery-doc-service-page](https://user-images.githubusercontent.com/3492540/59111456-fbf7b680-8938-11e9-86e3-b0442747caed.png)

The Service presenter class already combines supplier data with service data. We're now adding in declaration data (where the Modern Slavery doc URL is kept).

The hardcoded document list is moved to the top of the `service_presenters` module for easier future editing.

The section of the manifest that previously displayed the documents at the bottom of the page has been removed, and a new `_service_documents.html` template has been included (with the same content as the top panel). 

Content changes of the document names need to be OK-ed with Stefan.