### PR TITLE
replace page_title block with pageTitle

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -3,3 +3,6 @@
 // Insert line for each component module import
 
 {% from "components/button/macro.njk" import govukButton %}
+
+{# TODO: Remove once we start removing govuk_template, GOV.UK Frontend template uses pageTitle #}
+{% block page_title %}{% block pageTitle %}{% endblock %}{% endblock %}

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -1,7 +1,9 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{ brief.title }} - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ brief.title }} - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/choose-lot.html
+++ b/app/templates/choose-lot.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}G-Cloud - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  G-Cloud - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Cookies - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Cookies - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -116,7 +118,7 @@
         </table>
 
         <h3>User research recruitment banner cookie</h3>
-        
+
         <p>
             When you use our service, you may see a pop up banner about user research recruitment. Once you&rsquo;ve interacted with the message (by visiting or clicking on any of the links), we
             store a cookie on your computer so it knows not to show it again.

--- a/app/templates/content/index-crown-hosting.html
+++ b/app/templates/content/index-crown-hosting.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Physical datacentre space - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Physical datacentre space - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -49,7 +51,7 @@
         </p>
         <ul class='service-summary-features-and-benefits'>
           <li>
-            mission-critical datacentres 
+            mission-critical datacentres
           </li>
           <li>
             a secure environment for transition to the cloud

--- a/app/templates/content/privacy-notice.html
+++ b/app/templates/content/privacy-notice.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}How we use your data (privacy notice) - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  How we use your data (privacy notice) - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -20,7 +22,7 @@
   <div class="help-page grid-row legal-content">
     <div class="column-two-thirds">
 
-      
+
       <header class="page-heading">
         <h1>How we use your data (privacy notice)</h1>
       </header>
@@ -39,7 +41,7 @@
           <li>email addresses, phone number and address</li>
           <li>company name and contact information (suppliers only)</li>
         </ul>
-        <p>We use this data when you create a user account to buy or sell digital services.</p> 
+        <p>We use this data when you create a user account to buy or sell digital services.</p>
       </div>
 
       <h3>Your email address and contact details</h3>
@@ -62,29 +64,29 @@
         </ul>
       </div>
       <p>You will always be told if the personal data you provide is going to be displayed on the Digital Marketplace.</p>
- 
+
       <h3>Information about criminal convictions and company directors</h3>
       <div class="check-list">
       <p>We’ll ask you if you have any criminal convictions.</p>
-      
+
          <p class="lead">If you’re a supplier applying to join a framework we’ll also ask if your company director has been:</p>
         <ul class="list-bullet">
           <li>convicted of bribery</li>
           <li>declared bankrupt within the last 5 years</li>
         </ul>
       </div>
-    
+
     <p>We use this information to help make a decision about your application.</p>
-    
+
     <p>The legal basis for processing this data is because it is ‘necessary for reasons of substantial public interest for the exercise of a function of a government department’ (<a href="https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/" rel="external">Article 6 of The General Data Protection Regulation (GDPR)</a>). This means we’re legally allowed to process this data because it’s in the public interest that government checks this information about suppliers.</p>
-      
+
       <h3>Cookies and analytics</h3>
       <p>You can read our <a href="{{ url_for('.cookies') }}">full cookie policy</a> to find out how we use cookies to track user journeys using Google Analytics.</p>
       <div class="dmspeak">
         <h2 class="heading-xmedium">What we do with your data</h2>
       </div>
       <div class="check-list">
-        <p class="lead">Digital Marketplace staff have access to the data they need to manage the live services or frameworks, and make sure spend data is collected correctly.</p> 
+        <p class="lead">Digital Marketplace staff have access to the data they need to manage the live services or frameworks, and make sure spend data is collected correctly.</p>
         <p>We will not:</p>
         <ul class="list-bullet">
           <li>sell or rent your data to third parties</li>
@@ -94,7 +96,7 @@
       <p>We will share your data if we’re required to do so by law – for example, by court order, or to prevent fraud or other crime.</p>
 <p>We’ll also share your data with our IT suppliers who provide notification and mailing list management services.</p>
     <h3>Giving feedback about the Digital Marketplace</h3>
-    
+
     <p>You may be asked to provide feedback or take part in research about the Digital Marketplace. We use this data to improve our systems.</p>
 <p>The legal basis for processing this data is because you give your consent.</p>
 
@@ -120,7 +122,7 @@
       <p>We set up systems and processes to prevent unauthorised access to or disclosure of the data we collect about you – for example, we protect your data using varying levels of encryption.</p>
       <p>All third parties that process personal data for Cabinet Office are required to keep that data secure.</p>
 
