### PR TITLE
Cross domain tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "12.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
-      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ=="
+      "version": "12.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -895,8 +895,8 @@
       "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.1.2"
     },
     "digitalmarketplace-frontend-toolkit": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#87fd99dddd47ab620db6fb83637f8c8bd10540c4",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.3.0",
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b0287c4eb54721b126fb56050705cde5bd940efc",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
       "requires": {
         "del": "^4.1.0",
         "govuk-elements-sass": "3.0.3",
@@ -990,6 +990,40 @@
             }
           }
         },
+        "gulp-jasmine-phantom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-jasmine-phantom/-/gulp-jasmine-phantom-3.0.0.tgz",
+          "integrity": "sha1-jgsrsi5x1AVqIumoGyFmGRhiU5Y=",
+          "requires": {
+            "glob": "^4.0.6",
+            "gulp-util": "^3.0.0",
+            "handlebars": "^2.0.0",
+            "jasmine": "github:dflynn15/jasmine-npm",
+            "lodash": "^4.3.0",
+            "through2": "^0.6.1"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "4.5.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^2.0.1",
+                "once": "^1.3.0"
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "requires": {
+                "brace-expansion": "^1.0.0"
+              }
+            }
+          }
+        },
         "is-path-cwd": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -1011,10 +1045,40 @@
             "path-is-inside": "^1.0.2"
           }
         },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
         "object-assign": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
         }
       }
     },
@@ -1470,7 +1534,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1488,11 +1553,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1505,15 +1572,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1616,7 +1686,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1626,6 +1697,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1638,17 +1710,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1665,6 +1740,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1737,7 +1813,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1747,6 +1824,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1822,7 +1900,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1852,6 +1931,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1869,6 +1949,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1907,11 +1988,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -2643,7 +2726,7 @@
         "glob": "^4.0.6",
         "gulp-util": "^3.0.0",
         "handlebars": "^2.0.0",
-        "jasmine": "github:dflynn15/jasmine-npm#5f74e4336b247e67bbc509a8f82f3c4fa6b52964",
+        "jasmine": "github:dflynn15/jasmine-npm",
         "lodash": "^4.3.0",
         "through2": "^0.6.1"
       },
