### PR TITLE
Remove external link component

### DIFF
--- a/app/assets/scss/_service-page.scss
+++ b/app/assets/scss/_service-page.scss
@@ -65,10 +65,6 @@
   .framework-name {
     @extend %meta-item;
   }
-
-  .external-link-default {
-    @extend %meta-item;
-  }
 }
 
 .price {
@@ -77,17 +73,6 @@
 
   @include media(tablet) {
     margin-top: 0;
-  }
-}
-
-.price-caveats {
-  @include core-16;
-  color: $text-colour;
-  @extend %plain-list;
-  margin: 0 0 20px;
-
-  li {
-    margin-bottom: 5px;
   }
 }
 

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -1,5 +1,5 @@
 <div id="meta">
-  <h2 class="visuallyhidden">Pricing</h2>
+  <h2 class="govuk-visually-hidden">Pricing</h2>
   <p class="price">{{ service.meta.price }}</p>
   <ul class="govuk-list">
   {% for caveat in service.meta.priceCaveats %}
@@ -16,7 +16,7 @@
     </li>
   {% endfor %}
   </ul>
-  <h2 class="visuallyhidden">Service documents</h2>
+  <h2 class="govuk-visually-hidden">Service documents</h2>
   <ul class="govuk-list">
   {% for document in service.meta.documents %}
     <li class="govuk-!-margin-bottom-2">

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -27,14 +27,7 @@
   {% endfor %}
   </ul>
   <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Framework</h2>
-  {% if service.meta.externalFrameworkUrl is not none %}
-    <a href="{{ service.meta.externalFrameworkUrl }}"
-        class="govuk-link govuk-!-display-inline-block govuk-!-margin-bottom-6"
-        rel="external"
-    >{{ service.frameworkName }}</a>
-  {% else %}
-    <p class="framework-name">{{ service.frameworkName }}</p>
-  {% endif %}
+  <p class="framework-name">{{ service.frameworkName }}</p>
   <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Service ID</h2>
   {% for chunk in service.meta.serviceId -%}
   <span class="govuk-!-margin-bottom-6 {% if not loop.first %} govuk-!-padding-left-1 {% endif %} govuk-!-display-inline-block">{{chunk}}</span>

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -1,16 +1,15 @@
 <div id="meta">
   <h2 class="visuallyhidden">Pricing</h2>
   <p class="price">{{ service.meta.price }}</p>
-  <ul class="price-caveats">
+  <ul class="govuk-list">
   {% for caveat in service.meta.priceCaveats %}
     <li>
       {% if caveat['link'] %}
-        {% with text = caveat['text'],
-                link = caveat['link'],
-                target = "_blank"
-        %}
-          {% include "toolkit/external-link.html" %}
-        {% endwith %}
+        <a href="{{ caveat['link'] }}"
+           class="govuk-link"
+           rel="external noopener noreferrer"
+           target="_blank"
+        >{{ caveat['text'] }}</a>
       {% else %}
         {{ caveat['text'] }}
       {% endif %}
@@ -29,12 +28,10 @@
   </ul>
   <h2 class="sidebar-heading">Framework</h2>
   {% if service.meta.externalFrameworkUrl is not none %}
-    {%
-      with
-      text=service.frameworkName,
-      link=service.meta.externalFrameworkUrl %}
-      {% include "toolkit/external-link.html" %}
-    {% endwith %}
+    <a href="{{ service.meta.externalFrameworkUrl }}"
+        class="govuk-link govuk-!-display-inline-block govuk-!-margin-bottom-6"
+        rel="external"
+    >{{ service.frameworkName }}</a>
   {% else %}
     <p class="framework-name">{{ service.frameworkName }}</p>
   {% endif %}

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -26,7 +26,7 @@
     </li>
   {% endfor %}
   </ul>
-  <h2 class="sidebar-heading">Framework</h2>
+  <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Framework</h2>
   {% if service.meta.externalFrameworkUrl is not none %}
     <a href="{{ service.meta.externalFrameworkUrl }}"
         class="govuk-link govuk-!-display-inline-block govuk-!-margin-bottom-6"
@@ -35,11 +35,11 @@
   {% else %}
     <p class="framework-name">{{ service.frameworkName }}</p>
   {% endif %}
-  <h2 class="sidebar-heading">Service ID</h2>
+  <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Service ID</h2>
   {% for chunk in service.meta.serviceId -%}
   <span class="govuk-!-margin-bottom-6 {% if not loop.first %} govuk-!-padding-left-1 {% endif %} govuk-!-display-inline-block">{{chunk}}</span>
   {%- endfor %}
-  <h2 class="sidebar-heading">Contact</h2>
+  <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Contact</h2>
   {%
     with
     organisation_type="supplier",


### PR DESCRIPTION
https://trello.com/c/uXuR0W1j/30-1-remove-external-link-component-from-buyer-frontend

This component was used twice in the service meta information.

While I was on this template file, I've also done a quick pass and updated the `.visuallyhidden` and `sidebar-heading` classes with govuk frontend classes.