### PR TITLE
Bumps digitalmarketplace-frontend-toolkit to v36.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1164,8 +1164,8 @@
       "from": "git+https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.0.0"
     },
     "digitalmarketplace-frontend-toolkit": {
-      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#eeffbec6e5d30d6f9f4906f35efeb6be6e908ec3",
-      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.0.0",
+      "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",
+      "from": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
       "requires": {
         "govuk-elements-sass": "3.0.3",
         "govuk_frontend_toolkit": "5.0.3"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "https://github.com/alphagov/digitalmarketplace-frameworks.git#v17.0.0",
-    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.0.0",
+    "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.3.1",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",


### PR DESCRIPTION
Required for #973 tests to pass.