@@ -2663,6 +2746,40 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "jasmine": {
+          "version": "github:dflynn15/jasmine-npm#5f74e4336b247e67bbc509a8f82f3c4fa6b52964",
+          "from": "github:dflynn15/jasmine-npm",
+          "requires": {
+            "exit": "^0.1.2",
+            "glob": "^3.2.11",
+            "jasmine-core": "~2.4.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+              "requires": {
+                "inherits": "2",
+                "minimatch": "0.3"
+              }
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+              "requires": {
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
+              }
+            }
+          }
+        },
+        "jasmine-core": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz",
+          "integrity": "sha1-b4OrOg8WlRcizgfSBsdz1XzIOL4="
         },
         "minimatch": {
           "version": "2.0.10",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "1.2.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.1.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v34.3.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",

--- a/spec/javascripts/manifest.js
+++ b/spec/javascripts/manifest.js
@@ -3,8 +3,9 @@ var manifest = {
   support : [
     '../../../node_modules/jquery/dist/jquery.js',
     '../../../node_modules/scrolldepth/jquery.scrolldepth.js',
-    '../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js',
-    '../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/analytics/analytics.js',
+    '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_pii.js',
+    '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_googleAnalyticsUniversalTracker.js',
+    '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_govukAnalytics.js',
     '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_register.js',
     '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_trackExternalLinks.js',
     '../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/analytics/_events.js',
@@ -15,7 +16,8 @@ var manifest = {
     '../../../app/assets/javascripts/analytics/_init.js'
   ],
   test : [
-    '../unit/AnalyticsSpec.js'
+    '../unit/AnalyticsSpec.js',
+    '../unit/piiSpec.js',
   ]
 };
 

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -60,21 +60,21 @@ describe("GOVUK.Analytics", function () {
     });
 
     it('configures a universal tracker', function() {
-      expect(universalSetupArguments[0]).toEqual(['create', 'UA-49258698-1', {
+      expect(universalSetupArguments).toContain(['create', 'UA-49258698-1', {
         'cookieDomain': document.domain
       }]);
-      expect(universalSetupArguments[9]).toEqual(['send', 'pageview']);
+      expect(universalSetupArguments).toContain(['send', 'pageview']);
     });
     it('configures a cross domain tracker', function() {
-      expect(universalSetupArguments[2]).toEqual(['create', 'UA-145652997-1', 'auto', {
+      expect(universalSetupArguments).toContain(['create', 'UA-145652997-1', 'auto', {
         'name': 'govuk_shared'
       }]);
-      expect(universalSetupArguments[3]).toEqual(['require', 'linker']);
-      expect(universalSetupArguments[4]).toEqual(['govuk_shared.require', 'linker']);
-      expect(universalSetupArguments[5]).toEqual(['linker:autoLink', [ 'www.gov.uk' ]]);
-      expect(universalSetupArguments[6]).toEqual(['govuk_shared.linker:autoLink', [ 'www.gov.uk' ]]);
-      expect(universalSetupArguments[7]).toEqual(['govuk_shared.set', 'anonymizeIp', true ]);
-      expect(universalSetupArguments[8]).toEqual(['govuk_shared.send', 'pageview']);
+      expect(universalSetupArguments).toContain(['require', 'linker']);
+      expect(universalSetupArguments).toContain(['govuk_shared.require', 'linker']);
+      expect(universalSetupArguments).toContain(['linker:autoLink', [ 'www.gov.uk' ]]);
+      expect(universalSetupArguments).toContain(['govuk_shared.linker:autoLink', [ 'www.gov.uk' ]]);
+      expect(universalSetupArguments).toContain(['govuk_shared.set', 'anonymizeIp', true ]);
+      expect(universalSetupArguments).toContain(['govuk_shared.send', 'pageview']);
     });
   });
 
@@ -97,7 +97,7 @@ describe("GOVUK.Analytics", function () {
       mockLink.appendChild(document.createTextNode('Download supplier responses to ‘Brief 1’'));
       mockLink.href = assetHost + '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-outcomes/1/responses/download';
       GOVUK.GDM.analytics.buyerSpecificEvents.supplierListDownload({ 'target': mockLink });
-      expect(window.ga.calls.first().args).toEqual(['send', {
+      expect(window.ga.calls.allArgs()).toContain(['send', {
         'hitType': 'event',
         'eventCategory': 'download',
         'eventAction': 'csv',
@@ -116,7 +116,7 @@ describe("GOVUK.Analytics", function () {
       mockLink.appendChild(document.createTextNode('Download supplier responses to ‘Brief 1’'));
       mockLink.href = assetHost + '/buyers/frameworks/digital-outcomes-and-specialists/requirements/digital-specialists/1/responses/download';
       GOVUK.GDM.analytics.buyerSpecificEvents.supplierListDownload({ 'target': mockLink });
-      expect(window.ga.calls.first().args).toEqual(['send', {
+      expect(window.ga.calls.allArgs()).toContain(['send', {
         'hitType': 'event',
         'eventCategory': 'download',
         'eventAction': 'csv',
@@ -129,7 +129,7 @@ describe("GOVUK.Analytics", function () {
       $(document.body).append('<a id="opportunity-data" data-analytics="trackEvent" data-analytics-category="opportunity-data-csv" data-analytics-action="download CSV" data-analytics-label="Opportunity Data CSV" href="https://assets.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists-2/communications/data/opportunity-data.csv">Download data</a>');
       GOVUK.GDM.analytics.events.init();
       $('#opportunity-data').click();
-      expect(window.ga.calls.first().args).toEqual(['send', {
+      expect(window.ga.calls.allArgs()).toContain(['send', {
         'hitType': 'event',
         'eventCategory': "opportunity-data-csv",
         'eventAction': "download CSV",
@@ -147,7 +147,7 @@ describe("GOVUK.Analytics", function () {
       mockLink.appendChild(document.createTextNode('List of labs'));
       mockLink.href = assetHost + '/digital-outcomes-and-specialists/communications/catalogues/user-research-studios.csv';
       GOVUK.GDM.analytics.buyerSpecificEvents.supplierListDownload({ 'target': mockLink });
-      expect(window.ga.calls.first().args).toEqual(['send', {
+      expect(window.ga.calls.allArgs()).toContain(['send', {
         'hitType': 'event',
         'eventCategory': 'download',
         'eventAction': 'csv',
@@ -164,7 +164,7 @@ describe("GOVUK.Analytics", function () {
       mockLink.appendChild(document.createTextNode('Download list of suppliers.'));
       mockLink.href = assetHost + '/digital-outcomes-and-specialists/communications/catalogues/user-research-participants-suppliers.csv';
       GOVUK.GDM.analytics.buyerSpecificEvents.supplierListDownload({ 'target': mockLink });
-      expect(window.ga.calls.first().args).toEqual(['send', {
+      expect(window.ga.calls.allArgs()).toContain(['send', {
         'hitType': 'event',
         'eventCategory': 'download',
         'eventAction': 'csv',
@@ -181,7 +181,7 @@ describe("GOVUK.Analytics", function () {
       mockLink.appendChild(document.createTextNode('Download list of suppliers.'));
       mockLink.href = assetHost + '/digital-outcomes-and-specialists/communications/catalogues/digital-specialists-suppliers.csv';
       GOVUK.GDM.analytics.buyerSpecificEvents.supplierListDownload({ 'target': mockLink });
-      expect(window.ga.calls.first().args).toEqual(['send', {
+      expect(window.ga.calls.allArgs()).toContain(['send', {
         'hitType': 'event',
         'eventCategory': 'download',
         'eventAction': 'csv',
@@ -198,7 +198,7 @@ describe("GOVUK.Analytics", function () {
       mockLink.appendChild(document.createTextNode('Download list of suppliers.'));
       mockLink.href = assetHost + '/digital-outcomes-and-specialists/communications/catalogues/digital-outcomes-suppliers.csv';
       GOVUK.GDM.analytics.buyerSpecificEvents.supplierListDownload({ 'target': mockLink });
-      expect(window.ga.calls.first().args).toEqual(['send', {
+      expect(window.ga.calls.allArgs()).toContain(['send', {
         'hitType': 'event',
         'eventCategory': 'download',
         'eventAction': 'csv',
@@ -239,8 +239,7 @@ describe("GOVUK.Analytics", function () {
       $analyticsString = $("<div data-analytics='trackPageView' data-url='http://example.com'/>");
       $(document.body).append($analyticsString);
       window.GOVUK.GDM.analytics.virtualPageViews.init();
-      expect(window.ga.calls.first().args).toEqual([ 'send', 'pageview', { page: 'http://example.com/vpv' } ]);
-      expect(window.ga.calls.count()).toEqual(1);
+      expect(window.ga.calls.allArgs()).toContain([ 'send', 'pageview', { page: 'http://example.com/vpv' } ]);
     });
 
 
@@ -248,14 +247,14 @@ describe("GOVUK.Analytics", function () {
       $analyticsString = $('<div data-analytics="trackPageView" data-url="http:/testing.co.uk/testrubbs?sweet"/>');
       $(document.body).append($analyticsString);
       window.GOVUK.GDM.analytics.virtualPageViews.init();
-      expect(window.ga.calls.first().args[2]).toEqual({page: "http:/testing.co.uk/testrubbs/vpv?sweet"});
+      expect(window.ga.calls.allArgs()).toContain([ 'send', 'pageview', {page: "http:/testing.co.uk/testrubbs/vpv?sweet"} ]);
     });
 
     it("Should add '/vpv/' to url at the end if no question mark", function () {
       $analyticsString = $("<div data-analytics='trackPageView' data-url='http://example.com'/>");
       $(document.body).append($analyticsString);
       window.GOVUK.GDM.analytics.virtualPageViews.init();
-      expect(window.ga.calls.first().args[2]).toEqual({page: "http://example.com/vpv"});
+      expect(window.ga.calls.allArgs()).toContain([ 'send', 'pageview', {page: "http://example.com/vpv"} ]);
     });
 
     it("Should trigger virtual page view on filter selection", function () {
@@ -263,10 +262,10 @@ describe("GOVUK.Analytics", function () {
       $(document.body).append($analyticsString);
       window.GOVUK.GDM.analytics.virtualPageViews.init();
       $('#filter-option-1').click();
-      expect(window.ga.calls.first().args[2]).toEqual({
+      expect(window.ga.calls.allArgs()).toContain([ 'send', 'pageview', {
         page: "/g-cloud/test-lot/filters/example-filters-group/filter-option-1/filter-option-1-value/vpv", 
         title: "Filter - g-cloud - test-lot - example-filters-group - filter-option-1 - filter-option-1-value"
-      });
+      }]);
     });
 
     it("Should not trigger virtual page view if a user is removing a filter", function () {
@@ -305,70 +304,70 @@ describe("GOVUK.Analytics", function () {
     it('should send the number of results as a custom dimension', function() {
       window.GOVUK.GDM.analytics.pageViews.init();
 
-      expect(window.ga.calls.first().args).toEqual(['set', 'dimension21', '32']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension21', '32']);
     });
 
     it('should send the category filters as a custom dimension if only one', function() {
       setupQueryString('?lot=digital-outcomes');
 
-      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension23', 'digital-outcomes']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension23', 'digital-outcomes']);
     });
 
     it('should send the category filters as a custom dimension if multiple', function() {
       setupQueryString('?lot=digital-outcomes&lot=digital-specialists');
 
-      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension23', 'digital-outcomes|digital-specialists']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension23', 'digital-outcomes|digital-specialists']);
     });
 
     it('should send the category filters as a custom dimension if multiple and in wrong order', function() {
       setupQueryString('?lot=digital-specialists&lot=digital-outcomes');
 
-      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension23', 'digital-outcomes|digital-specialists']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension23', 'digital-outcomes|digital-specialists']);
     });
 
     it('should send the status filters as a custom dimension if only one', function() {
       setupQueryString('?status=closed');
 
-      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension24', 'closed']);
     });
 
     it('should send the status filters as a custom dimension if multiple', function() {
       setupQueryString('?status=closed&status=live');
 
-      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed|live']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension24', 'closed|live']);
     });
 
     it('should send the status filters as a custom dimension if multiple and in wrong order', function() {
       setupQueryString('?status=live&status=closed');
 
-      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed|live']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension24', 'closed|live']);
     });
 
     it('should send the filter groups as a custom dimension if one', function() {
       setupQueryString('?status=closed');
 
-      expect(window.ga.calls.all()[2].args).toEqual(['set', 'dimension22', 'status']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension22', 'status']);
     });
 
     it('should send the filter groups as a custom dimension if multiple', function() {
       setupQueryString('?status=closed&lot=digital-specialists');
 
-      expect(window.ga.calls.all()[3].args).toEqual(['set', 'dimension22', 'lot|status']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension22', 'lot|status']);
     });
 
     it('should send the filter groups as a custom dimension if multiple and wrong order', function() {
       setupQueryString('?lot=digital-specialists&status=closed');
 
-      expect(window.ga.calls.all()[3].args).toEqual(['set', 'dimension22', 'lot|status']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension22', 'lot|status']);
     });
 
     it('should send the correct custom dimension if all filters are used', function() {
       setupQueryString('?lot=digital-specialists&status=closed&lot=digital-outcomes&status=live&lot=user-research-participants');
 
-      expect(window.ga.calls.first().args).toEqual(['set', 'dimension21', '32']);
-      expect(window.ga.calls.all()[1].args).toEqual(['set', 'dimension24', 'closed|live']);
-      expect(window.ga.calls.all()[2].args).toEqual(['set', 'dimension23', 'digital-outcomes|digital-specialists|user-research-participants']);
-      expect(window.ga.calls.all()[3].args).toEqual(['set', 'dimension22', 'lot|status']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension21', '32']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension24', 'closed|live']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension23', 'digital-outcomes|digital-specialists|user-research-participants']);
+      expect(window.ga.calls.allArgs()).toContain(['set', 'dimension22', 'lot|status']);
     });
 
   });

--- a/spec/javascripts/unit/AnalyticsSpec.js
+++ b/spec/javascripts/unit/AnalyticsSpec.js
@@ -63,6 +63,18 @@ describe("GOVUK.Analytics", function () {
       expect(universalSetupArguments[0]).toEqual(['create', 'UA-49258698-1', {
         'cookieDomain': document.domain
       }]);
+      expect(universalSetupArguments[9]).toEqual(['send', 'pageview']);
+    });
+    it('configures a cross domain tracker', function() {
+      expect(universalSetupArguments[2]).toEqual(['create', 'UA-145652997-1', 'auto', {
+        'name': 'govuk_shared'
+      }]);
+      expect(universalSetupArguments[3]).toEqual(['require', 'linker']);
+      expect(universalSetupArguments[4]).toEqual(['govuk_shared.require', 'linker']);
+      expect(universalSetupArguments[5]).toEqual(['linker:autoLink', [ 'www.gov.uk' ]]);
+      expect(universalSetupArguments[6]).toEqual(['govuk_shared.linker:autoLink', [ 'www.gov.uk' ]]);
+      expect(universalSetupArguments[7]).toEqual(['govuk_shared.set', 'anonymizeIp', true ]);
+      expect(universalSetupArguments[8]).toEqual(['govuk_shared.send', 'pageview']);
     });
   });
 

--- a/spec/javascripts/unit/piiSpec.js
+++ b/spec/javascripts/unit/piiSpec.js
@@ -1,0 +1,139 @@
+describe("GOVUK.PII", function() {
+  var pii
+
+  beforeEach(function() {
+    resetHead()
+    pii = new GOVUK.pii()
+  })
+
+  afterEach(function() {
+    resetHead()
+  });
+
+  describe('by default', function() {
+    it("strips email addresses, but not postcodes and dates from strings", function() {
+      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date")
+      expect(string).toEqual("this is [email] address, this is a sw1a 1aa postcode, this is a 2019-01-21 date")
+    })
+
+    it("strips email addresses but not dates and postcodes from objects", function() {
+      var obj = {
+        'email': 'this is an@email.com address',
+        'postcode': 'this is a sw1a 1aa postcode',
+        'date': 'this is a 2019-01-21 date'
+      }
+
+      var strippedObj = {
+        'email': 'this is [email] address',
+        'postcode': 'this is a sw1a 1aa postcode',
+        'date': 'this is a 2019-01-21 date'
+      }
+
+      obj = pii.stripPII(obj)
+      expect(obj).toEqual(strippedObj)
+    })
+
+    it("strips email addresses but not dates and postcodes from arrays", function() {
+      var arr = [
+        'this is an@email.com address',
+        'this is a sw1a 1aa postcode',
+        'this is a 2019-01-21 date'
+      ]
+
+      var strippedArr = [
+        'this is [email] address',
+        'this is a sw1a 1aa postcode',
+        'this is a 2019-01-21 date'
+      ]
+
+      arr = pii.stripPII(arr)
+      expect(arr).toEqual(strippedArr)
+    })
+  })
+
+  describe('when configured to remove all PII', function() {
+    beforeEach(function() {
+      pageWantsDatesStripped()
+      pageWantsPostcodesStripped()
+      pii = new GOVUK.pii()
+    })
+
+    it("strips email addresses, postcodes and dates from strings", function() {
+      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date")
+      expect(string).toEqual("this is [email] address, this is a [postcode] postcode, this is a [date] date")
+    })
+
+    it("strips all PII from objects", function() {
+      var obj = {
+        'email': 'this is an@email.com address',
+        'postcode': 'this is a sw1a 1aa postcode',
+        'date': 'this is a 2019-01-21 date'
+      }
+
+      var strippedObj = {
+        'email': 'this is [email] address',
+        'postcode': 'this is a [postcode] postcode',
+        'date': 'this is a [date] date'
+      }
+
+      obj = pii.stripPII(obj)
+      expect(obj).toEqual(strippedObj)
+    })
+
+    it("strips all PII from arrays", function() {
+      var arr = [
+        'this is an@email.com address',
+        'this is a sw1a 1aa postcode',
+        'this is a 2019-01-21 date'
+      ]
+
+      var strippedArr = [
+        'this is [email] address',
+        'this is a [postcode] postcode',
+        'this is a [date] date'
+      ]
+
+      arr = pii.stripPII(arr)
+      expect(arr).toEqual(strippedArr)
+    })
+  })
+
+  describe('when there is a a govuk:static-analytics:strip-postcodes meta tag present', function() {
+    beforeEach(function() {
+      pageWantsPostcodesStripped()
+      pii = new GOVUK.pii()
+    });
+
+    it('observes the meta tag and strips out postcodes', function() {
+      expect(pii.stripPostcodePII).toEqual(true);
+      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date")
+      expect(string).toEqual("this is [email] address, this is a [postcode] postcode, this is a 2019-01-21 date")
+    });
+  });
+
+  describe('when there is a a govuk:static-analytics:strip-dates meta tag present', function() {
+    beforeEach(function() {
+      pageWantsDatesStripped()
+      pii = new GOVUK.pii()
+    });
+
+    it('observes the meta tag and strips out postcodes', function() {
+      expect(pii.stripDatePII).toEqual(true);
+      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date")
+      expect(string).toEqual("this is [email] address, this is a sw1a 1aa postcode, this is a [date] date")
+    });
+  });
+
+  function resetHead() {
+    $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove();
+    $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove();
+  }
+
+  function pageWantsDatesStripped() {
+    $('head').append('<meta name="govuk:static-analytics:strip-dates" value="does not matter" />');
+  }
+
+  function pageWantsPostcodesStripped() {
+    $('head').append('<meta name="govuk:static-analytics:strip-postcodes" value="does not matter" />');
+  }
+});


### PR DESCRIPTION
https://trello.com/c/XzgBSxIQ/1125-fwd-important-cross-domain-tracking-for-govuk-and-digital-market-place-service

Pulls in and tests changes to the new toolkit analytics files: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/480

The `piiSpec.js` tests are entirely cribbed from https://github.com/alphagov/static/blob/master/spec/javascripts/analytics/pii.spec.js. 
The main issue with our existing tests is that we can no longer rely on specific ordering of GA calls, so I've just used `window.ga.calls.allArgs()).toContain([ < some event info > ])`. The GOV.UK team also encountered this issue - see https://github.com/alphagov/static/pull/1856/files.

Tested locally: PII data is now stripped from both our original `ga("send", "pageview")` call as well as the linked beacon `ga("govuk_shared.send", "pageview")` call.