### PR TITLE
content loader: make thread-safe through use of context-local deep copies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,12 +7,24 @@ let
     forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
+  sitePrioNonNix = args.pkgs.writeTextFile {
+    name = "site-prio-non-nix";
+    destination = "/${args.pythonPackages.python.sitePackages}/sitecustomize.py";
+    text = ''
+      import sys
+      first_nix_i = next((i for i, p in enumerate(sys.path) if p.startswith("/nix/")), 1)
+      # after the first nix-provided path in sys.path (presumably the python stdlib itself), re-sort all non-nix
+      # paths to be before the nix paths. this is helped by python's sort being a stable-sort
+      sys.path[first_nix_i+1:] = sorted(sys.path[first_nix_i+1:], key=lambda p: p.startswith("/nix/"))
+    '';
+  };
 in (with args; {
   digitalMarketplaceBuyerFrontendEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-buyer-frontend-env";
     shortName = "dm-byr-fe";
     buildInputs = [
       pythonPackages.python
+      sitePrioNonNix
       pkgs.glibcLocales
       pkgs.nodejs-8_x
       pkgs.yarn

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,5 +8,5 @@ itsdangerous==0.24 # pyup: ignore
 lxml==4.3.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,14 +9,14 @@ itsdangerous==0.24 # pyup: ignore
 lxml==4.3.4
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@5.2.1#egg=digitalmarketplace-content-loader==5.2.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@19.15.1#egg=digitalmarketplace-apiclient==19.15.1
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.169
-botocore==1.12.169
+boto3==1.9.187
+botocore==1.12.187
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4


### PR DESCRIPTION
https://trello.com/c/RW2tzjbM

This implementation is a little more involved than the one in the supplier frontend, required because the buyer frontend needs information from the `application` object and the api before it can populate its content loader. Hence this is performed quite late in the startup process. This should all
be fine as long as no code needs to access the methods of the content loader before the `application` is initialized, though in such a case the attempt is made to fail obviously and loudly.