### PR TITLE
43-create-a-base-page-for-the-apps

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -1,0 +1,4 @@
+{% extends "toolkit/layouts/_base_page.html" %}
+
+// Insert line for each component module import
+

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -1,5 +1,5 @@
 
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}{{ brief.title }} - Digital Marketplace{% endblock %}
 

--- a/app/templates/choose-lot.html
+++ b/app/templates/choose-lot.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}G-Cloud - Digital Marketplace{% endblock %}
 

--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Cookies - Digital Marketplace{% endblock %}
 

--- a/app/templates/content/index-crown-hosting.html
+++ b/app/templates/content/index-crown-hosting.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Physical datacentre space - Digital Marketplace{% endblock %}
 

--- a/app/templates/content/privacy-notice.html
+++ b/app/templates/content/privacy-notice.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}How we use your data (privacy notice) - Digital Marketplace{% endblock %}
 

--- a/app/templates/content/terms-and-conditions.html
+++ b/app/templates/content/terms-and-conditions.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Terms and conditions - Digital Marketplace{% endblock %}
 

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Did you award a contract? - Digital Marketplace{% endblock %}
 

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Export your results - Digital Marketplace{% endblock %}
 

--- a/app/templates/direct-award/index.html
+++ b/app/templates/direct-award/index.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
 {% block page_title %}Your saved searches - Digital Marketplace{% endblock %}
 

--- a/app/templates/direct-award/results.html
+++ b/app/templates/direct-award/results.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Download your results - Digital Marketplace{% endblock %}
 

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% set page_name = "Save your search" %}
 

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Tell us about your contract - Digital Marketplace{% endblock %}
 

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% set page_title = project.name|default("Find cloud hosting, software and support") %}
 

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Which service won the contract? - Digital Marketplace{% endblock %}
 

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Why didn't you award a contract? - Digital Marketplace{% endblock %}
 

--- a/app/templates/help/index.html
+++ b/app/templates/help/index.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 {% block page_title %}Help and feedback - Digital Marketplace{% endblock %}
 
 {% block breadcrumb %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}Digital Marketplace{% endblock %}
 

--- a/app/templates/search/_search_layout.html
+++ b/app/templates/search/_search_layout.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block head %}
   <meta name="robots" content="noindex">

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -1,5 +1,5 @@
 
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}{{ service.title }} - Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}{{ supplier.name }} – Digital Marketplace{% endblock %}
 

--- a/app/templates/suppliers_list.html
+++ b/app/templates/suppliers_list.html
@@ -1,4 +1,4 @@
-{% extends "toolkit/layouts/_base_page.html" %}
+{% extends "_base_page.html" %}
 
 {% block page_title %}
   Suppliers starting with {{ prefix }} – {{ gcloud_framework_description|capitalize }} – Digital Marketplace


### PR DESCRIPTION
https://trello.com/c/PpFz5qRc/43-create-a-base-page-for-the-apps

The work to move to govuk-frontend will be easier if we have a base page in each app in which to import macros.

GOVUK Frontend may solve this down the road
https://github.com/alphagov/govuk-frontend/issues/1278

iIt seems from research (Googling and GOV Pay) for now this is the accepted pattern