### PR TITLE
Bump gulp-shell to address lodash vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "digital-marketplace-frontend",
+  "name": "digitalmarketplace-buyer-frontend",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -2829,61 +2829,14 @@
       }
     },
     "gulp-shell": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.2.9.tgz",
-      "integrity": "sha1-CgtT4BhCmlaR7G4iwyA1V+S4Orc=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.5.2.tgz",
+      "integrity": "sha1-pJWcoGUa0ce7/nCy0K27tOGuqY0=",
       "requires": {
-        "async": "~0.9.0",
-        "gulp-util": "~3.0.0",
-        "lodash": "~2.4.1",
-        "through2": "~0.5.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "through2": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-          "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~3.0.0"
-          }
-        },
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-        }
+        "async": "^1.5.0",
+        "gulp-util": "^3.0.7",
+        "lodash": "^4.0.0",
+        "through2": "^2.0.0"
       }
     },
     "gulp-sourcemaps": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "digital-marketplace-frontend",
+  "name": "digitalmarketplace-buyer-frontend",
   "description": "Front end application for the Digital Marketplace",
   "version": "1.0.0",
   "private": true,
@@ -18,7 +18,7 @@
     "gulp-include": "2.3.1",
     "gulp-jasmine-phantom": "alphagov/gulp-jasmine-phantom#node-10-fs-unlink",
     "gulp-sass": "3.1.0",
-    "gulp-shell": "0.2.9",
+    "gulp-shell": "0.5.2",
     "gulp-sourcemaps": "1.5.2",
     "gulp-uglify": "1.5.1",
     "hogan.js": "3.0.2",


### PR DESCRIPTION
https://trello.com/c/aQbqH2uC/1196-vulnerability-fix-weekly-tracking

Bumping `gulp-shell` to address the `lodash` vulnerability as per the Snyk recommendation: https://app.snyk.io/vuln/SNYK-JS-LODASH-73638

Also renames the package.json to reflect Buyer FE's status as no longer being the sole FE app.