### PR TITLE
Update G-Cloud 12 dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2042,8 +2042,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "github:alphagov/digitalmarketplace-frameworks#201fa3ff133bd11da4bd90562b7e90dbfb573025",
-      "from": "github:alphagov/digitalmarketplace-frameworks#v17.8.0"
+      "version": "github:alphagov/digitalmarketplace-frameworks#301e129389edf2a8a8f809fe3a1e2b9d70ade87b",
+      "from": "github:alphagov/digitalmarketplace-frameworks#v17.8.2"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",
@@ -3637,7 +3637,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.8.0",
+    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.8.2",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^0.6.5",
     "govuk-elements-sass": "3.0.3",


### PR DESCRIPTION
Pulls in digitalmarketplace-frameworks 17.8.2 with alphagov/digitalmarketplace-frameworks#615.