### PR TITLE
Include mandatory assessment methods in brief section description

### DIFF
--- a/app/main/helpers/brief_helpers.py
+++ b/app/main/helpers/brief_helpers.py
@@ -28,3 +28,28 @@ def format_winning_supplier_size(size):
         return "SME"
     elif size in LARGE:
         return "large"
+
+
+def show_mandatory_assessment_method(brief, current_app):
+    # To ensure suppliers see the same info while a brief is live, only show for closed briefs or
+    # briefs published after the feature flag date.
+    if brief['status'] != 'live':
+        return True
+    if current_app.config['SHOW_BRIEF_MANDATORY_EVALUATION_METHOD']:
+        if brief['publishedAt'] >= current_app.config['SHOW_BRIEF_MANDATORY_EVALUATION_METHOD']:
+            return True
+    return False
+
+
+# TODO: split the manifest sections and add the relevant description for each DOS5 lot instead
+def get_evaluation_description(brief, current_app, brief_content):
+    # Add in mandatory evaluation method, missing from the display_brief manifest summary_page_description
+    #   Digital Specialists: work history
+    #   Digital Outcomes / User Research Participants: written proposal
+    if show_mandatory_assessment_method(brief, current_app):
+        for section in brief_content.summary(brief):
+            if section.name == 'How suppliers will be evaluated':
+                if brief['lotSlug'] == 'digital-specialists':
+                    return 'All suppliers will be asked to provide a work history.'
+                return 'All suppliers will be asked to provide a written proposal.'
+    return None

--- a/app/main/helpers/brief_helpers.py
+++ b/app/main/helpers/brief_helpers.py
@@ -31,8 +31,11 @@ def format_winning_supplier_size(size):
 
 
 def show_mandatory_assessment_method(brief, current_app):
+    # For DOS4 briefs only.
     # To ensure suppliers see the same info while a brief is live, only show for closed briefs or
     # briefs published after the feature flag date.
+    if brief['frameworkSlug'] != 'digital-outcomes-and-specialists-4':
+        return False
     if brief['status'] != 'live':
         return True
     if current_app.config['SHOW_BRIEF_MANDATORY_EVALUATION_METHOD']:
@@ -43,7 +46,7 @@ def show_mandatory_assessment_method(brief, current_app):
 
 # TODO: split the manifest sections and add the relevant description for each DOS5 lot instead
 def get_evaluation_description(brief, current_app, brief_content):
-    # Add in mandatory evaluation method, missing from the display_brief manifest summary_page_description
+    # Add in mandatory evaluation method, missing from the DOS4 display_brief manifest summary_page_description
     #   Digital Specialists: work history
     #   Digital Outcomes / User Research Participants: written proposal
     if show_mandatory_assessment_method(brief, current_app):

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -171,6 +171,18 @@ def get_brief_by_id(framework_family, brief_id):
 
     brief_content = content_loader.get_manifest(brief['frameworkSlug'], 'display_brief').filter(brief)
 
