### PR TITLE
Pull in updated G12 homepage message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2048,8 +2048,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "github:alphagov/digitalmarketplace-frameworks#0588451ffe4d131b64bfb403266e17b702d29563",
-      "from": "github:alphagov/digitalmarketplace-frameworks#v17.5.0"
+      "version": "github:alphagov/digitalmarketplace-frameworks#1e13d8af4674a6386c4e5388c1046f572edfb4e7",
+      "from": "github:alphagov/digitalmarketplace-frameworks#v17.7.3"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.5.0",
+    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.7.3",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.6.5",
     "govuk-elements-sass": "3.0.3",


### PR DESCRIPTION
https://trello.com/c/FmDeNVc2/370-add-3pm-gmt-to-homepage

To manage supplier expectations on opening day, let's include the opening time on the home page sidebar. See https://github.com/alphagov/digitalmarketplace-frameworks/pull/611 for screenshot.