### PR TITLE
Remove get_external_framework_url from service presenters

### DIFF
--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -3,8 +3,6 @@ import re
 from collections import OrderedDict
 from urllib.parse import unquote, urlparse
 
-from app import content_loader
-from dmcontent.errors import ContentNotFoundError
 from dmcontent.formats import format_service_price
 
 DECLARATION_DOCUMENT_KEYS = [
@@ -61,7 +59,6 @@ class Meta(object):
         self.serviceId = self.get_service_id(service_data)
         self.declaration = declaration or {}
         self.documents = self.get_documents(service_data)
-        self.externalFrameworkUrl = self.get_external_framework_url(service_data)
 
     def set_contact_attribute(self, contactName, phone, email):
         self.contact = {
@@ -76,18 +73,6 @@ class Meta(object):
             return [id]
         else:
             return list(chunk_string(str(id), 4))
-
-    def get_external_framework_url(self, service_data):
-        try:
-            content_loader.load_messages(service_data['frameworkSlug'], ['urls'])
-            return content_loader.get_message(
-                service_data['frameworkSlug'],
-                'urls',
-                'framework_url'
-            ) or None
-        except ContentNotFoundError:
-            # If no urls.yml exists then we don't have a URL for the framework
-            return None
 
     def _add_declaration_documents_to_service_data(self, service_data):
         # Check if the supplier has provided a declaration document, and add it to the service data.

--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -122,14 +122,16 @@ class Meta(object):
         caveats = []
         main_caveats = [
             {
-                'key': 'vatIncluded',
-                'if_exists': 'Including VAT',
-                'if_absent': 'Excluding VAT'
-            },
-            {
                 'key': 'educationPricing',
                 'if_exists': 'Education pricing available',
                 'if_absent': False
+            }
+        ]
+        g8_and_earlier_caveats = [
+            {
+                'key': 'vatIncluded',
+                'if_exists': 'Including VAT',
+                'if_absent': 'Excluding VAT'
             },
             {
                 'key': 'terminationCost',
@@ -139,12 +141,14 @@ class Meta(object):
         ]
 
         if 'minimumContractPeriod' in service_data:
+            # G-Cloud 8 and earlier
             caveats.append(make_caveat('Minimum contract period: {}'.format(service_data['minimumContractPeriod'])))
 
         if service_data.get('freeVersionTrialOption') is True:
             options = make_caveat('Free trial available', service_data.get('freeVersionLink'))
 
         else:
+            # G-Cloud 8 and earlier
             options = self._if_both_keys_or_either(
                 service_data,
                 keys=['trialOption', 'freeOption'],
@@ -157,7 +161,8 @@ class Meta(object):
             )
             options = make_caveat(options) if options else options
 
-        for item in main_caveats:
+        for item in main_caveats + g8_and_earlier_caveats:
+            # 'vatIncluded' and 'terminationCost' only displayed for services on G8 and earlier
             if item['key'] in service_data:
                 if service_data[item['key']]:
                     caveats.append(make_caveat(item['if_exists']))

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -129,13 +129,6 @@ class TestMeta:
         assert self.meta.get_service_id({'id': 123456789012345}) == ['1234', '5678', '9012', '345']
         assert self.meta.get_service_id({'id': '5-G4-1046-001'}) == ['5-G4-1046-001']
 
-    def test_external_framework_url_returns_correct_suffix(self):
-        assert self.meta.get_external_framework_url({'frameworkSlug': 'g-cloud-7'}) == (
-            'http://ccs-agreements.cabinetoffice.gov.uk/contracts/rm1557vii'
-        )
-        assert self.meta.get_external_framework_url({'frameworkSlug': 'g-cloud-6'}) is None
-        assert self.meta.get_external_framework_url({'frameworkSlug': 'None'}) is None
-
     def test_get_documents_returns_the_correct_document_information(self):
         expected_information = [
             {


### PR DESCRIPTION
https://trello.com/c/CXGExCLO/55-3-replace-summary-table-with-summary-list-on-g-cloud-service-page-and-dos-opportunity-page

We removed the `get_external_framework_url` template logic in https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/1035 (it's not been used since G-Cloud 7 and that link now 404s). This means we can also remove the service presenter method that derives it from the content loader instance, which means we don't need to use the content loader at all in this module 🎉 

I also added some comments to make it clear which attributes are for older services, in case we decide to refactor in future (or find ourselves wondering why we can't find those attributes on our modern services). The tests still rely on a G-Cloud 6 fixture, but it's definitely out of scope of this PR to update those.