### PR TITLE
Move G-Cloud search summary and button

### DIFF
--- a/app/assets/scss/_search-page.scss
+++ b/app/assets/scss/_search-page.scss
@@ -29,26 +29,6 @@
   }
 }
 
-.button-save-wrapper {
-  margin: 0px 0px 20px;
-
-  .save-summary-text {
-    @include core-16;
-    padding: 7px 15px;
-    @include media(mobile) {
-      margin-bottom: 10px;
-    }
-  }
-
-  .save-button {
-    padding: 0;
-
-    .button-save {
-      @include core-19;
-    }
-  }
-}
-
 @import "search/_search-result.scss";
 
 .search-page-filters {

--- a/app/templates/search/_services_save_search.html
+++ b/app/templates/search/_services_save_search.html
@@ -3,8 +3,6 @@
 <div id="js-dm-live-save-search-form">
   <form action="{{ url_for('direct_award.save_search', framework_family=framework_family) }}">
     <input type="hidden" name="search_query" value="{{ search_query_url }}">
-    <div class="button-save-wrapper govuk-grid-row">
-      <div class="save-button govuk-grid-column-one-quarter">
         {{ govukButton({
           "text": "Save your search",
           "attributes": {
@@ -16,7 +14,5 @@
             "data-analytics-label": search_count|string(),
           },
         }) }}
-      </div>
-    </div>
   </form>
 </div>

--- a/app/templates/search/services.html
+++ b/app/templates/search/services.html
@@ -36,10 +36,11 @@
 {% endblock %}
 
 {% block post_heading %}
-  <section class="govuk-grid-column-full" aria-label="Search summary">
+{% endblock %}
+
+{% block pre_results %}
+  <section aria-label="Search summary">
     {% include 'search/_summary.html' %}
     {% include 'search/_services_save_search.html' %}
   </section>
 {% endblock %}
-
-{% block pre_results %}{% endblock %}


### PR DESCRIPTION
https://trello.com/c/jyjVLG6K/43-1-move-search-results-summary-and-save-your-search-button-on-g-cloud-search-page

This brings the search page more in line with the DOS search page.