### PR TITLE
177-3-update-breadcrumbs-to-use-govuk-frontend-component-in-buyer-frontend

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -3,6 +3,7 @@
 // Insert line for each component module import
 
 {% from "components/button/macro.njk" import govukButton %}
+{% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {# TODO: Remove once we start removing govuk_template, GOV.UK Frontend template uses pageTitle #}
 {% block page_title %}{% block pageTitle %}{% endblock %}{% endblock %}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -7,3 +7,17 @@
 
 {# TODO: Remove once we start removing govuk_template, GOV.UK Frontend template uses pageTitle #}
 {% block page_title %}{% block pageTitle %}{% endblock %}{% endblock %}
+
+{# override content block to add a beforeContent block like the one in govuk-frontend template #}
+{% block content %}
+  {% block top_header %}{% endblock %}
+  <div id="wrapper">
+    {% block beforeContent %}
+      {% block breadcrumb %}{% endblock %}
+    {% endblock %}
+    <main id="content" role="main">
+      {% include "toolkit/flash_messages.html" %}
+      {% block main_content %}{% endblock %}
+    </main>
+  </div>
+{% endblock %}

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -6,22 +6,19 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-          "link": url_for('.list_opportunities', framework_family=brief.framework.family),
-          "label": "Supplier opportunities"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('.list_opportunities', framework_family=brief.framework.family),
+      "text": "Supplier opportunities"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 

--- a/app/templates/choose-lot.html
+++ b/app/templates/choose-lot.html
@@ -5,25 +5,22 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('main.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-        "link": url_for('direct_award_public.pre_project_task_list', framework_family=framework_family),
-        "label": "Find cloud hosting, software and support"
-      },
-      {
-          "label": title|capitalize
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('direct_award_public.pre_project_task_list', framework_family=framework_family),
+      "text": "Find cloud hosting, software and support"
+    },
+    {
+      "text": title|capitalize
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 

--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -11,6 +11,9 @@
       "href": url_for('main.index'),
       "text": "Digital Marketplace"
     },
+    {
+      "text": "Cookies"
+    },
   ]
 }) }}
 {% endblock breadcrumb %}

--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -5,18 +5,15 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 <div class="grid-row legal-content">

--- a/app/templates/content/index-crown-hosting.html
+++ b/app/templates/content/index-crown-hosting.html
@@ -12,7 +12,6 @@
       "text": "Digital Marketplace"
     },
     {
-      "href": url_for('.index_crown_hosting'),
       "text": "Physical datacentre space"
     },
   ]

--- a/app/templates/content/index-crown-hosting.html
+++ b/app/templates/content/index-crown-hosting.html
@@ -5,22 +5,19 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-          "link": url_for('.index_crown_hosting'),
-          "label": "Physical datacentre space"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('.index_crown_hosting'),
+      "text": "Physical datacentre space"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 

--- a/app/templates/content/privacy-notice.html
+++ b/app/templates/content/privacy-notice.html
@@ -5,18 +5,15 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
   <div class="help-page grid-row legal-content">

--- a/app/templates/content/privacy-notice.html
+++ b/app/templates/content/privacy-notice.html
@@ -11,6 +11,9 @@
       "href": url_for('main.index'),
       "text": "Digital Marketplace"
     },
+    {
+      "text": "Privacy notice"
+    },
   ]
 }) }}
 {% endblock breadcrumb %}

--- a/app/templates/content/terms-and-conditions.html
+++ b/app/templates/content/terms-and-conditions.html
@@ -11,6 +11,9 @@
       "href": url_for('main.index'),
       "text": "Digital Marketplace"
     },
+    {
+      "text": "Terms and conditions"
+    },
   ]
 }) }}
 {% endblock breadcrumb %}

