### PR TITLE
query_args_for_pagination: handle multi-valued dicts by expanding values to lists

### DIFF
--- a/app/main/helpers/search_helpers.py
+++ b/app/main/helpers/search_helpers.py
@@ -1,5 +1,6 @@
 from math import ceil
 import re
+from typing import Dict, Sequence
 
 from flask import url_for
 from werkzeug.datastructures import MultiDict
@@ -210,20 +211,12 @@ def build_search_query(request_args, lot_filters, content_builder, lots_by_slug,
     return group_request_filters(query, content_builder)
 
 
-def query_args_for_pagination(args):
+def query_args_for_pagination(args: MultiDict) -> Dict[str, Sequence[str]]:
     """
-    To use url_for for pagination next/prev page links
-    We need to not have the current page in the query args
-    :param request:
-    :return request args without page
+    Strip page from args and expand values to lists (to allow url_for to cope
+    with multi-valued keys)
     """
-    query = args.copy()
-
-    if 'page' in query:
-        del query['page']
-        return query
-    else:
-        return query
+    return {key: values for key, values in args.lists() if key != "page"}
 
 
 def total_pages(total, page_size):

--- a/tests/main/helpers/test_search_helpers.py
+++ b/tests/main/helpers/test_search_helpers.py
@@ -66,7 +66,7 @@ def test_should_strip_page_from_multidict():
     params.add("page", 100)
 
     parsed = search_helpers.query_args_for_pagination(params)
-    assert parsed['this'] == 'that'
+    assert parsed['this'] == ['that']
     assert 'page' not in parsed
 
 

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1280,7 +1280,7 @@ class TestCatalogueOfBriefsPage(APIClientMixin, BaseApplicationTest):
 
     def test_catalogue_of_briefs_page_filtered(self):
         original_url = "/digital-outcomes-and-specialists/opportunities?page=2"\
-            "&statusOpenClosed=open&lot=digital-outcomes&location=wales"
+            "&statusOpenClosed=open&lot=digital-outcomes&location=wales&location=london"
         res = self.client.get(original_url)
         assert res.status_code == 200
 
@@ -1292,7 +1292,7 @@ class TestCatalogueOfBriefsPage(APIClientMixin, BaseApplicationTest):
             doc_type='briefs',
             statusOpenClosed='open',
             lot='digital-outcomes',
-            location='wales',
+            location='wales,london',
             page='2',
         )
 
@@ -1346,7 +1346,7 @@ class TestCatalogueOfBriefsPage(APIClientMixin, BaseApplicationTest):
             "west midlands": False,
             "east of england": False,
             "wales": True,
-            "london": False,
+            "london": True,
             "south east england": False,
             "south west england": False,
             "northern ireland": False,


### PR DESCRIPTION
Originating from https://trello.com/c/KaL0fCtR

This is the format which `url_for()` likes when it's being asked to construct a querystring which might have multi-valued keys. This will allow the paging links to retain their full filter selection between pages.