### PR TITLE
Fix styles for temporary message text

### DIFF
--- a/app/assets/scss/overrides/_temporary-messages.scss
+++ b/app/assets/scss/overrides/_temporary-messages.scss
@@ -15,3 +15,17 @@
     }
   }
 }
+
+.temporary-message {
+  p.temporary-message-message {
+    color: $white;
+
+    a, a:visited {
+      color: $white;
+    }
+
+    a:hover, a:active {
+      color: $light-blue-50;
+    }
+  }
+}


### PR DESCRIPTION
Ticket: https://trello.com/c/lbW5IQFx/

Similar fix to https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1163.

The text on sidebar temporary messages for G-Cloud saved searches (only visible when the current framework is about to expire) is black by default. I've added in the styling fix to the `_temporary-messages.scss` (next to the banner fix) for now until we upgrade the temporary messages component in Digital Marketplace GOVUK Frontend.

Before:
![g-cloud-temporary-message-banner](https://user-images.githubusercontent.com/3492540/73431366-2965fa00-4338-11ea-82b1-2379cac01d11.png)

After:
![g-cloud-temporary-message-fix](https://user-images.githubusercontent.com/3492540/73431371-2f5bdb00-4338-11ea-971c-cf0dd2ee8a87.png)