-      
+
       <div class="dmspeak">
         <h2 class="heading-xmedium">Children’s privacy protection</h2>
       </div>
@@ -159,12 +161,12 @@
 
       <h3>Email</h3>
       <p><a href="mailto:gds-privacy-office@digital.cabinet-office.gov.uk">gds-privacy-office@digital.cabinet-office.gov.uk</a></p>
-    
+
     <p>You can also contact The Data Protection Officer (DPO) if you have any concerns about how your personal data has been handled. The DPO gives advice and monitors Cabinet Office’s use of personal information.</p>
-    
+
       <h3>Email</h3>
     <p><a href="mailto:dpo@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a></p>
-        
+
      <h3>Post</h3>
       <ul>
         <li>Data Protection Officer</li>

--- a/app/templates/content/terms-and-conditions.html
+++ b/app/templates/content/terms-and-conditions.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Terms and conditions - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Terms and conditions - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Did you award a contract? - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Did you award a contract? - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Export your results - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Export your results - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/direct-award/index.html
+++ b/app/templates/direct-award/index.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 {% import "toolkit/summary-table.html" as summary %}
-{% block page_title %}Your saved searches - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Your saved searches - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -60,7 +62,7 @@
       {% call summary.row() %}
         {{ summary.service_link(item.name, url_for('direct_award.view_project', framework_family=framework.family, project_id=item.id), wide=False) }}
         {{ summary.text(item.lockedAt | datetimeformat ) }}
-        {{ 
+        {{
           summary.text("Awarded") if item.outcome and item.outcome.result == "awarded"
           else summary.text("The work has been cancelled") if item.outcome and item.outcome.result == "cancelled"
           else summary.text("No suitable services found") if item.outcome and item.outcome.result == "none-suitable"
@@ -68,7 +70,7 @@
           else summary.service_link("Tell us the outcome", url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=item.id), wide=False) }}
       {% endcall %}
     {% endcall %}
-    
+
   </div>
 
 </div>

--- a/app/templates/direct-award/results.html
+++ b/app/templates/direct-award/results.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Download your results - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Download your results - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -2,7 +2,9 @@
 
 {% set page_name = "Save your search" %}
 
-{% block page_title %}{{ page_name }} - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ page_name }} - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Tell us about your contract - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Tell us about your contract - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -2,7 +2,9 @@
 
 {% set page_title = project.name|default("Find cloud hosting, software and support") %}
 
-{% block page_title %}{{ page_title }} - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ page_title }} - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Which service won the contract? - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Which service won the contract? - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%
@@ -39,7 +41,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
-    
+
       {% with heading = 'Which service won the contract?' %}
         {% include 'toolkit/page-heading.html' %}
       {% endwith %}

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Why didn't you award a contract? - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Why didn't you award a contract? - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/help/index.html
+++ b/app/templates/help/index.html
@@ -1,5 +1,8 @@
 {% extends "_base_page.html" %}
-{% block page_title %}Help and feedback - Digital Marketplace{% endblock %}
+
+{% block pageTitle %}
+  Help and feedback - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Digital Marketplace
+{% endblock %}
 
 {% block top_header %}
 <header class="marketplace-homepage-heading">

--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -1,6 +1,6 @@
 {% extends "search/_search_layout.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Supplier opportunities – {{ framework_family_name }} – Digital Marketplace
 {% endblock %}
 

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -1,6 +1,8 @@
 {% extends "search/_search_layout.html" %}
 
-{% block page_title %}Search - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  Search - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {% with %}

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -1,7 +1,9 @@
 
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{ service.title }} - Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ service.title }} - Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -1,6 +1,8 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}{{ supplier.name }} – Digital Marketplace{% endblock %}
+{% block pageTitle %}
+  {{ supplier.name }} – Digital Marketplace
+{% endblock %}
 
 {% block breadcrumb %}
   {%

--- a/app/templates/suppliers_list.html
+++ b/app/templates/suppliers_list.html
@@ -1,6 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}
+{% block pageTitle %}
   Suppliers starting with {{ prefix }} – {{ gcloud_framework_description|capitalize }} – Digital Marketplace
 {% endblock %}
 


### PR DESCRIPTION
As part of migrating us off govuk_template and on to govuk frontend template
we need to be mindful of what blocks govuk frontend used. govuk frontend
template uses pageTitle so instead of adding this commit to that work it
can be done as a separate commit and then once we come to replace govuk_template
we can just remove the two lines of code in `_base_page` which we added
in this commit.

Ticket: https://trello.com/c/d3sJhHq8