### PR TITLE
Update cookie banner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk-frontend/all.js
+//= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/digitalmarketplace-govuk-frontend.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/shim-links-with-button-role.js
@@ -22,6 +23,8 @@
 //= require _selection-buttons.js
 
 GOVUKFrontend.initAll();
+DMGOVUKFrontend.initAll();
+
 
 (function(GOVUK, GDM) {
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -21,12 +21,7 @@
 {% endblock %}
 
 {% block header %}
-  {% block cookieBanner %}
-    {{ dmCookieBanner({
-      'cookieSettingsUrl': url_for('external.cookie_settings'),
-      'cookieInfoUrl': url_for('main.cookies'),
-    }) }}
-  {% endblock %}
+  {% include "_cookie_banner.html" %}
   {{ dmHeader({
     "role": current_user.role | default(None)
   }) }}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -7,6 +7,7 @@
 {% from "govuk-frontend/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {# Import DM Components #}
+{% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader%}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter%}
 
@@ -20,6 +21,12 @@
 {% endblock %}
 
 {% block header %}
+  {% block cookieBanner %}
+    {{ dmCookieBanner({
+      'cookieSettingsUrl': url_for('external.cookie_settings'),
+      'cookieInfoUrl': url_for('main.cookies'),
+    }) }}
+  {% endblock %}
   {{ dmHeader({
     "role": current_user.role | default(None)
   }) }}

--- a/app/templates/_cookie_banner.html
+++ b/app/templates/_cookie_banner.html
@@ -1,0 +1,6 @@
+{% block cookieBanner %}
+  {{ dmCookieBanner({
+    'cookieSettingsUrl': url_for('external.cookie_settings'),
+    'cookieInfoUrl': url_for('main.cookies'),
+  }) }}
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -60,6 +60,13 @@
       }
     ]%}
   {% endif %}
+
+  {% block cookieBanner %}
+    {{ dmCookieBanner({
+      'cookieSettingsUrl': url_for('external.cookie_settings'),
+      'cookieInfoUrl': url_for('main.cookies'),
+    }) }}
+  {% endblock %}
   <header class="govuk-header" role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
       <div class="govuk-header__logo">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -61,12 +61,8 @@
     ]%}
   {% endif %}
 
-  {% block cookieBanner %}
-    {{ dmCookieBanner({
-      'cookieSettingsUrl': url_for('external.cookie_settings'),
-      'cookieInfoUrl': url_for('main.cookies'),
-    }) }}
-  {% endblock %}
+  {% include "_cookie_banner.html" %}
+
   <header class="govuk-header" role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
       <div class="govuk-header__logo">

--- a/package-lock.json
+++ b/package-lock.json
@@ -2060,9 +2060,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.4.1.tgz",
-      "integrity": "sha512-SecGO1BzepmOg9z13n5ZHoRIyw1FwrhntI2y5gum3hRFkKf38MwsRHNcq0MzR8HsyIc3UsIGj2pjehJqG7rdUA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-0.6.0.tgz",
+      "integrity": "sha512-JuThzUkpgeIRDFfdLnljqZcuz1Ywkzk5lsKdlsrRe20Dg0j8rEuvWhfPJU5rBtcnnyBfoLdILeOXKt55to2lsg=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.1.0",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^0.4.1",
+    "digitalmarketplace-govuk-frontend": "^0.6.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",
     "gulp": "^4.0.2",

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,7 +7,7 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 lxml==4.5.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.1#egg=digitalmarketplace-utils==51.3.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.0-alpha#egg=govuk-frontend-jinja==0.5.0-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-WTF==0.14.2
 itsdangerous==0.24 # pyup: ignore
 lxml==4.5.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.1.0#egg=digitalmarketplace-utils==51.1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.3.1#egg=digitalmarketplace-utils==51.3.1
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.0-alpha#egg=govuk-frontend-jinja==0.5.0-alpha
@@ -16,10 +16,10 @@ git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.0-alpha#egg=govuk-
 ## The following requirements were added by pip freeze:
 asn1crypto==1.3.0
 blinker==1.4
-boto3==1.11.9
-botocore==1.14.9
+boto3==1.11.13
+botocore==1.14.13
 certifi==2019.11.28
-cffi==1.13.2
+cffi==1.14.0
 chardet==3.0.4
 Click==7.0
 contextlib2==0.6.0.post1
@@ -51,7 +51,7 @@ python-json-logger==0.1.11
 pytz==2019.3
 PyYAML==5.3
 requests==2.22.0
-s3transfer==0.3.2
+s3transfer==0.3.3
 six==1.14.0
 unicodecsv==0.14.1
 urllib3==1.25.8

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -26,12 +26,12 @@ class TestApplication(APIClientMixin, BaseApplicationTest):
         assert res.status_code == 200
         assert 'trackPageview' in res.get_data(as_text=True)
 
-    @pytest.mark.skip(reason="cookie banner still outstanding")
-    def test_should_use_local_cookie_page_on_cookie_message(self):
+    def test_should_display_cookie_banner(self):
         res = self.client.get('/')
         assert res.status_code == 200
-        assert '<p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">' \
-            'Find out more about cookies</a></p>' in res.get_data(as_text=True)
+        document = html.fromstring(res.get_data(as_text=True))
+        cookie_banner = document.xpath('//div[@id="dm-cookie-banner"]')
+        assert cookie_banner[0].xpath('//h2//text()')[0].strip() == "Can we store analytics cookies on your device?"
         assert len(self.data_api_client.find_frameworks.call_args_list) == 2
 
     def test_google_verification_code_shown_on_homepage(self):


### PR DESCRIPTION
https://trello.com/c/hGlNERQ6/294-3-cookie-settings-page-incl-analytics-roll-out

Introduces the new opt-in cookie banner.

Relies on https://github.com/alphagov/digitalmarketplace-user-frontend/pull/214 (which allows a user to change their preferences) and https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/63 (the updated JS)
![cookie-banner-home-page](https://user-images.githubusercontent.com/3492540/74047985-38e4e300-49c9-11ea-961e-b6f08b0f9f4c.png)
