### PR TITLE
help page: add information about the Public Procurement Review Service

### DIFF
--- a/app/templates/help/index.html
+++ b/app/templates/help/index.html
@@ -51,6 +51,10 @@
           </ul>
         </div>
 
+        <h2 class="heading-xmedium">Report a late payment, an opportunity or a procurement</h2>
+
+        <p>Email <a href="mailto:publicprocurementreview@cabinetoffice.gov.uk">publicprocurementreview@cabinetoffice.gov.uk</a> if a buyer isn’t following the correct processes, the rules of the framework, or hasn’t paid you.</p>
+
         <h2 class="heading-xmedium">Feedback about the Digital Marketplace</h2>
 
         <p>Email <a href="mailto:cloud_digital@crowncommercial.gov.uk">cloud_digital@crowncommercial.gov.uk</a> if you have feedback about your experience using the Digital Marketplace.</p>


### PR DESCRIPTION
https://trello.com/c/xey48L9F

@pocketstefan what do you think about the positioning of this paragraph? Stuck it second to last...

Also I noticed that all the other paragraphs use the form "Email abc@example.com if..." - do you think we should try and fit in with that somehow? Should I make the email address visible instead of just a blind `mailto:` link?

![image](https://user-images.githubusercontent.com/807447/68302863-b7fd0f00-009a-11ea-9475-9498968ce46d.png)