### PR TITLE
Remove mandatory assessment feature flag

### DIFF
--- a/app/main/helpers/brief_helpers.py
+++ b/app/main/helpers/brief_helpers.py
@@ -30,26 +30,13 @@ def format_winning_supplier_size(size):
         return "large"
 
 
-def show_mandatory_assessment_method(brief, current_app):
-    # For DOS4 briefs only.
-    # To ensure suppliers see the same info while a brief is live, only show for closed briefs or
-    # briefs published after the feature flag date.
-    if brief['frameworkSlug'] != 'digital-outcomes-and-specialists-4':
-        return False
-    if brief['status'] != 'live':
-        return True
-    if current_app.config['SHOW_BRIEF_MANDATORY_EVALUATION_METHOD']:
-        if brief['publishedAt'] >= current_app.config['SHOW_BRIEF_MANDATORY_EVALUATION_METHOD']:
-            return True
-    return False
-
-
-# TODO: split the manifest sections and add the relevant description for each DOS5 lot instead
-def get_evaluation_description(brief, current_app, brief_content):
-    # Add in mandatory evaluation method, missing from the DOS4 display_brief manifest summary_page_description
+# TODO: split the manifest sections and add the relevant description for each DOS5 lot to dm-frameworks instead
+def get_evaluation_description(brief, brief_content):
+    # For DOS4 briefs only, add in mandatory evaluation method. This is missing from the DOS4 display_brief manifest
+    # summary_page_description.
     #   Digital Specialists: work history
     #   Digital Outcomes / User Research Participants: written proposal
-    if show_mandatory_assessment_method(brief, current_app):
+    if brief['frameworkSlug'] == 'digital-outcomes-and-specialists-4':
         for section in brief_content.summary(brief):
             if section.name == 'How suppliers will be evaluated':
                 if brief['lotSlug'] == 'digital-specialists':

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -173,7 +173,7 @@ def get_brief_by_id(framework_family, brief_id):
     brief_content = content_loader.get_manifest(brief['frameworkSlug'], 'display_brief').filter(brief)
 
     # Add in mandatory evaluation method, missing from the display_brief manifest summary_page_description
-    evaluation_description = get_evaluation_description(brief, current_app, brief_content)
+    evaluation_description = get_evaluation_description(brief, brief_content)
 
     return render_template(
         'brief.html',

--- a/config.py
+++ b/config.py
@@ -84,9 +84,6 @@ class Config(object):
 
     GOOGLE_SITE_VERIFICATION = None
 
-    # Feature flag - show for briefs published after this date
-    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = None
-
     @staticmethod
     def init_app(app):
         repo_root = os.path.abspath(os.path.dirname(__file__))
@@ -133,9 +130,6 @@ class Development(Config):
 
     GOOGLE_SITE_VERIFICATION = "NotARealVerificationKey"
 
-    # Feature flag - show for briefs published after this date
-    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = '2019-11-18'
-
 
 class Live(Config):
     """Base config for deployed environments"""
@@ -150,31 +144,19 @@ class Live(Config):
         "user.marketplace.team": "success@simulator.amazonses.com",
     }
 
-    # Feature flag - show for briefs published after this date
-    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = None
-
 
 class Preview(Live):
     DM_PATCH_FRONTEND_URL = 'https://www.preview.marketplace.team/'
 
-    # Feature flag - show for briefs published after this date
-    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = '2019-11-18'
-
 
 class Staging(Live):
     DM_PATCH_FRONTEND_URL = 'https://www.staging.marketplace.team/'
-
-    # Feature flag - show for briefs published after this date
-    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = '2019-11-21'
 
 
 class Production(Live):
     DM_PATCH_FRONTEND_URL = 'https://www.digitalmarketplace.service.gov.uk/'
 
     GOOGLE_SITE_VERIFICATION = "TKGSGZnfHpx1-lKOthI17ANtwk7fz3F4Sbr77I0ppO0"
