### PR TITLE
Help page changes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,7 +8,6 @@
 //= require ../../../node_modules/jquery/dist/jquery.js
 //= require ../../../node_modules/hogan.js/web/builds/3.0.2/hogan-3.0.2.js
 //= require ../../../node_modules/scrolldepth/jquery.scrolldepth.js
-//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/xhr-semaphore.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/option-select.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/support.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/live-search.js

--- a/app/templates/help/index.html
+++ b/app/templates/help/index.html
@@ -20,35 +20,42 @@
 <div class="help-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = "What do you need help with?", smaller="true" %} {% include "toolkit/page-heading.html" %} {% endwith %}
-  
+      {% with heading = "Help and feedback", smaller="true" %} {% include "toolkit/page-heading.html" %} {% endwith %}
+
       <div class="dmspeak">
         <h2 class="heading-xmedium">Selling services</h2>
-      </div>
-      <p>
-        For support selling your services, for example, lowering your prices, email
-        <a href="mailto:cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
-        <br>
-        <br>
-        For questions or help with monthly management information (MISO), email
-        <a href="mailto:miso.mailbox@crowncommercial.gov.uk">miso.mailbox@crowncommercial.gov.uk</a>
-      </p>
 
-      <div class="dmspeak">
-        <h2 class="heading-xmedium">Buying services</h2>
-      </div>      
-      <p>
-        For support buying services, for example, evaluating suppliers, email
-        <a href="mailto:cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a>
-      </p>
+        <div class="explanation-list">
+          <p class="lead">Email <a href="mailto:cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a> if you need support:</p>
 
-      <div class="dmspeak">
-        <h2 class="heading-xmedium">Creating and updating an account</h2>
+          <ul class="list-bullet">
+            <li>selling your services, for example lowering your prices</li>
+            <li>buying services, for example evaluating suppliers</li>
+            <li>updating your account </li>
+          </ul>
+        </div>
+
+        <h2 class="heading-xmedium">Help with monthly management information (MI)</h2>
+
+        <p>Email <a href="mailto:report-mi@crowncommercial.gov.uk">report-mi@crowncommercial.gov.uk</a> for help with monthly management information (MI).</p>
+
+        <h2 class="heading-xmedium">Guidance about buying and selling on the Digital Marketplace</h2>
+
+        <div class="explanation-list">
+          <p class="lead"><a href="https://www.gov.uk/guidance/buying-and-selling-on-the-digital-marketplace">Read the guidance</a> for information about:</p>
+
+          <ul class="list-bullet">
+            <li>the G-Cloud and Digital Outcomes and Specialists frameworks</li>
+            <li>how to apply to join as a supplier</li>
+            <li>how to buy</li>
+          </ul>
+        </div>
+
+        <h2 class="heading-xmedium">Feedback about the Digital Marketplace</h2>
+
+        <p>Email <a href="mailto:cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a> if you have feedback about your experience using the Digital Marketplace.</p>
       </div>
-      <p>
-        To make changes to your user account, for example, if you have trouble logging in, email
-        <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-      </p>
+
     </div>
   </div>
 </div>

--- a/config.py
+++ b/config.py
@@ -39,7 +39,7 @@ class Config(object):
     DEBUG = False
 
     RESET_PASSWORD_EMAIL_NAME = 'Digital Marketplace Admin'
-    RESET_PASSWORD_EMAIL_FROM = 'enquiries@digitalmarketplace.service.gov.uk'
+    RESET_PASSWORD_EMAIL_FROM = 'cloud_digital@crowncommercial.gov.uk'
     RESET_PASSWORD_EMAIL_SUBJECT = 'Reset your Digital Marketplace password'
 
     CREATE_USER_SUBJECT = 'Create your Digital Marketplace account'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gulp-jasmine-phantom": "3.0.0",
     "jquery": "1.12.0",
     "hogan.js": "3.0.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#33.1.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#34.1.0",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#16.0.2",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"

--- a/tests/main/views/test_errors.py
+++ b/tests/main/views/test_errors.py
@@ -25,10 +25,10 @@ class TestErrors(BaseApplicationTest):
             "address or start again on the Digital Marketplace homepage." \
             in res.get_data(as_text=True)
         assert "If you can’t find what you’re looking for, contact us at " \
-            "<a href=\"mailto:enquiries@digitalmarketplace.service.gov.uk?" \
+            "<a href=\"mailto:cloud_digital@crowncommercial.gov.uk?" \
             "subject=Digital%20Marketplace%20feedback\" title=\"Please " \
-            "send feedback to enquiries@digitalmarketplace.service.gov.uk\">" \
-            "enquiries@digitalmarketplace.service.gov.uk</a>" \
+            "send feedback to cloud_digital@crowncommercial.gov.uk\">" \
+            "cloud_digital@crowncommercial.gov.uk</a>" \
             in res.get_data(as_text=True)
 
     def test_410(self):

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,9 +766,9 @@ detect-libc@^1.0.2:
   version "16.0.2"
   resolved "https://github.com/alphagov/digitalmarketplace-frameworks.git#a2dee95441da190c3d09dbe09b59f5dbe42cf090"
 
-"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#33.1.0":
-  version "33.1.0"
-  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#0031663d012eb10e228880322c4de7d963612592"
+"digitalmarketplace-frontend-toolkit@https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#34.1.0":
+  version "34.1.0"
+  resolved "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#acb4f5e2b902df76d5517a37512980e8b911902a"
   dependencies:
     del "^4.1.0"
     govuk-elements-sass "3.0.3"


### PR DESCRIPTION
https://trello.com/c/ZTIHOFaJ/146-find-and-replace-old-support-address-to-new-address-your-account-has-been-locked-page-update-support-e-mail-address

- Update 'from' address on password reset email
- Pull in error page templates from FE toolkit (also reverts the AJAX test from v33.1.0)
- Updates a test for those error pages
- Help page content changes

These changes shouldn't be deployed before Monday 8th July.