### PR TITLE
Update content for search G-Cloud services journey

### DIFF
--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -121,7 +121,7 @@ class TellUsAboutContractForm(FlaskForm):
 
 class WhyDidYouNotAwardForm(FlaskForm):
     why_did_you_not_award_the_contract = DMRadioField(
-        "Why didn't you award a contract?",
+        "Why didn’t you award a contract?",
         options=[
             {
                 "label": "The work has been cancelled",
@@ -140,8 +140,8 @@ class WhyDidYouNotAwardForm(FlaskForm):
 
 class BeforeYouDownloadForm(FlaskForm):
     user_understands = DMBooleanField(
-        "I understand that I cannot edit my search again after I export my results",
+        "I understand that I cannot edit my search after I export my results",
         validators=[
-            InputRequired(message="Confirm that you have finished editing your search")
+            InputRequired(message="Confirm that you’ve finished editing your search")
         ],
     )

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -23,6 +23,9 @@
       "href": url_for('direct_award.view_project', framework_family=framework.framework, project_id=project.id),
       "text": project.name
     },
+    {
+      "text": "Did you award a contract?"
+    }
   ]
 }) }}
 {% endblock breadcrumb %}

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -23,6 +23,9 @@
       "href": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
       "text": project.name
     },
+    {
+      "text": "Export your results"
+    }
   ]
 }) }}
 {% endblock breadcrumb %}

--- a/app/templates/direct-award/results.html
+++ b/app/templates/direct-award/results.html
@@ -23,6 +23,9 @@
       "href": url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id),
       "text": project.name
     },
+    {
+      "text": "Download your results"
+    }
   ]
 }) }}
 {% endblock breadcrumb %}

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -24,12 +24,7 @@
       "text": project.name
     },
     {
-      "href": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
-      "text": "Did you award a contract?"
-    },
-    {
-      "href": url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id),
-      "text": "Which service won the contract?"
+      "text": "Tell us about your contract"
     },
   ]
 }) }}

--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -23,6 +23,9 @@
         "href": url_for('direct_award.saved_search_overview', framework_family=framework.family),
         "text": "Your saved searches"
       },
+      {
+        "text": page_title
+      },
     ] if project else [
       {
         "text": page_title
@@ -121,7 +124,8 @@ Follow the <a href="https://www.gov.uk/guidance/g-cloud-buyers-guide#review-and-
               data-analytics="trackEvent"
               data-analytics-category="Direct Award"
               data-analytics-action="External Link">guidance for assessing services</a>. Choose the one that best meets
-your budget and requirements.Do not hold a competition to decide the winner. You can
+            your budget and requirements.'},
+            {"type": "text", "text": 'Do not hold a competition to decide the winner. You can
 <a href="https://www.gov.uk/guidance/g-cloud-buyers-guide#what-to-do-if-you-have-a-question-for-the-suppliers
    data-analytics="trackEvent"
    class="govuk-link"

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -24,8 +24,7 @@
       "text": project.name
     },
     {
-      "href": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
-      "text": "Did you award a contract?"
+      "text": "Which service won the contract?"
     },
   ]
 }) }}

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
-  Why didn't you award a contract? - Digital Marketplace
+  Why didn’t you award a contract? - Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -24,8 +24,7 @@
       "text": project.name
     },
     {
-      "href": url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id),
-      "text": "Did you award a contract?"
+      "text": "Why didn’t you award a contract?"
     },
   ]
 }) }}

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -20,6 +20,9 @@
       "href": url_for('.search_services', lot=lot.slug),
       "text": lot.name
     },
+    {
+    "text": service.title
+    }
   ]
 }) }}
 {% endblock breadcrumb %}

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -306,11 +306,13 @@ class TestDirectAwardProjectOverview(TestDirectAwardBase):
             "Digital Marketplace",
             "Your account",
             "Your saved searches",
+            "My procurement project <",
         )
         assert tuple(li.xpath(".//a/@href") for li in breadcrumbs) == (
             ["/"],
             ["/buyers"],
             ["/buyers/direct-award/g-cloud"],
+            [],
         )
 
     def test_overview_renders_specific_elements_for_no_search_state(self):


### PR DESCRIPTION
Ticket: https://trello.com/c/v6elozgK/25-2-high-level-content-review-of-pages-in-search-for-g-cloud-services-journey

Applies suggested content fixes from review by @noraGDS.

- Add final breadcrumb to G-Cloud service page template
- Update content for BeforeYouDownload form
- Split step 3 of search G-Cloud services task list into two paras
- Fix breadcrumbs for tell us about your contract flow
- Fix apostrophes on why didn't you award a contract page

---

#### Changes not made

- I didn't change the search page layout
- There are a couple of places where the form label (question heading)
  is the same as the page heading. We should make the form label into the
  page heading using the govuk-frontend components, when we've migrated
  the components to using govuk-frontend components.