### PR TITLE
Fix header menu button on mobile on homepage

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -63,7 +63,7 @@
 
   {% include "_cookie_banner.html" %}
 
-  <header class="govuk-header" role="banner" data-module="govuk-header">
+  <header class="govuk-header" role="banner" data-module="header">
     <div class="govuk-header__container govuk-width-container">
       <div class="govuk-header__logo">
         <a href="/" class="govuk-header__link govuk-header__link--homepage">
@@ -114,7 +114,7 @@
         </a>
       </div>
       <div class="govuk-header__content">
-      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <button type="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
       <nav>
         <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="Top Level Navigation">
           {% for item in headerNavigation %}


### PR DESCRIPTION
Ticket: https://trello.com/c/7gIPVCgk/1269-mobile-header-menu-not-working-on-homepage

This wasn't working because I copied the header template from govuk-frontend v3, which namespaces data-module attributes (see https://github.com/alphagov/govuk-frontend/commit/9977b6df6a7ca508d8513f295612cca9970f2081).