+    # Add in mandatory evaluation method, missing from the display_brief manifest summary_page_description
+    # Digital Specialists: work history
+    # Digital Outcomes / User Research Participants: written proposal
+    # TODO: split the manifest sections and add the relevant description for each DOS5 lot
+    evaluation_description = None
+    for section in brief_content.summary(brief):
+        if section.name == 'How suppliers will be evaluated':
+            if brief['lotSlug'] == 'digital-specialists':
+                evaluation_description = 'All suppliers will be asked to provide a work history.'
+            else:
+                evaluation_description = 'All suppliers will be asked to provide a written proposal.'
+
     return render_template(
         'brief.html',
         brief=brief,
@@ -178,7 +190,8 @@ def get_brief_by_id(framework_family, brief_id):
         content=brief_content,
         has_supplier_responded_to_brief=has_supplier_responded_to_brief,
         winning_response=winning_response,
-        winning_supplier_size=winning_supplier_size
+        winning_supplier_size=winning_supplier_size,
+        evaluation_description=evaluation_description
     )
 
 

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -15,6 +15,7 @@ from dmutils.flask import timed_render_template as render_template
 from app import search_api_client, data_api_client, content_loader
 from ..helpers.brief_helpers import (
     count_brief_responses_by_size_and_status, format_winning_supplier_size,
+    get_evaluation_description,
     COMPLETED_BRIEF_RESPONSE_STATUSES, ALL_BRIEF_RESPONSE_STATUSES, PUBLISHED_BRIEF_STATUSES
 )
 from ..helpers.framework_helpers import (
@@ -172,16 +173,7 @@ def get_brief_by_id(framework_family, brief_id):
     brief_content = content_loader.get_manifest(brief['frameworkSlug'], 'display_brief').filter(brief)
 
     # Add in mandatory evaluation method, missing from the display_brief manifest summary_page_description
-    # Digital Specialists: work history
-    # Digital Outcomes / User Research Participants: written proposal
-    # TODO: split the manifest sections and add the relevant description for each DOS5 lot
-    evaluation_description = None
-    for section in brief_content.summary(brief):
-        if section.name == 'How suppliers will be evaluated':
-            if brief['lotSlug'] == 'digital-specialists':
-                evaluation_description = 'All suppliers will be asked to provide a work history.'
-            else:
-                evaluation_description = 'All suppliers will be asked to provide a written proposal.'
+    evaluation_description = get_evaluation_description(brief, current_app, brief_content)
 
     return render_template(
         'brief.html',

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -20,8 +20,11 @@
 {% for section in content.summary(brief) %}
     {{ summary.heading(section.name, id="opportunity-attributes-{}".format(loop.index)) }}
      {% if section.summary_page_description %}
-          {{ summary.description(section.summary_page_description) }}
-        {% endif %}
+        <p>{{ summary.description(section.summary_page_description) }}</p>
+     {# DISPLAY MANDATORY EVALUATION METHODS #}
+     {% elif section.name == 'How suppliers will be evaluated' and evaluation_description %}
+        <p>{{ evaluation_description }}</p>
+     {% endif %}
     {% call(item) summary.list_table(
       section.questions,
       caption=section.name,

--- a/config.py
+++ b/config.py
@@ -84,6 +84,9 @@ class Config(object):
 
     GOOGLE_SITE_VERIFICATION = None
 
+    # Feature flag - show for briefs published after this date
+    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = None
+
     @staticmethod
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
@@ -130,6 +133,9 @@ class Development(Config):
 
     GOOGLE_SITE_VERIFICATION = "NotARealVerificationKey"
 
+    # Feature flag - show for briefs published after this date
+    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = '2019-11-18'
+
 
 class Live(Config):
     """Base config for deployed environments"""
@@ -144,9 +150,15 @@ class Live(Config):
         "user.marketplace.team": "success@simulator.amazonses.com",
     }
 
+    # Feature flag - show for briefs published after this date
+    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = None
+
 
 class Preview(Live):
     DM_PATCH_FRONTEND_URL = 'https://www.preview.marketplace.team/'
+
+    # Feature flag - show for briefs published after this date
+    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = '2019-11-18'
 
 
 class Staging(Live):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -49,6 +49,10 @@ def get_frameworks_list_fixture_data():
             lots=dos_lots(), framework_agreement_version='v1.0', has_further_competition=True
         ).single_result_response(),
         FrameworkStub(
+            id=12, slug='digital-outcomes-and-specialists-4', status='live',
+            lots=dos_lots(), has_further_competition=True
+        ).single_result_response(),
+        FrameworkStub(
             id=5, slug='digital-outcomes-and-specialists', status='live',
             lots=dos_lots(), framework_agreement_version='v1.0', has_further_competition=True
         ).single_result_response(),

--- a/tests/main/helpers/test_brief_helpers.py
+++ b/tests/main/helpers/test_brief_helpers.py
@@ -31,14 +31,34 @@ class TestBriefHelpers(BaseApplicationTest):
     def test_show_mandatory_assessment_method_for_non_live_briefs(self, status):
         brief = {
             'status': status,
+            'frameworkSlug': 'digital-outcomes-and-specialists-4',
             'publishedAt': '2019-11-01'
         }
         current_app = mock.Mock()
         assert show_mandatory_assessment_method(brief, current_app)
 
+    @pytest.mark.parametrize(
+        'framework_slug',
+        [
+            'digital-outcomes-and-specialists',
+            'digital-outcomes-and-specialists-2',
+            'digital-outcomes-and-specialists-3',
+        ]
+    )
+    def test_do_not_show_mandatory_assessment_method_for_non_dos4_briefs(self, framework_slug):
+        brief = {
+            'status': 'live',
+            'frameworkSlug': framework_slug,
+            'publishedAt': '2019-11-02'
+        }
+        current_app = mock.Mock()
+        current_app.config = {'SHOW_BRIEF_MANDATORY_EVALUATION_METHOD': '2019-11-02'}
+        assert not show_mandatory_assessment_method(brief, current_app)
+
     def test_do_not_show_mandatory_assessment_method_for_live_briefs_before_date(self):
         brief = {
             'status': 'live',
+            'frameworkSlug': 'digital-outcomes-and-specialists-4',
             'publishedAt': '2019-11-01'
         }
         current_app = mock.Mock()
@@ -49,6 +69,7 @@ class TestBriefHelpers(BaseApplicationTest):
     def test_show_mandatory_assessment_method_for_live_briefs_on_or_after_date(self, date):
         brief = {
             'status': 'live',
+            'frameworkSlug': 'digital-outcomes-and-specialists-4',
             'publishedAt': date
         }
         current_app = mock.Mock()

--- a/tests/main/helpers/test_brief_helpers.py
+++ b/tests/main/helpers/test_brief_helpers.py
@@ -1,4 +1,10 @@
-from app.main.helpers.brief_helpers import count_brief_responses_by_size_and_status, format_winning_supplier_size
+import pytest
+import mock
+from app.main.helpers.brief_helpers import (
+    count_brief_responses_by_size_and_status,
+    format_winning_supplier_size,
+    show_mandatory_assessment_method
+)
 from ...helpers import BaseApplicationTest
 
 
@@ -20,3 +26,31 @@ class TestBriefHelpers(BaseApplicationTest):
         assert format_winning_supplier_size("small") == "SME"
         assert format_winning_supplier_size("medium") == "SME"
         assert format_winning_supplier_size("large") == "large"
+
+    @pytest.mark.parametrize('status', ['draft', 'closed', 'awarded', 'cancelled', 'unsuccessful'])
+    def test_show_mandatory_assessment_method_for_non_live_briefs(self, status):
+        brief = {
+            'status': status,
+            'publishedAt': '2019-11-01'
+        }
+        current_app = mock.Mock()
+        assert show_mandatory_assessment_method(brief, current_app)
+
+    def test_do_not_show_mandatory_assessment_method_for_live_briefs_before_date(self):
+        brief = {
+            'status': 'live',
+            'publishedAt': '2019-11-01'
+        }
+        current_app = mock.Mock()
+        current_app.config = {'SHOW_BRIEF_MANDATORY_EVALUATION_METHOD': '2019-11-02'}
+        assert not show_mandatory_assessment_method(brief, current_app)
+
+    @pytest.mark.parametrize('date', ['2019-11-02', '2019-11-03'])
+    def test_show_mandatory_assessment_method_for_live_briefs_on_or_after_date(self, date):
+        brief = {
+            'status': 'live',
+            'publishedAt': date
+        }
+        current_app = mock.Mock()
+        current_app.config = {'SHOW_BRIEF_MANDATORY_EVALUATION_METHOD': '2019-11-02'}
+        assert show_mandatory_assessment_method(brief, current_app)

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -616,9 +616,14 @@ class TestBriefPage(BaseBriefPageTest):
         brief = self.brief.copy()
         brief['briefs']['lot'] = lot_slug
         brief['briefs']['lotSlug'] = lot_slug
+        brief['briefs']['status'] = 'live'
+        brief['briefs']['publishedAt'] = '2019-01-02T00:00:00.000000Z'
         self.data_api_client.get_brief.return_value = brief
 
-        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief['briefs']['id']))
+        with self.app.app_context():
+            current_app.config['SHOW_BRIEF_MANDATORY_EVALUATION_METHOD'] = '2019-01-01'
+            res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief['briefs']['id']))
+
         assert res.status_code == 200
 
         document = html.fromstring(res.get_data(as_text=True))

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -618,6 +618,7 @@ class TestBriefPage(BaseBriefPageTest):
         brief['briefs']['lotSlug'] = lot_slug
         brief['briefs']['status'] = 'live'
         brief['briefs']['publishedAt'] = '2019-01-02T00:00:00.000000Z'
