### PR TITLE
Remove toolkit/service-id

### DIFF
--- a/app/assets/scss/_service-page.scss
+++ b/app/assets/scss/_service-page.scss
@@ -70,10 +70,6 @@
     @extend %meta-item;
   }
 
-  .service-id {
-    @extend %meta-item;
-  }
-
   .external-link-default {
     @extend %meta-item;
   }

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -33,7 +33,6 @@ $path: "/static/images/";
 @import "toolkit/_page-headings.scss";
 @import "toolkit/_phase-banner.scss";
 @import "toolkit/_proposition-header.scss";
-@import "toolkit/_service-id.scss";
 @import "toolkit/_statistics.scss";
 @import "toolkit/_temporary-message.scss";
 @import "toolkit/_report-a-problem.scss";

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -40,9 +40,9 @@
     <p class="framework-name">{{ service.frameworkName }}</p>
   {% endif %}
   <h2 class="sidebar-heading">Service ID</h2>
-  {% with id=service.meta.serviceId %}
-    {% include "toolkit/service-id.html" %}
-  {% endwith %}
+  {% for chunk in service.meta.serviceId -%}
+  <span class="govuk-!-margin-bottom-6 {% if not loop.first %} govuk-!-padding-left-1 {% endif %} govuk-!-display-inline-block">{{chunk}}</span>
+  {%- endfor %}
   <h2 class="sidebar-heading">Contact</h2>
   {%
     with


### PR DESCRIPTION
[https://trello.com/c/CnYKKppy/3-1-remove-service-id-component-from-buyer-frontend](https://trello.com/c/CnYKKppy/3-1-remove-service-id-component-from-buyer-frontend)

Removes use of toolkit/service-id and replaces with Design System classes.

Route: /g-cloud/services/...service_id...