### PR TITLE
Add feature flag date for assessment method fix

### DIFF
--- a/config.py
+++ b/config.py
@@ -164,11 +164,17 @@ class Preview(Live):
 class Staging(Live):
     DM_PATCH_FRONTEND_URL = 'https://www.staging.marketplace.team/'
 
+    # Feature flag - show for briefs published after this date
+    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = '2019-11-21'
+
 
 class Production(Live):
     DM_PATCH_FRONTEND_URL = 'https://www.digitalmarketplace.service.gov.uk/'
 
     GOOGLE_SITE_VERIFICATION = "TKGSGZnfHpx1-lKOthI17ANtwk7fz3F4Sbr77I0ppO0"
+
+    # Feature flag - show for briefs published after this date
+    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = '2019-11-21'
 
 
 configs = {


### PR DESCRIPTION
https://trello.com/c/B3ncZNdh/128-dos4-published-briefs-dont-show-mandatory-written-proposal-value-just-additional-assessement-methods

We're ready to release the bug fix today (20th Nov). Therefore the feature flag dates will be set to tomorrow (21st Nov):

 - any new briefs published from `2019-11-21T00:00:00.000000Z` onwards will show the additional line
- any closed briefs (including awarded, cancelled, etc) will show the additional line
- any live briefs published today (20th Nov) will not show the additional line

We will be able to remove the feature flag in production on 5th December, as by then all live briefs will be showing the additional line. I've created a reminder ticket to do this: https://trello.com/c/RrAfdgsv/137-remove-feature-flag-on-brief-mandatory-assessment-method-5th-dec