### PR TITLE
Bump digitalmarketplace-utils dependency to 48.5.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,6 +7,6 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 lxml==4.4.1
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,15 +8,15 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 lxml==4.4.1
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.2.0#egg=digitalmarketplace-utils==48.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.210
-botocore==1.12.210
+boto3==1.9.214
+botocore==1.12.214
 certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4


### PR DESCRIPTION
https://trello.com/c/HsZ9mj7o

Bringing in "probe cookie"-setting, along with a re-freeze of dependencies