+        brief['briefs']['frameworkSlug'] = 'digital-outcomes-and-specialists-4'
         self.data_api_client.get_brief.return_value = brief
 
         with self.app.app_context():

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -605,6 +605,29 @@ class TestBriefPage(BaseBriefPageTest):
         assert contract_length_key[0] == 'Expected contract length'
         assert contract_length_value[0] == '4 weeks'
 
+    @pytest.mark.parametrize(
+        'lot_slug, assessment_type', [
+            ('digital-outcomes', 'written proposal'),
+            ('digital-specialists', 'work history'),
+            ('user-research-participants', 'written proposal'),
+        ]
+    )
+    def test_dos_brief_displays_mandatory_evaluation_method_for_lot(self, lot_slug, assessment_type):
+        brief = self.brief.copy()
+        brief['briefs']['lot'] = lot_slug
+        brief['briefs']['lotSlug'] = lot_slug
+        self.data_api_client.get_brief.return_value = brief
+
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief['briefs']['id']))
+        assert res.status_code == 200
+
+        document = html.fromstring(res.get_data(as_text=True))
+        section_heading = document.xpath(
+            '//h2[@class="summary-item-heading"][contains(text(), "How suppliers will be evaluated")]'
+        )[0]
+        section_description = section_heading.xpath('following-sibling::p')[0]
+        assert section_description.text.strip() == f'All suppliers will be asked to provide a {assessment_type}.'
+
     def test_dos_brief_has_questions_and_answers(self):
         brief_id = self.brief['briefs']['id']
         res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief_id))


