### PR TITLE
This replaces toolkit/page-headings with govuk frontend page titles

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -34,6 +34,7 @@ $path: "/static/images/";
 @import "toolkit/_grids.scss";
 @import "toolkit/_instruction-list.scss";
 @import "toolkit/_notification-banners.scss";
+@import "toolkit/_page-headings.scss";
 @import "toolkit/_phase-banner.scss";
 @import "toolkit/_proposition-header.scss";
 @import "toolkit/_secondary-action-link.scss";

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -34,7 +34,6 @@ $path: "/static/images/";
 @import "toolkit/_grids.scss";
 @import "toolkit/_instruction-list.scss";
 @import "toolkit/_notification-banners.scss";
-@import "toolkit/_page-headings.scss";
 @import "toolkit/_phase-banner.scss";
 @import "toolkit/_proposition-header.scss";
 @import "toolkit/_secondary-action-link.scss";
@@ -83,6 +82,9 @@ $govuk-compatibility-govukelements: true;
 @import "_table.scss";
 @import "_text.scss";
 @import "_help-page.scss";
+
+// Overrides
+@import "overrides/_page_headings.scss";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_page_headings.scss
+++ b/app/assets/scss/overrides/_page_headings.scss
@@ -1,0 +1,11 @@
+// FIXME: Temporary, remove once we are using govuk-frontend grids
+//
+// This is needed to push down the page content but more specifically page
+// headings.
+//
+// Previously CSS would adjust top and bottom margins/padding. We should try
+// spacing by pushing content down and not worrying about what is above it.
+
+#content {
+    @include govuk-responsive-margin(7, "top");
+  }

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -36,9 +36,7 @@
 <div class="did-you-award-contract-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = ("Did you award a contract for ‘" + project.name + "’?") %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-xl">Did you award a contract for ‘{{ project.name }}’?</h1>
 
       <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -45,9 +45,7 @@
 <div class="tell-us-about-contract-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading="Tell us about your contract" %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-xl">Tell us about your contract</h1>
 
       <form method="POST" action="{{ url_for('direct_award.tell_us_about_contract', framework_family=framework.family, project_id=project.id, outcome_id=outcome_id) }}" class="tell-us-about-contract-form">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -37,11 +37,7 @@
   {% include "direct-award/_saved-search-locked-project-temp-message.html" %}
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with
-        heading = page_title
-      %}
-        {% include "toolkit/page-heading.html" %}
-      {% endwith %}
+      <h1 class="govuk-heading-xl">{{ page_title }}</h1>
     </div>
   </div>
   <div class="grid-row direct-award-project-overview-page">

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -41,10 +41,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
 
-
-      {% with heading = 'Which service won the contract?' %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-xl">Which service won the contract?</h1>
 
         {% if form.which_service_won_the_contract.options %}
 

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -40,9 +40,7 @@
 <div class="why-didnt-you-award-contract-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = "Why didn’t you award a contract?" %}
-        {% include 'toolkit/page-heading.html' %}
-      {% endwith %}
+      <h1 class="govuk-heading-xl">Why didn’t you award a contract?</h1>
 
       <form method="POST" action="{{ url_for('direct_award.why_did_you_not_award_the_contract', framework_family=framework.family, project_id=project.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />

--- a/app/templates/help/index.html
+++ b/app/templates/help/index.html
@@ -23,7 +23,7 @@
 <div class="help-page">
   <div class="grid-row">
     <div class="column-two-thirds">
-      {% with heading = "Help and feedback", smaller="true" %} {% include "toolkit/page-heading.html" %} {% endwith %}
+      <h1 class="govuk-heading-l">Help and feedback</h1>
 
       <div class="dmspeak">
         <h2 class="heading-xmedium">Buying and selling services</h2>

--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -39,9 +39,7 @@
 {% block page_heading %}
 <div class="grid-row">
   <div class="column-two-thirds">
-    {% with heading="{} opportunities".format(framework_family_name) %}
-        {% include "toolkit/page-heading.html" %}
-    {% endwith %}
+    <h1 class="govuk-heading-xl">{{ framework_family_name }} opportunities</h1>
     <div class="marketplace-paragraph">
       <p>View buyer requirements for {{ lot_names | map('lower') | smartjoin }}.</p>
     </div>

--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -32,14 +32,8 @@
 
 {% block main_content %}
 
-{%
-  with
-  heading = supplier.name,
-  context = "Digital Marketplace supplier",
-  smaller = True
-%}
-  {% include "toolkit/page-heading.html" %}
-{% endwith %}
+<span class="govuk-caption-l">Digital Marketplace supplier</span>
+<h1 class="govuk-heading-l">{{ supplier.name }}</h1>
 
 <div class="grid-row supplier-profile">
     {% if supplier.description or supplier.clients %}

--- a/app/templates/suppliers_list.html
+++ b/app/templates/suppliers_list.html
@@ -25,17 +25,9 @@
 {% block main_content %}
 
 {% if prefix == "other"%}
-{%
-  with heading="Suppliers starting with 1–9"
-%}
-  {% include "toolkit/page-heading.html" %}
-{% endwith %}
+  <h1 class="govuk-heading-xl">Suppliers starting with 1–9</h1>
 {% else %}
-{%
-  with heading="Suppliers starting with " + prefix
-%}
-  {% include "toolkit/page-heading.html" %}
-{% endwith %}
+  <h1 class="govuk-heading-xl">Suppliers starting with {{ prefix }}</h1>
 {% endif %}
 
 <div id="global-atoz-navigation">

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -217,7 +217,8 @@ class TestSuppliersPage(DataAPIClientMixin, BaseApplicationTest):
     def test_should_have_supplier_details_on_supplier_page(self):
         res = self.client.get('/g-cloud/supplier/92191')
         assert res.status_code == 200
-        assert '<h1>ExampleCompanyLimited</h1>' in self._strip_whitespace(res.get_data(as_text=True))
+        assert '<h1class="govuk-heading-l">ExampleCompanyLimited</h1>' \
+            in self._strip_whitespace(res.get_data(as_text=True))
         assert "Example Company Limited is an innovation station sensation; we deliver software so bleeding "\
             "edge you literally won&#39;t be able to run any of it on your systems." in res.get_data(as_text=True)
 
@@ -226,7 +227,8 @@ class TestSuppliersPage(DataAPIClientMixin, BaseApplicationTest):
 
         res = self.client.get('/g-cloud/supplier/92191')
         assert res.status_code == 200
-        assert '<h1>ExampleCompanyLimited</h1>' in self._strip_whitespace(res.get_data(as_text=True))
+        assert '<h1class="govuk-heading-l">ExampleCompanyLimited</h1>' \
+            in self._strip_whitespace(res.get_data(as_text=True))
         assert self._strip_whitespace("<h2>Clients</h2>") not in self._strip_whitespace(res.get_data(as_text=True))
 
     def test_should_have_supplier_contact_details_on_supplier_page(self):


### PR DESCRIPTION
trello: https://trello.com/c/zSFIq80i/