### PR TITLE
Upgrade Jquery to v3.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,14 +1172,14 @@
       "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.1.2"
     },
     "digitalmarketplace-frontend-toolkit": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#b0287c4eb54721b126fb56050705cde5bd940efc",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#cb02d571e916e6152bd98e37a6a6b12e5b2a8368",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.1.0",
       "requires": {
         "del": "^4.1.0",
         "govuk-elements-sass": "3.0.3",
         "govuk_frontend_toolkit": "5.0.3",
         "gulp": "4.0.0",
-        "gulp-jasmine-phantom": "3.0.0",
+        "gulp-jasmine-phantom": "github:alphagov/gulp-jasmine-phantom#node-10-fs-unlink",
         "jasmine-core": "3.4.0"
       },
       "dependencies": {
@@ -1195,19 +1195,6 @@
             "p-map": "^2.0.0",
             "pify": "^4.0.1",
             "rimraf": "^2.6.3"
-          }
-        },
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -1265,96 +1252,6 @@
                 "yargs": "^7.1.0"
               }
             }
-          }
-        },
-        "gulp-jasmine-phantom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/gulp-jasmine-phantom/-/gulp-jasmine-phantom-3.0.0.tgz",
-          "integrity": "sha1-jgsrsi5x1AVqIumoGyFmGRhiU5Y=",
-          "requires": {
-            "glob": "^4.0.6",
-            "gulp-util": "^3.0.0",
-            "handlebars": "^2.0.0",
-            "jasmine": "github:dflynn15/jasmine-npm",
-            "lodash": "^4.3.0",
-            "through2": "^0.6.1"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "4.5.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-              "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^2.0.1",
-                "once": "^1.3.0"
-              }
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-              "requires": {
-                "brace-expansion": "^1.0.0"
-              }
-            }
-          }
-        },
-        "is-path-cwd": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-          "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
-        },
-        "is-path-in-cwd": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-          "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-          "requires": {
-            "is-path-inside": "^2.1.0"
-          }
-        },
-        "is-path-inside": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-          "requires": {
-            "path-is-inside": "^1.0.2"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -4100,6 +3997,24 @@
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
       "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
     },
+    "is-path-in-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+      "requires": {
+        "is-path-inside": "^2.1.0"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+          "requires": {
+            "path-is-inside": "^1.0.2"
+          }
+        }
+      }
+    },
     "is-path-inside": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
@@ -4192,49 +4107,15 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "jasmine": {
-      "version": "github:dflynn15/jasmine-npm#5f74e4336b247e67bbc509a8f82f3c4fa6b52964",
-      "from": "github:dflynn15/jasmine-npm",
-      "requires": {
-        "exit": "^0.1.2",
-        "glob": "^3.2.11",
-        "jasmine-core": "~2.4.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
-          }
-        },
-        "jasmine-core": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz",
-          "integrity": "sha1-b4OrOg8WlRcizgfSBsdz1XzIOL4="
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
-      }
-    },
     "jasmine-core": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.4.0.tgz",
       "integrity": "sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg=="
     },
     "jquery": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.0.tgz",
-      "integrity": "sha1-RGU75OPkYosQa/IUHf0Q+8pgIe8="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "js-base64": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v16.1.2",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.0.1",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v35.1.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "govuk_template": "https://github.com/alphagov/govuk_template/releases/download/v0.19.2/jinja_govuk_template-0.19.2.tgz",
@@ -22,7 +22,7 @@
     "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify": "^3.0.2",
     "hogan.js": "3.0.2",
-    "jquery": "1.12.0",
+    "jquery": "3.4.1",
     "scrolldepth": "https://github.com/alphagov/jquery-scrolldepth.git#1.0"
   },
   "scripts": {


### PR DESCRIPTION
https://trello.com/c/aQbqH2uC/1196-vulnerability-fix-weekly-tracking

Bumps Jquery to v3.x. Includes some breaking changes to the live search AJAX code, which is kept in the FE toolkit: https://github.com/alphagov/digitalmarketplace-frontend-toolkit/pull/485