### PR TITLE
digitalmarketplace-apiclient dependency: experimentally revert this to 20.2.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,4 +9,4 @@ lxml==4.4.1
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lxml==4.4.1
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.0.0#egg=digitalmarketplace-apiclient==21.0.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0


### PR DESCRIPTION
in an attempt to diagnose unusual timeouts on production. We'll bump it back up if we continue to see these errors.

https://trello.com/c/Kd4qas51