### PR TITLE
Remove reference to Google Analytics in cookie policy

### DIFF
--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -30,66 +30,10 @@
         </p>
 
         <p class="govuk-body">
-            We use cookies to store information about how you use the Digital Marketplace, such as the pages you visit.
+            Digital Marketplace uses cookies that are essential for the site to work.
         </p>
       
         <h2>How cookies are used on Digital Marketplace</h2>
-
-        <h3>Measuring website usage</h3>
-
-        <p class="govuk-body">
-            We use Google Analytics to measure how you use the Digital Marketplace so we can improve it based on user needs.
-        </p>
-
-        <p class="govuk-body">Google Analytics sets cookies that store anonymised information about:
-
-        <ul class="govuk-list govuk-list--bullet">
-            <li>how you got to Digital Marketplace</li>
-            <li>the pages you visit on Digital Marketplace and government digital services, and how long you spend on each page</li>
-            <li>what you click on while you&rsquo;re using the service</li>
-        </ul>
-        </p>
-  
-        <p class="govuk-body">
-            We do not allow Google to use or share the data about how you use this site.
-        </p>
-
-        <table class="content-table">
-            <thead>
-            <tr>
-                <th>Name</th>
-                <th>Purpose</th>
-                <th>Expires</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-                <td>_ga</td>
-                <td>Helps us count how many people visit Digital Marketplace by tracking if you’ve visited the service before
-                </td>
-                <td>2 years</td>
-            </tr>
-            <tr>
-                <td>_gid</td>
-                <td>Helps us count how many people visit Digital Marketplace by tracking if you’ve visited the service before
-                </td>
-                <td>24 hours</td>
-            </tr>
-            <tr>
-                <td>_gat</td>
-                <td>Used to manage the rate at which page view requests are made
-                </td>
-                <td>10 minutes</td>
-            </tr>
-            <tr>
-                <td>_gat_govuk_shared</td>
-                <td> Helps us count how many users visit <a class="govuk-link" href="http://www.gov.uk" rel=external>GOV.UK</a> 
-                        after visiting Digital Marketplace
-                </td>
-                <td>10 minutes</td>
-            </tr>
-            </tbody>
-        </table>
 
         <h3>Introductory message cookie</h3>
 


### PR DESCRIPTION
https://trello.com/c/Eth9oZbJ/203-disable-ga-cookies-temporarily

- Removes GA section
- Replaces an otherwise confusing line with the 'essential' wording from the current GOV.UK banner.