--- a/app/templates/content/terms-and-conditions.html
+++ b/app/templates/content/terms-and-conditions.html
@@ -5,18 +5,15 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
   <div class="grid-row legal-content">

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -5,30 +5,28 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-        "link": url_for('main.index'),
-        "label": "Digital Marketplace"
-      },
-      {
-        "link": url_for('external.buyer_dashboard'),
-        "label": "Your account"
-      },
-      {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
-        "label": "Your saved searches"
-      },
-      {
-        "link": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
-        "label": project.name
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('external.buyer_dashboard'),
+      "text": "Your account"
+    },
+    {
+      "href": url_for('direct_award.saved_search_overview', framework_family=framework.framework),
+      "text": "Your saved searches"
+    },
+    {
+      "href": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
+      "text": project.name
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
+
 
 {% block main_content %}
 {% include "toolkit/forms/validation.html" %}

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -5,30 +5,27 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-        "link": url_for('main.index'),
-        "label": "Digital Marketplace"
-      },
-      {
-        "link": url_for('external.buyer_dashboard'),
-        "label": "Your account"
-      },
-      {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
-        "label": "Your saved searches"
-      },
-      {
-        "link": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
-        "label": project.name
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('external.buyer_dashboard'),
+      "text": "Your account"
+    },
+    {
+      "href": url_for('direct_award.saved_search_overview', framework_family=framework.family),
+      "text": "Your saved searches"
+    },
+    {
+      "href": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
+      "text": project.name
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 {% if errors %}

--- a/app/templates/direct-award/index.html
+++ b/app/templates/direct-award/index.html
@@ -15,6 +15,9 @@
       "href": url_for('external.buyer_dashboard'),
       "text": "Your account"
     },
+    {
+      "text": "Your saved searches"
+    },
   ]
 }) }}
 {% endblock breadcrumb %}

--- a/app/templates/direct-award/index.html
+++ b/app/templates/direct-award/index.html
@@ -5,22 +5,19 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('main.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-          "link": url_for('external.buyer_dashboard'),
-          "label": "Your account"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('external.buyer_dashboard'),
+      "text": "Your account"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 

--- a/app/templates/direct-award/results.html
+++ b/app/templates/direct-award/results.html
@@ -5,30 +5,28 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('main.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-        "link": url_for('external.buyer_dashboard'),
-        "label": "Your account"
-      },
-      {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
-        "label": "Your saved searches"
-      },
-      {
-        "link": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
-        "label": project.name
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('external.buyer_dashboard'),
+      "text": "Your account"
+    },
+    {
+      "href": url_for('direct_award.saved_search_overview', framework_family=framework.family),
+      "text": "Your saved searches"
+    },
+    {
+      "href": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
+      "text": project.name
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
+
 
 {% block main_content %}
 <div class="grid-row">

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -7,25 +7,22 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('main.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-          "link": search_url,
-          "label": "Search"
-      },
-      {
-          "label": page_name
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": search_url,
+      "text": "Search"
+    },
+    {
+      "text": page_name
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -5,38 +5,35 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-        "link": url_for('main.index'),
-        "label": "Digital Marketplace"
-      },
-      {
-        "link": url_for('external.buyer_dashboard'),
-        "label": "Your account"
-      },
-      {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
-        "label": "Your saved searches"
-      },
-      {
-        "link": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
-        "label": project.name
-      },
-      {
-        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
-        "label": "Did you award a contract?"
-      },
-      {
-        "link": url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id),
-        "label": "Which service won the contract?"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('external.buyer_dashboard'),
+      "text": "Your account"
+    },
+    {
+      "href": url_for('direct_award.saved_search_overview', framework_family=framework.family),
+      "text": "Your saved searches"
+    },
+    {
+      "href": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
+      "text": project.name
+    },
+    {
+      "href": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
+      "text": "Did you award a contract?"
+    },
+    {
+      "href": url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id),
+      "text": "Which service won the contract?"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -7,31 +7,30 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+  ] + (
+    [
       {
-          "link": url_for('main.index'),
-          "label": "Digital Marketplace"
-      }
-    ] + ([
-      {
-          "link": url_for('external.buyer_dashboard'),
-          "label": "Your account"
+        "href": url_for('external.buyer_dashboard'),
+        "text": "Your account"
       },
       {
-          "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
-          "label": "Your saved searches"
-      }
+        "href": url_for('direct_award.saved_search_overview', framework_family=framework.family),
+        "text": "Your saved searches"
+      },
     ] if project else [
       {
-          "label": page_title
-      }
-    ])
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+        "text": page_title
+      },
+    ]
+  )
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
   {% include "direct-award/_saved-search-locked-project-temp-message.html" %}

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -5,34 +5,31 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-        "link": url_for('main.index'),
-        "label": "Digital Marketplace"
-      },
-      {
-        "link": url_for('external.buyer_dashboard'),
-        "label": "Your account"
-      },
-      {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
-        "label": "Your saved searches"
-      },
-      {
-        "link": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
-        "label": project.name
-      },
-      {
-        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
-        "label": "Did you award a contract?"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('external.buyer_dashboard'),
+      "text": "Your account"
+    },
+    {
+      "href": url_for('direct_award.saved_search_overview', framework_family=framework.family),
+      "text": "Your saved searches"
+    },
+    {
+      "href": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
+      "text": project.name
+    },
+    {
+      "href": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
+      "text": "Did you award a contract?"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 {% include "toolkit/forms/validation.html" %}

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -5,34 +5,31 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-        "link": url_for('main.index'),
-        "label": "Digital Marketplace"
-      },
-      {
-        "link": url_for('external.buyer_dashboard'),
-        "label": "Your account"
-      },
-      {
-        "link": url_for('direct_award.saved_search_overview', framework_family=framework.family),
-        "label": "Your saved searches"
-      },
-      {
-        "link": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
-        "label": project.name
-      },
-      {
-        "link": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
-        "label": "Did you award a contract?"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('external.buyer_dashboard'),
+      "text": "Your account"
+    },
+    {
+      "href": url_for('direct_award.saved_search_overview', framework_family=framework.family),
+      "text": "Your saved searches"
+    },
+    {
+      "href": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
+      "text": project.name
+    },
+    {
+      "href": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
+      "text": "Did you award a contract?"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 {% include "toolkit/forms/validation.html" %}

--- a/app/templates/help/index.html
+++ b/app/templates/help/index.html
@@ -11,6 +11,9 @@
       "href": url_for('main.index'),
       "text": "Digital Marketplace"
     },
