### PR TITLE
Review G-Cloud Services Journey Error Messages

### DIFF
--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -57,7 +57,7 @@ class DidYouAwardAContractForm(FlaskForm):
 
     did_you_award_a_contract = DMRadioField(
         "Did you award a contract?",
-        validators=[InputRequired(message="You need to answer this question.")],
+        validators=[InputRequired(message="Select yes if you awarded a contract")],
         options=[
             {'value': YES, 'label': 'Yes'},
             {'value': NO, 'label': 'No'},

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -82,24 +82,21 @@ class WhichServiceWonTheContractForm(FlaskForm):
 
 
 class TellUsAboutContractForm(FlaskForm):
-    INPUT_REQUIRED_MESSAGE = "You need to answer this question."
-    INVALID_DATE_MESSAGE = "Your answer must be a valid date."
-    INVALID_VALUE_MESSAGE = "Enter your value in pounds and pence using numbers and decimals only" \
-                            ", for example 9900.05 for 9900 pounds and 5 pence."
+    INVALID_VALUE_MESSAGE = "Enter the value in pounds and pence using numbers and decimals only"
 
     start_date = DMDateField(
         "Start date",
         validators=[
-            InputRequired(INPUT_REQUIRED_MESSAGE),
-            DataRequired(INVALID_DATE_MESSAGE),
+            InputRequired("Enter the start date"),
+            DataRequired("Enter a real start date"),
         ],
     )
 
     end_date = DMDateField(
         "End date",
         validators=[
-            InputRequired(INPUT_REQUIRED_MESSAGE),
-            DataRequired(INVALID_DATE_MESSAGE),
+            InputRequired("Enter the end date"),
+            DataRequired("Enter a real end date"),
             GreaterThan("start_date", "Your end date must be later than the start date."),
         ],
     )
@@ -107,7 +104,7 @@ class TellUsAboutContractForm(FlaskForm):
     value_in_pounds = DMPoundsField(
         "Value",
         validators=[
-            InputRequired(INPUT_REQUIRED_MESSAGE),
+            InputRequired("Enter the contract value"),
             DataRequired(INVALID_VALUE_MESSAGE),
             NumberRange(min=Decimal('0.01'), message=INVALID_VALUE_MESSAGE),
         ],
@@ -117,7 +114,7 @@ class TellUsAboutContractForm(FlaskForm):
         "Organisation buying the service",
         hint="For example, National Audit Office or Lewisham Council",
         validators=[
-            InputRequired(INPUT_REQUIRED_MESSAGE)
+            InputRequired("Enter an organisation")
         ],
     )
 

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -82,7 +82,7 @@ class WhichServiceWonTheContractForm(FlaskForm):
 
 
 class TellUsAboutContractForm(FlaskForm):
-    INVALID_VALUE_MESSAGE = "Enter the value in pounds and pence using numbers and decimals only"
+    INVALID_VALUE_MESSAGE = "Enter the value in pounds and pence, using numbers and decimals only"
 
     start_date = DMDateField(
         "Start date",

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 class CreateProjectForm(FlaskForm):
     save_search_selection = DMRadioField(
         validators=[
-            InputRequired("Please choose where to save your search")
+            InputRequired("Select a save location")
         ]
     )
     name = DMStripWhitespaceStringField(
@@ -44,7 +44,7 @@ class CreateProjectForm(FlaskForm):
     def validate_name(form, field):
         if form.save_search_selection.data == "new_search":
             try:
-                Length(min=1, max=100, message="Names must be between 1 and 100 characters")(form, field)
+                Length(min=1, max=100, message="Name must be between 1 and 100 characters")(form, field)
             except ValidationError as e:
                 form.save_search_selection.options[-1]["reveal"]["error"] = e.args[0]
                 raise

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -68,7 +68,7 @@ class DidYouAwardAContractForm(FlaskForm):
 class WhichServiceWonTheContractForm(FlaskForm):
     which_service_won_the_contract = DMRadioField(
         "Which service won the contract?",
-        validators=[InputRequired(message="Please select the service that won the contract")],
+        validators=[InputRequired(message="Select the service that won the contract")],
     )
 
     def __init__(self, services, *args, **kwargs):

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -134,7 +134,7 @@ class WhyDidYouNotAwardForm(FlaskForm):
                 "hint": "The services in your search results did not meet your requirements",
             },
         ],
-        validators=[InputRequired(message="Please select a reason why you didn't award a contract")]
+        validators=[InputRequired(message="Select a reason why you didn't award a contract")]
     )
 
 

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 class CreateProjectForm(FlaskForm):
     save_search_selection = DMRadioField(
         validators=[
-            InputRequired("Select a save location")
+            InputRequired("Select where to save your search result")
         ]
     )
     name = DMStripWhitespaceStringField(
@@ -44,7 +44,7 @@ class CreateProjectForm(FlaskForm):
     def validate_name(form, field):
         if form.save_search_selection.data == "new_search":
             try:
-                Length(min=1, max=100, message="Name must be between 1 and 100 characters")(form, field)
+                Length(min=1, max=100, message="Search name must be between 1 and 100 characters")(form, field)
             except ValidationError as e:
                 form.save_search_selection.options[-1]["reveal"]["error"] = e.args[0]
                 raise
@@ -57,7 +57,7 @@ class DidYouAwardAContractForm(FlaskForm):
 
     did_you_award_a_contract = DMRadioField(
         "Did you award a contract?",
-        validators=[InputRequired(message="Select yes if you awarded a contract")],
+        validators=[InputRequired(message="Select if you have awarded your contract")],
         options=[
             {'value': YES, 'label': 'Yes'},
             {'value': NO, 'label': 'No'},
@@ -82,13 +82,13 @@ class WhichServiceWonTheContractForm(FlaskForm):
 
 
 class TellUsAboutContractForm(FlaskForm):
-    INVALID_VALUE_MESSAGE = "Enter the value in pounds and pence, using numbers and decimals only"
+    INVALID_VALUE_MESSAGE = "Enter the value in pounds and pence, using numbers and decimals"
 
     start_date = DMDateField(
         "Start date",
         validators=[
             InputRequired("Enter the start date"),
-            DataRequired("Enter a real start date"),
+            DataRequired("Enter the full start date of your contract"),
         ],
     )
 
@@ -96,7 +96,7 @@ class TellUsAboutContractForm(FlaskForm):
         "End date",
         validators=[
             InputRequired("Enter the end date"),
-            DataRequired("Enter a real end date"),
+            DataRequired("Enter the full end date of your contract"),
             GreaterThan("start_date", "Your end date must be later than the start date."),
         ],
     )

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -145,6 +145,6 @@ class BeforeYouDownloadForm(FlaskForm):
     user_understands = DMBooleanField(
         "I understand that I cannot edit my search again after I export my results",
         validators=[
-            InputRequired(message="Please confirm that you understand before you continue.")
+            InputRequired(message="Confirm that you have finished editing your search")
         ],
     )

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -119,7 +119,7 @@ def choose_lot(framework_family):
         else:
             errors["lot"] = {
                 "question": "Choose a category",
-                "message": "Please select a category to start your search"
+                "message": "Select a category to start your search"
             }
 
     return render_template('choose-lot.html',

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -161,7 +161,7 @@ class TestDirectAward(TestDirectAwardBase):
         html = res.get_data(as_text=True)
         assert self.SEARCH_API_URL not in html  # it was once, so let's check
         assert self.SIMPLE_SEARCH_PARAMS in html
-        assert "Names must be between 1 and 100 characters" in html
+        assert "Name must be between 1 and 100 characters" in html
 
     def test_save_search_submit_success(self):
         res = self._save_search('some name " foo bar \u2016')

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -783,7 +783,7 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
         assert res.status_code == 400
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//legend[contains(normalize-space(), "You need to answer this question.")]')) == 1
+        assert len(doc.xpath('//legend[contains(normalize-space(), "Select yes if you awarded a contract")]')) == 1
         assert doc.xpath('boolean(//div[@class="validation-masthead"])')
         assert doc.xpath('count(//div[@class="validation-masthead"]/a[@class="validation-masthead-link"])') == 1
 

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -161,7 +161,7 @@ class TestDirectAward(TestDirectAwardBase):
         html = res.get_data(as_text=True)
         assert self.SEARCH_API_URL not in html  # it was once, so let's check
         assert self.SIMPLE_SEARCH_PARAMS in html
-        assert "Name must be between 1 and 100 characters" in html
+        assert "Search name must be between 1 and 100 characters" in html
 
     def test_save_search_submit_success(self):
         res = self._save_search('some name " foo bar \u2016')
@@ -783,7 +783,7 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
         assert res.status_code == 400
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//legend[contains(normalize-space(), "Select yes if you awarded a contract")]')) == 1
+        assert len(doc.xpath('//legend[contains(normalize-space(), "Select if you have awarded your contract")]')) == 1
         assert doc.xpath('boolean(//div[@class="validation-masthead"])')
         assert doc.xpath('count(//div[@class="validation-masthead"]/a[@class="validation-masthead-link"])') == 1
 


### PR DESCRIPTION
https://trello.com/c/4SyHm8wo/14-2-review-error-messages-for-search-for-g-cloud-services-journey-in-buyer-frontend

Updates the error messages in the G-Cloud services journey to bring them in line with the [Design System guidance](https://design-system.service.gov.uk/components/text-input/#error-messages). 

See the equivalent changes for the G12 supplier application error messages: https://github.com/alphagov/digitalmarketplace-frameworks/pull/606

And for DOS Opportunities:
https://github.com/alphagov/digitalmarketplace-frameworks/pull/617

### Notes
- Commits are broken down by page, with a further commit for changes decided with content design.
- In-place message fixes only - this PR doesn't address things like needing to feed back exactly what's missing from an incomplete date, or providing a dynamic character count on fields with character limits.