### PR TITLE
Feature/pvks 320 reinstate analytics content

### DIFF
--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -140,27 +140,6 @@
             </tr>
             </tbody>
         </table>
-
-        <h3>User research recruitment banner cookie</h3>
-
-        <p class="govuk-body">
-            When you use our service, you may see a pop up banner about user research recruitment. Once you&rsquo;ve interacted with the message (by visiting or clicking on any of the links), we
-            store a cookie on your computer so it knows not to show it again.
-        </p>
-        <table class="content-table">
-            <tbody>
-                <tr>
-                    <th scope="col">Name</th>
-                    <th scope="col">Purpose</th>
-                    <th scope="col">Expires</th>
-                </tr>
-                <tr>
-                    <td>seen_user_research_message</td>
-                    <td>Tells us that you have seen our user research banner</td>
-                    <td>Never expires</td>
-                </tr>
-            </tbody>
-        </table>
     </div>
 </div>
 {% endblock %}

--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -77,7 +77,7 @@
             </tr>
             </tbody>
         </table>
-  
+
         <h3>Session cookies</h3>
 
         <p class="govuk-body">
@@ -97,7 +97,50 @@
             </tr>
             </tbody>
         </table>
-  
+
+        <h3>Measuring website usage</h3>
+
+        <p class="govuk-body">
+            We use Google Analytics to measure how you use the Digital Marketplace so we can improve it based on user needs.
+        </p>
+
+        <p class="govuk-body">Google Analytics sets cookies that store anonymised information about:
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>how you got to Digital Marketplace</li>
+            <li>the pages you visit on Digital Marketplace and government digital services, and how long you spend on each page</li>
+            <li>what you click on while you&rsquo;re using the service</li>
+        </ul>
+        </p>
+
+        <p class="govuk-body">
+            We do not allow Google to use or share the data about how you use this site.
+        </p>
+
+        <table class="content-table">
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Purpose</th>
+                <th>Expires</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>_ga</td>
+                <td>Helps us count how many people visit Digital Marketplace by tracking if you’ve visited the service before
+                </td>
+                <td>2 years</td>
+            </tr>
+            <tr>
+                <td>_gid</td>
+                <td>Helps us count how many people visit Digital Marketplace by tracking if you’ve visited the service before
+                </td>
+                <td>24 hours</td>
+            </tr>
+            </tbody>
+        </table>
+
         <h3>User research recruitment banner cookie</h3>
 
         <p class="govuk-body">

--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -140,6 +140,11 @@
             </tr>
             </tbody>
         </table>
+
+        <h2>Change your settings</h2>
+
+        <p>You can <a href="{{ url_for('external.cookie_settings')}}" class="govuk-link">change which cookies you’re happy for us
+            to use</a>.</p>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Ticket: https://trello.com/c/hnvXlnQJ

- re-instates the analytics content on the cookies page, minus the cross-site cookies, removed on #971 
- remove user research banner
- reformat to use 2 spaces instead of 4