+    {
+      "text": "Help and feedback"
+    },
   ]
 }) }}
 {% endblock breadcrumb %}

--- a/app/templates/help/index.html
+++ b/app/templates/help/index.html
@@ -5,18 +5,15 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('main.index'),
-          "label": "Digital Marketplace"
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 

--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -5,36 +5,19 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {% with %}
-    {% if current_lot %}
-      {% set items = [
-        {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-        },
-        {
-          "link": url_for('.{}'.format(view_name), framework_family=framework_family),
-          "label": "Supplier opportunities"
-        },
-        {
-          "label": current_lot.name
-        }
-      ] %}
-    {% else %}
-      {% set items = [
-        {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-        },
-        {
-          "link": url_for('.{}'.format(view_name), framework_family=framework_family),
-          "label": "Supplier opportunities"
-        }
-      ] %}
-    {% endif %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('.{}'.format(view_name), framework_family=framework_family),
+      "text": "Supplier opportunities"
+    },
+  ] + ([{"text": current_lot.name},] if current_lot else [])
+}) }}
+{% endblock breadcrumb %}
 
 {% block page_heading %}
 <div class="grid-row">

--- a/app/templates/search/briefs.html
+++ b/app/templates/search/briefs.html
@@ -11,11 +11,21 @@
       "href": url_for('main.index'),
       "text": "Digital Marketplace"
     },