### PR DESCRIPTION
https://trello.com/c/B3ncZNdh/1249-dos4-published-briefs-dont-show-mandatory-written-proposal-value-just-additional-assessement-methods

A change to the DOS4 assessment method section meant that the mandatory written proposal (for Digital Outcomes and User Research Participant lots) or work history (for Digital Specialist lots) was missing from the public brief page. 

The information is now added to the top of the Supplier Evaluation section, where the `summary_page_description` would be:

![written-proposal](https://user-images.githubusercontent.com/3492540/68962788-48d79700-07cd-11ea-8b5b-13fcdb0a49e4.png)
 
We need to deploy this carefully to ensure we are fair to suppliers, so I've added a `config` flag, where we can set the date once we're ready to deploy to production.  

How this works:
- Currently the `Live` flag is set to `None`, and the new info will not be shown for live briefs except on `Development` and `Preview` environments.
- Once the flag is set, any briefs published after this date can display the new information (as all suppliers will see the same info)
- Any non-live briefs can display the new information, regardless of date (as suppliers can't apply!)
- Two weeks after the deploy date, all briefs protected by the flag will have closed, and we can remove it from the config and code.
- Once this PR is approved I'll add a deploy date to the Staging/Production config so we can test before deploying. 

Unfortunately it's not straightforward to just add the text to the `summary_page_description` in the frameworks repo, as we'd need two versions for the different lots (which would be even more complicated to deploy in a fair way to suppliers). 

Mocking content loader objects can get quite annoying so I've avoided it here, but `brief_helpers.get_evaluation_description` should have enough coverage from the new tests in `TestBriefPage`.