### PR TITLE
switch missed use of old button toolkit template to digitalmarketplace-govuk-frontend

### DIFF
--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -141,13 +141,9 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <form action="{{ url_for('external.start_brief_response', brief_id=brief.id) }}" method="get">
-        {%
-          with
-          label="Apply for this opportunity",
-          type="save"
-        %}
-          {% include "toolkit/button.html" %}
-        {% endwith %}
+        {{ govukButton({
+          "text": "Apply for this opportunity",
+        }) }}
       </form>
     </div>
   </div>

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -138,6 +138,7 @@
     </div>
   </div>
 {% elif brief.status == 'live' %}
+  <br/><!-- <- remove once grid and body elements have been converted to govuk frontend -->
   <div class="grid-row">
     <div class="column-two-thirds">
       <form action="{{ url_for('external.start_brief_response', brief_id=brief.id) }}" method="get">

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -687,10 +687,10 @@ class TestBriefPage(BaseBriefPageTest):
         assert 'Quality assurance analyst' in res.get_data(as_text=True)
 
     def _assert_start_application(self, document, brief_id):
-        assert document.xpath("//form[@method='get']/@action") == [
-            "/suppliers/opportunities/{}/responses/start".format(brief_id)
-        ]
-        assert document.xpath("//input[@class='button-save']/@value") == ['Apply for this opportunity']
+        assert document.xpath(
+            "//form[@method='get'][normalize-space(string(.//button))=$t]/@action",
+            t="Apply for this opportunity",
+        ) == ["/suppliers/opportunities/{}/responses/start".format(brief_id)]
 
     def _assert_view_application(self, document, brief_id):
         assert len(document.xpath(


### PR DESCRIPTION
https://trello.com/c/reSSXWv8

Missed one. This one doesn't produce _wonderful_ layout when switched, but I'm certain this will get fixed when the content above it gets converted...

![2019-11-08T10:15:01 880172Zc](https://user-images.githubusercontent.com/807447/68473304-86ab4d00-021a-11ea-99d0-077fefca574d.png)