-    {
-      "href": url_for('.{}'.format(view_name), framework_family=framework_family),
-      "text": "Supplier opportunities"
-    },
-  ] + ([{"text": current_lot.name},] if current_lot else [])
+  ] + (
+    [
+      {
+        "href": url_for('.{}'.format(view_name), framework_family=framework_family),
+        "text": "Supplier opportunities"
+      },
+      {
+        "text": current_lot.name
+      },
+    ] if current_lot else [
+      {
+        "text": "Supplier opportunities"
+      },
+    ]
+  )
 }) }}
 {% endblock breadcrumb %}
 

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -5,36 +5,19 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {% with %}
-    {% if current_lot %}
-      {% set items = [
-        {
-            "link": url_for('.index'),
-            "label": "Digital Marketplace"
-        },
-        {
-            "link": url_for('.index_g_cloud'),
-            "label": gcloud_framework_description|capitalize
-        },
-        {
-          "label": current_lot.name
-        }
-      ] %}
-    {% else %}
-      {% set items = [
-        {
-            "link": url_for('.index'),
-            "label": "Digital Marketplace"
-        },
-        {
-            "link": url_for('.index_g_cloud'),
-            "label": gcloud_framework_description|capitalize
-        }
-      ] %}
-    {% endif %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('.index_g_cloud'),
+      "text": gcloud_framework_description|capitalize
+    },
+  ] + ([{"text": current_lot.name},] if current_lot else [])
+}) }}
+{% endblock breadcrumb %}
 
 {% block page_heading %}
   <h1 class="govuk-heading-xl">

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -11,11 +11,21 @@
       "href": url_for('main.index'),
       "text": "Digital Marketplace"
     },
-    {
-      "href": url_for('.index_g_cloud'),
-      "text": gcloud_framework_description|capitalize
-    },
-  ] + ([{"text": current_lot.name},] if current_lot else [])
+  ] + (
+    [
+      {
+        "href": url_for('.index_g_cloud'),
+        "text": gcloud_framework_description|capitalize
+      },
+      {
+        "text": current_lot.name
+      },
+    ] if current_lot else [
+      {
+        "text": gcloud_framework_description|capitalize
+      },
+    ]
+  )
 }) }}
 {% endblock breadcrumb %}
 

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -6,26 +6,23 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-          "link": url_for('.index_g_cloud'),
-          "label": gcloud_framework_description|capitalize
-      },
-      {
-          "link": url_for('.search_services', lot=lot.slug),
-          "label": lot.name
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('.index_g_cloud'),
+      "text": gcloud_framework_description|capitalize
+    },
+    {
+      "href": url_for('.search_services', lot=lot.slug),
+      "text": lot.name
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 {% if service_unavailability_information %}

--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -5,30 +5,27 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-          "link": url_for('.index_g_cloud'),
-          "label": gcloud_framework_description|capitalize
-      },
-      {
-          "link": url_for('.suppliers_list_by_prefix'),
-          "label": "Suppliers"
-      },
-      {
-          "link": url_for('.suppliers_list_by_prefix', prefix=prefix),
-          "label": prefix
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('.index_g_cloud'),
+      "text": gcloud_framework_description|capitalize
+    },
+    {
+      "href": url_for('.suppliers_list_by_prefix'),
+      "text": "Suppliers"
+    },
+    {
+      "href": url_for('.suppliers_list_by_prefix', prefix=prefix),
+      "text": prefix
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 

--- a/app/templates/suppliers_list.html
+++ b/app/templates/suppliers_list.html
@@ -15,7 +15,21 @@
       "href": url_for('.index_g_cloud'),
       "text": gcloud_framework_description|capitalize
     },
-  ]
+  ] + (
+    [
+      {
+        "href": url_for('.suppliers_list_by_prefix'),
+        "text": "Suppliers"
+      },
+      {
+        "text": request.args['prefix']
+      },
+    ] if request.args['prefix'] else [
+      {
+        "text": "Suppliers"
+      },
+    ]
+  )
 }) }}
 {% endblock breadcrumb %}
 

--- a/app/templates/suppliers_list.html
+++ b/app/templates/suppliers_list.html
@@ -5,22 +5,19 @@
 {% endblock %}
 
 {% block breadcrumb %}
