### PR TITLE
Fix "return to top" button

### DIFF
--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -74,7 +74,7 @@
   <div class="govuk-grid-column-full">
     {% include '_service_attributes.html' %}
     {% include '_service_documents.html' %}
-    <a class="govuk-link" href="#content" class="return-to-top">Return to top ↑</a>
+    <a class="govuk-link" href="#main-content" class="return-to-top">Return to top ↑</a>
   </div>
 </div>
 


### PR DESCRIPTION
Adjusts the href for the return to top button on `/g-cloud/services/<service id>`