### PR TITLE
Add Python 3.7 and 3.8 checks to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 before_install:
   - nvm install
 install:

--- a/app/main/helpers/dm_google_analytics.py
+++ b/app/main/helpers/dm_google_analytics.py
@@ -23,12 +23,11 @@ def custom_dimension(custom_dimension_enum, value):
 
     Pass in the relevant enum from this module, and either an instance or an actual value from that enum.
     """
-
-    if value in CurrentProjectStageEnum:
-        custom_dimension_instance = value
-    else:
+    if isinstance(value, str):
         # If we've been given a string, try to convert it to an instance of the enum - if that fails then it'll be loud.
         custom_dimension_instance = custom_dimension_enum(value)
+    elif value in CurrentProjectStageEnum:
+        custom_dimension_instance = value
 
     return {
         "data_id": CUSTOM_DIMENSION_IDENTIFIERS[custom_dimension_enum],

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,7 +7,7 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 lxml==4.4.1
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.0#egg=digitalmarketplace-content-loader==7.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.0-alpha#egg=govuk-frontend-jinja==0.5.0-alpha

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,4 @@ pytest-cov==2.7.1
 python-dotenv==0.10.3  # used to load .flaskenv
 watchdog==0.9.0
 
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.1.2#egg=digitalmarketplace-test-utils==2.1.2
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,16 +8,16 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 lxml==4.4.1
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.0#egg=digitalmarketplace-content-loader==7.1.0
-git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.0#egg=digitalmarketplace-apiclient==21.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.0-alpha#egg=govuk-frontend-jinja==0.5.0-alpha
 
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.10.16
-botocore==1.13.16
+boto3==1.10.22
+botocore==1.13.22
 certifi==2019.9.11
 cffi==1.13.2
 chardet==3.0.4

--- a/tests/main/helpers/test_dm_google_analytics.py
+++ b/tests/main/helpers/test_dm_google_analytics.py
@@ -8,9 +8,21 @@ def test_custom_dimension_create_with_enum_instance():
     assert dimension_dict == {'data_id': 8, 'data_value': 'awarded'}
 
 
-def test_custom_dimension_create_with_string():
-    dimension_dict = custom_dimension(CurrentProjectStageEnum, 'awarded')
-    assert dimension_dict == {'data_id': 8, 'data_value': 'awarded'}
+@pytest.mark.parametrize(
+    'value',
+    [
+        'save_and_refine_search',
+        'search_ended',
+        'download_results',
+        'ready_to_assess',
+        'none-suitable',
+        'cancelled',
+        'awarded'
+    ]
+)
+def test_custom_dimension_create_with_string(value):
+    dimension_dict = custom_dimension(CurrentProjectStageEnum, value)
+    assert dimension_dict == {'data_id': 8, 'data_value': value}
 
 
 def test_custom_dimension_fail():


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

- Bumps content loader, utils, test utils and API client
- Adds 3.7 and 3.8 to Travis config (trying without specifying `xenial` first, as we didn't specify `trusty` in this repo...)