### PR TITLE
Replace validation banner with GOV.UK Frontend error summary component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/clear-filters.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
-//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/validation.js
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/govuk-frontend/all.js
 //= require ../../../node_modules/digitalmarketplace-govuk-frontend/digitalmarketplace/digitalmarketplace-govuk-frontend.js
 //= require ../../../node_modules/govuk_frontend_toolkit/javascripts/govuk/selection-buttons.js

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -86,6 +86,7 @@ class TellUsAboutContractForm(FlaskForm):
 
     start_date = DMDateField(
         "Start date",
+        id="input-start_date-day",
         validators=[
             InputRequired("Enter the start date"),
             DataRequired("Enter the full start date of your contract"),
@@ -94,6 +95,7 @@ class TellUsAboutContractForm(FlaskForm):
 
     end_date = DMDateField(
         "End date",
+        id="input-end_date-day",
         validators=[
             InputRequired("Enter the end date"),
             DataRequired("Enter the full end date of your contract"),

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -11,7 +11,7 @@ from dmapiclient import HTTPError
 from dmcontent.formats import format_service_price
 from dmcontent.questions import Pricing
 from dmutils.flask import timed_render_template as render_template
-from dmutils.forms.helpers import get_errors_from_wtform
+from dmutils.forms.errors import get_errors_from_wtform, govuk_errors
 from dmutils.formats import dateformat, DATETIME_FORMAT, datetimeformat
 from dmutils.filters import capitalize_first
 from dmutils.ods import A as AnchorElement
@@ -118,12 +118,14 @@ def choose_lot(framework_family):
                 return redirect(url_for("main.search_services"))
         else:
             errors["lot"] = {
+                "input_name": "lot",
+                "href": "#input-lot-1",
                 "question": "Choose a category",
-                "message": "Select a category to start your search"
+                "message": "Select a category to start your search",
             }
 
     return render_template('choose-lot.html',
-                           errors=errors,
+                           errors=govuk_errors(errors),
                            framework_family=framework_family,
                            title="Choose a category",
                            lots=lots)

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -4,6 +4,7 @@
 
 {% from "components/button/macro.njk" import govukButton %}
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk-frontend/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {# Import DM Components #}
@@ -41,6 +42,14 @@
 
 {% block content %}
   {% include "toolkit/flash_messages.html" %}
+  {% block errorSummary %}
+    {% if errors %}
+      {{ govukErrorSummary({
+      "titleText": "There is a problem",
+      "errorList": errors.values(),
+    }) }}
+    {% endif %}
+  {% endblock %}
   {% block mainContent %}{% endblock %}
 {% endblock %}
 

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -32,7 +32,6 @@
 
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 
 <div class="did-you-award-contract-page">
   <div class="govuk-grid-row">

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -31,16 +31,6 @@
 {% endblock breadcrumb %}
 
 {% block mainContent %}
-{% if errors %}
-  <div class="validation-masthead" aria-labelledby="validation-masthead-heading" aria-role="group" tabindex="-1">
-    <p>
-      You need to <a href="#{{ form.user_understands.id }}">confirm that you’ve finished editing your search</a> before you
-      export your results.
-    </p>
-  </div>
-{% endif %}
-
-
 <div class="end-search-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds dmspeak">

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -28,27 +28,6 @@
 
 <div class="single-question-page save-search-page">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        {% if errors %}
-        <div class="error-summary" role="alert" aria-labelledby="saving-search-error" tabindex="-1">
-
-          <div class="dmspeak">
-            <h2 class="heading-xmedium">There was a problem saving your search</h2>
-          </div>
-
-          <ul class="error-summary-list">
-            {% for error in errors.values() %}
-              <li>
-                <a href="#{{ error.input_name }}-error">{{ error.message }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-
-        </div>
-        {% endif %}
-    </div>
-  </div>
-  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
         {{ page_name }}

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -29,10 +29,6 @@
 <div class="single-question-page save-search-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        {#
-          we cannot use the toolkit/forms/validation.html template here,
-          as this page was designed with a govuk style error summary banner
-        #}
         {% if errors %}
         <div class="error-summary" role="alert" aria-labelledby="saving-search-error" tabindex="-1">
 

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -32,8 +32,6 @@
 
 {% block mainContent %}
 
-{% include "toolkit/forms/validation.html" %}
-
 <div class="tell-us-about-contract-page">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -31,7 +31,6 @@
 {% endblock breadcrumb %}
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 
 <div class="which-service-won-contract-page">
   <div class="govuk-grid-row">

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -31,7 +31,6 @@
 {% endblock breadcrumb %}
 
 {% block mainContent %}
-{% include "toolkit/forms/validation.html" %}
 
 <div class="why-didnt-you-award-contract-page">
   <div class="govuk-grid-row">

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 lxml==4.5.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.4.0#egg=digitalmarketplace-utils==52.4.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.8.1#egg=digitalmarketplace-content-loader==7.8.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.8.1#egg=digitalmarketplace-content-loader==7.8.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.4.0#egg=digitalmarketplace-utils==52.4.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-gzip==0.2           # via digitalmarketplace-utils

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -786,8 +786,9 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
 
         doc = html.fromstring(res.get_data(as_text=True))
         assert len(doc.xpath('//legend[contains(normalize-space(), "Select if you have awarded your contract")]')) == 1
-        assert doc.xpath('boolean(//div[@class="validation-masthead"])')
-        assert doc.xpath('count(//div[@class="validation-masthead"]/a[@class="validation-masthead-link"])') == 1
+        errors = doc.cssselect('div.govuk-error-summary a')
+        assert len(errors) == 1
+        assert errors[0].text_content() == 'Select if you have awarded your contract'
 
     @pytest.mark.parametrize('choice, expected_redirect',
                              (('still-assessing', '/buyers/direct-award/g-cloud/projects/1'),

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -158,10 +158,13 @@ class TestDirectAward(TestDirectAwardBase):
 
     def _asserts_for_create_project_failure(self, res):
         assert res.status_code == 400
-        html = res.get_data(as_text=True)
-        assert self.SEARCH_API_URL not in html  # it was once, so let's check
-        assert self.SIMPLE_SEARCH_PARAMS in html
-        assert "Search name must be between 1 and 100 characters" in html
+        doc = res.get_data(as_text=True)
+        assert self.SEARCH_API_URL not in doc  # it was once, so let's check
+        assert self.SIMPLE_SEARCH_PARAMS in doc
+        errors = html.fromstring(doc)
+        assert len(errors.cssselect("div.govuk-error-summary a")) == 1
+        assert errors.cssselect("div.govuk-error-summary a")[0].text_content() == \
+            "Search name must be between 1 and 100 characters"
 
     def test_save_search_submit_success(self):
         res = self._save_search('some name " foo bar \u2016')


### PR DESCRIPTION
trello: https://trello.com/c/u5CoMrCP/19-1-replace-validation-banner-with-govuk-frontend-error-summary-component-in-the-buyer-frontend

There are two templates in `direct-award` (`which-service-won-contract` and `why-didnt-you-award-contract`) that don't have unit tests that verify that the errors context variable is rendered within a specific DOM container.