### PR TITLE
1144-1-never-used-link-to-localhost-on-view-project-page

### DIFF
--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -206,13 +206,4 @@ negotiate with them.'|safe},
     </div>
     {% include "direct-award/_saved-search-not-locked-project-temp-message.html" %}
   </div>
-  {% if not delete_requested %}
-     <div class="grid-row">
-       <div class="column-two-thirds">
-         {% if framework.status == 'live' and project.status == 'draft' %}
-         <a href="http://localhost">Delete</a>
-         {% endif %}
-       </div>
-     </div>
-   {% endif %}
 {% endblock %}


### PR DESCRIPTION
https://trello.com/c/or2AB4SF/1144-1-never-used-link-to-localhost-on-view-project-page

* Remove link that never gets shown

To show the link the template requires `not delete_requested`, `framework.status == 'live'` and `project.status == 'draft'`.

* `delete_requested` is never passed to that template so presumably `not delete_requested` resolves to true.
* `live` is a legitimate `framework.status` and this page is accessible for frameworks with a status of `live` so has presumably resolved to true for users before.
* `project.status` is not an attribute of the data model, or of the serialization https://github.com/alphagov/digitalmarketplace-api/blob/master/app/models/direct_award.py#L58
* `project.status` is not attached to the object or serialization in either view that uses this page https://github.com/alphagov/digitalmarketplace-buyer-frontend/blob/master/app/main/views/g_cloud.py
#### Therefore while `framework.status` will resolve to `False` it will never resolve to `'draft'`

👋 