### PR TITLE
get_brief_by_id view: use with_data=False in find_brief_responses() call

### DIFF
--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -140,7 +140,8 @@ def get_brief_by_id(framework_family, brief_id):
 
     brief_responses = data_api_client.find_brief_responses(
         brief_id=brief_id,
-        status=",".join(ALL_BRIEF_RESPONSE_STATUSES)
+        status=",".join(ALL_BRIEF_RESPONSE_STATUSES),
+        with_data=False,
     ).get('briefResponses')
 
     winning_response, winning_supplier_size = None, None

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,4 +9,4 @@ lxml==4.4.1
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,18 +10,18 @@ lxml==4.4.1
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@48.5.0#egg=digitalmarketplace-utils==48.5.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@6.0.0#egg=digitalmarketplace-content-loader==6.0.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@20.2.0#egg=digitalmarketplace-apiclient==20.2.0
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.216
-botocore==1.12.216
-certifi==2019.6.16
+boto3==1.9.237
+botocore==1.12.237
+certifi==2019.9.11
 cffi==1.12.3
 chardet==3.0.4
 Click==7.0
-contextlib2==0.5.5
+contextlib2==0.6.0
 cryptography==2.3.1
 defusedxml==0.6.0
 docopt==0.6.2
@@ -52,7 +52,7 @@ requests==2.22.0
 s3transfer==0.2.1
 six==1.12.0
 unicodecsv==0.14.1
-urllib3==1.25.3
-Werkzeug==0.15.5
+urllib3==1.25.6
+Werkzeug==0.15.6
 workdays==1.4
 WTForms==2.2.1

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -431,6 +431,7 @@ class TestBriefPage(BaseBriefPageTest):
             mock.call.find_brief_responses(
                 brief_id=str(self.brief_id),
                 status='draft,submitted,pending-awarded,awarded',
+                with_data=False,
             ),
         ]
 


### PR DESCRIPTION
https://trello.com/c/2FBIg5LP

Also felt like I needed to add assertions to tests to ensure we actually check apiclient call arguments.