-  {%
-    with
-    items = [
-      {
-          "link": url_for('.index'),
-          "label": "Digital Marketplace"
-      },
-      {
-          "link": url_for('.index_g_cloud'),
-          "label": gcloud_framework_description|capitalize
-      }
-    ]
-  %}
-    {% include "toolkit/breadcrumb.html" %}
-  {% endwith %}
-{% endblock %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": url_for('.index_g_cloud'),
+      "text": gcloud_framework_description|capitalize
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
 
 {% block main_content %}
 

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -301,7 +301,7 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
                                                                             'customer_benefits_record_form_url')
         assert self._task_has_link(tasklist, 5, customer_benefits_record_form_url)
 
-        breadcrumbs = doc.xpath("//ol[@role='breadcrumbs']/li")
+        breadcrumbs = doc.xpath("//div[@class='govuk-breadcrumbs']/ol/li")
         assert tuple(li.xpath("normalize-space(string())") for li in breadcrumbs) == (
             "Digital Marketplace",
             "Your account",
@@ -1333,7 +1333,7 @@ class TestPreProjectTaskList(TestDirectAwardBase):
 
         doc = html.fromstring(res.get_data(as_text=True))
 
-        breadcrumbs = doc.xpath("//ol[@role='breadcrumbs']/li")
+        breadcrumbs = doc.xpath("//div[@class='govuk-breadcrumbs']/ol/li")
         assert tuple(li.xpath("normalize-space(string())") for li in breadcrumbs) == (
             "Digital Marketplace",
             "Find cloud hosting, software and support",

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -112,7 +112,7 @@ class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
             '/g-cloud/search?lot={}'.format(lot): self.lots[lot]['name']
         }
 
-        breadcrumbs = document.xpath('//div[@id="global-breadcrumb"]//a')
+        breadcrumbs = document.xpath("//div[@class='govuk-breadcrumbs']/ol/li/a")
         assert len(breadcrumbs) == 3
 
         for breadcrumb in breadcrumbs:


### PR DESCRIPTION
https://trello.com/c/qnhvbuYd/177-3-update-breadcrumbs-to-use-govuk-frontend-component-in-buyer-frontend

* Import breadcrumbs macro in the base page template
* Move `breadcrumbs` block into `beforeContent` block in base page template
* Find all `breadcrumbs` blocks in page templates and replace old component with new
  * Simple find and replace of existing breadcrumbs
    * Do not change logic
    * Do not change content
    * Do not change links
    * Update `.index` to  `main.index` for consistency
    * Normalise spacing
* Update tests for 'Find all breadcrumbs blocks in page templates and replace old component with new' commit
* Review pages in digitalmarketplace-buyer-frontend/app/templates (root)
  * `suppliers_list.html` /g-cloud/suppliers Add 'Suppliers' page title breadcrumb and conditional {{ prefix }} breadcrumb
* Review pages in digitalmarketplace-buyer-frontend/app/templates/content
  * `cookies.html` /cookies Add 'Cookies' page title breadcrumb
  * `index-crown-hosting.html` Remove link to self from title breadcrumb
  * `privacy-notice.html` Add 'Privacy notice' page title breadcrumb
  * `terms-and-conditions.html` Add 'Terms and conditions' page title breadcrumb
* Review page in digitalmarketplace-buyer-frontend/app/templates/help    
  * `index.html` Add 'Help' page title breadcrumb
* Review pages in digitalmarketplace-buyer-frontend/app/templates/search
  * `briefs.html` /digital-outcomes-and-specialists/opportunities Remove link to self from title breadcrumb
  * `services.html` /g-cloud/search?lot=xyz Ensure no link to self regardless of passed args
* Minor change in app/templates/direct-award
  * `index.html` Add 'Your saved searches' page title breadcrumb
    * As per https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/965#discussion_r357265062
* Add unittests for breadcrumbs on Gcloud search
  * We have removed these from the functional tests in favour of unit-testing here
    * see alphagov/digitalmarketplace-functional-tests#718


#### Out of scope: rewrite of breadcrumbs in direct award flow. These have been kept the same. Have created a document to demonstrate flow and current crumbs. It will require content/ design work and I don't think those breadcrumbs need to hold up this first pass https://www.draw.io/#G1CG2yJRKdfeltoQW_bBkTtBdAGrG19Cgy