-
-    # Feature flag - show for briefs published after this date
-    SHOW_BRIEF_MANDATORY_EVALUATION_METHOD = '2019-11-21'
 
 
 configs = {

--- a/tests/main/helpers/test_brief_helpers.py
+++ b/tests/main/helpers/test_brief_helpers.py
@@ -1,9 +1,6 @@
-import pytest
-import mock
 from app.main.helpers.brief_helpers import (
     count_brief_responses_by_size_and_status,
-    format_winning_supplier_size,
-    show_mandatory_assessment_method
+    format_winning_supplier_size
 )
 from ...helpers import BaseApplicationTest
 
@@ -26,52 +23,3 @@ class TestBriefHelpers(BaseApplicationTest):
         assert format_winning_supplier_size("small") == "SME"
         assert format_winning_supplier_size("medium") == "SME"
         assert format_winning_supplier_size("large") == "large"
-
-    @pytest.mark.parametrize('status', ['draft', 'closed', 'awarded', 'cancelled', 'unsuccessful'])
-    def test_show_mandatory_assessment_method_for_non_live_briefs(self, status):
-        brief = {
-            'status': status,
-            'frameworkSlug': 'digital-outcomes-and-specialists-4',
-            'publishedAt': '2019-11-01'
-        }
-        current_app = mock.Mock()
-        assert show_mandatory_assessment_method(brief, current_app)
-
-    @pytest.mark.parametrize(
-        'framework_slug',
-        [
-            'digital-outcomes-and-specialists',
-            'digital-outcomes-and-specialists-2',
-            'digital-outcomes-and-specialists-3',
-        ]
-    )
-    def test_do_not_show_mandatory_assessment_method_for_non_dos4_briefs(self, framework_slug):
-        brief = {
-            'status': 'live',
-            'frameworkSlug': framework_slug,
-            'publishedAt': '2019-11-02'
-        }
-        current_app = mock.Mock()
-        current_app.config = {'SHOW_BRIEF_MANDATORY_EVALUATION_METHOD': '2019-11-02'}
-        assert not show_mandatory_assessment_method(brief, current_app)
-
-    def test_do_not_show_mandatory_assessment_method_for_live_briefs_before_date(self):
-        brief = {
-            'status': 'live',
-            'frameworkSlug': 'digital-outcomes-and-specialists-4',
-            'publishedAt': '2019-11-01'
-        }
-        current_app = mock.Mock()
-        current_app.config = {'SHOW_BRIEF_MANDATORY_EVALUATION_METHOD': '2019-11-02'}
-        assert not show_mandatory_assessment_method(brief, current_app)
-
-    @pytest.mark.parametrize('date', ['2019-11-02', '2019-11-03'])
-    def test_show_mandatory_assessment_method_for_live_briefs_on_or_after_date(self, date):
-        brief = {
-            'status': 'live',
-            'frameworkSlug': 'digital-outcomes-and-specialists-4',
-            'publishedAt': date
-        }
-        current_app = mock.Mock()
-        current_app.config = {'SHOW_BRIEF_MANDATORY_EVALUATION_METHOD': '2019-11-02'}
-        assert show_mandatory_assessment_method(brief, current_app)

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -625,9 +625,7 @@ class TestBriefPage(BaseBriefPageTest):
         brief['briefs']['frameworkSlug'] = 'digital-outcomes-and-specialists-4'
         self.data_api_client.get_brief.return_value = brief
 
-        with self.app.app_context():
-            current_app.config['SHOW_BRIEF_MANDATORY_EVALUATION_METHOD'] = '2019-01-01'
-            res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief['briefs']['id']))
+        res = self.client.get('/digital-outcomes-and-specialists/opportunities/{}'.format(brief['briefs']['id']))
 
         assert res.status_code == 200
 


### PR DESCRIPTION
https://trello.com/c/RrAfdgsv/137-1-remove-feature-flag-on-brief-mandatory-assessment-method-5th-dec

- Removes the `SHOW_BRIEF_MANDATORY_EVALUATION_METHOD` config var
- The `show_mandatory_assessment_method` helper function is now redundant (we want to show the text for any DOS4 brief) so remove that and its tests
- Slightly tweaked the TODO to make it clearer what to do for DOS5

To be released any time after 2019-12-05T00:00:00 😸 