### PR TITLE
Update service meta block template

### DIFF
--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -16,7 +16,7 @@
     </li>
   {% endfor %}
   </ul>
-  <h2 class="govuk-visually-hidden">Service documents</h2>
+  <h2>Service documents</h2>
   <ul class="govuk-list">
   {% for document in service.meta.documents %}
     <li class="govuk-!-margin-bottom-2">
@@ -29,9 +29,12 @@
   <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Framework</h2>
   <p class="framework-name">{{ service.frameworkName }}</p>
   <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Service ID</h2>
-  {% for chunk in service.meta.serviceId -%}
-  <span class="govuk-!-margin-bottom-6 {% if not loop.first %} govuk-!-padding-left-1 {% endif %} govuk-!-display-inline-block">{{chunk}}</span>
-  {%- endfor %}
+  <p class="govuk-visually-hidden">{{ (service.meta.serviceId|join(''))|join(' ') }}</p>
+  <p aria-hidden="true">
+    {% for chunk in service.meta.serviceId -%}
+    <span class="{% if not loop.first %} govuk-!-padding-left-1 {% endif %}">{{chunk}}</span>
+    {%- endfor %}
+  </p>
   <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Contact</h2>
   {%
     with


### PR DESCRIPTION
1. I've made the "service documents" h2 visible - I think it looks better and it's useful to sighted and non-sighted users.
2. I've adjusted the service ID section to try and make it work better with screenreaders. I've tested with ChromeVox and VoiceOver and both seem to read the service ID more like a series of digits now, rather than 4 sets of numbers.