### PR TITLE
Replace summary table with summary list on G-Cloud Service and DOS Opportunity pages

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -82,6 +82,7 @@ $govuk-global-styles: true;
 // Overrides
 @import "overrides/_notification-banners.scss";
 @import "overrides/_temporary-messages.scss";
+@import "overrides/_summary-list.scss";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_summary-list.scss
+++ b/app/assets/scss/overrides/_summary-list.scss
@@ -1,0 +1,7 @@
+.app-govuk-summary-list--top-border {
+    border-top: 1px solid $govuk-border-colour;
+
+    @include govuk-media-query($until: tablet) {
+        padding-top: govuk-spacing(3)
+    }
+}

--- a/app/assets/scss/overrides/_summary-list.scss
+++ b/app/assets/scss/overrides/_summary-list.scss
@@ -1,7 +1,20 @@
+/*
+ * A top border more clearly delineates the multiple data lists per page
+ * from their headings and other context.
+ */
 .app-govuk-summary-list--top-border {
     border-top: 1px solid $govuk-border-colour;
 
     @include govuk-media-query($until: tablet) {
         padding-top: govuk-spacing(3)
+    }
+}
+/*
+ * We de-bold the questions to avoid bombarding users with emphasised text
+ * and to help the headings stand out.
+ */
+.app-govuk-summary-list .govuk-summary-list__key {
+    @include govuk-media-query($from: tablet) {
+        font-weight: $govuk-font-weight-regular;
     }
 }

--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from urllib.parse import unquote, urlparse
 
 from dmcontent.formats import format_service_price
+from dmcontent.html import to_summary_list_rows
 
 DECLARATION_DOCUMENT_KEYS = [
     ('modernSlaveryStatement', 'modernSlaveryStatementURL'),
@@ -29,6 +30,9 @@ class Service(object):
 
     def __init__(self, service_data, manifest, lots_by_slug, declaration=None):
         self.summary_manifest = manifest.summary(service_data)
+        # get attributes in format suitable for govukSummaryList
+        for section in self.summary_manifest:
+            section.summary_list = to_summary_list_rows(section.questions)
         # required attributes directly mapped to service_data values
         self.title = service_data['serviceName']
         self.serviceSummary = service_data.get('serviceSummary', service_data.get('serviceDescription'))

--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -32,7 +32,7 @@ class Service(object):
         self.summary_manifest = manifest.summary(service_data)
         # get attributes in format suitable for govukSummaryList
         for section in self.summary_manifest:
-            section.summary_list = to_summary_list_rows(section.questions)
+            section.summary_list = to_summary_list_rows(section.questions, preserve_line_breaks=True)
         # required attributes directly mapped to service_data values
         self.title = service_data['serviceName']
         self.serviceSummary = service_data.get('serviceSummary', service_data.get('serviceDescription'))

--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -32,7 +32,7 @@ class Service(object):
         self.summary_manifest = manifest.summary(service_data)
         # get attributes in format suitable for govukSummaryList
         for section in self.summary_manifest:
-            section.summary_list = to_summary_list_rows(section.questions, preserve_line_breaks=True)
+            section.summary_list = to_summary_list_rows(section.questions, capitalize_first=True)
         # required attributes directly mapped to service_data values
         self.title = service_data['serviceName']
         self.serviceSummary = service_data.get('serviceSummary', service_data.get('serviceDescription'))

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -1,44 +1,38 @@
-{% import "toolkit/summary-table.html" as summary %}
-{% call(item) summary.list_table(
-  [
-    {"label": "Published", "value": brief.publishedAt|dateformat},
-    {"label": "Deadline for asking questions", "value": brief.clarificationQuestionsClosedAt|utcdatetimeformat},
-    {"label": "Closing date for applications", "value": brief.applicationsClosedAt|utcdatetimeformat}
+{% from "govuk-frontend/components/summary-list/macro.njk" import govukSummaryList %}
+
+<h2 class="govuk-visually-hidden">Important dates</h2>
+{{ govukSummaryList({
+  "rows": [
+    {
+      "key": {"text": "Published"},
+      "value": {"text": brief.publishedAt|dateformat}
+    },
+    {
+      "key": {"text": "Deadline for asking questions"},
+      "value": {"text": brief.clarificationQuestionsClosedAt|utcdatetimeformat}
+    },
+    {
+      "key": {"text": "Closing date for applications"},
+      "value": {"text": brief.applicationsClosedAt|utcdatetimeformat}
+    }
   ],
-  caption="Important dates",
-  field_headings=[
-    "Opportunity attribute name",
-    "Opportunity attribute value"
-  ],
-  field_headings_visible=False
-) %}
-  {% call summary.row() %}
-    {{ summary.field_name(item.label) }}
-    {{ summary.text(item.value) }}
-  {% endcall %}
-{% endcall %}
-{% for section in content.summary(brief) %}
-    {{ summary.heading(section.name, id="opportunity-attributes-{}".format(loop.index)) }}
-     {% if section.summary_page_description %}
-        <p>{{ summary.description(section.summary_page_description) }}</p>
-     {# DISPLAY MANDATORY EVALUATION METHODS #}
-     {% elif section.name == 'How suppliers will be evaluated' and evaluation_description %}
-        <p>{{ evaluation_description }}</p>
-     {% endif %}
-    {% call(item) summary.list_table(
-      section.questions,
-      caption=section.name,
-      field_headings=[
-        "Opportunity attribute name",
-        "Opportunity attribute value"
-      ],
-      field_headings_visible=False
-    ) %}
-      {% call summary.row() %}
-        {{ summary.field_name(item.label) }}
-        {% with item_value = summary[item.type](item.value) | format_links %}
-            {{ (item_value | preserve_line_breaks) if item.type == 'textbox_large' else item_value }}
-        {% endwith %}
-      {% endcall %}
-    {% endcall %}
+  "attributes": {
+    "id": "opportunity-important-dates"
+  }, 
+  "classes": 'app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
+}) }}
+
+{% for section in brief_content_summary %}
+  <h2 id="{{ 'opportunity-attributes-{}'.format(loop.index) }}" class="govuk-heading-m govuk-!-font-size-27">{{ section.name }}</h2>
+  {% if section.summary_page_description %}
+  <p class="govuk-body govuk-!-margin-top-3">{{ section.summary_page_description }}</p>
+  {# DISPLAY MANDATORY EVALUATION METHODS #}
+  {% elif section.name == 'How suppliers will be evaluated' and evaluation_description %}
+  <p class="govuk-body govuk-!-margin-top-3">{{ evaluation_description }}</p>
+  {% endif %}
+  {{ govukSummaryList({
+    "rows": section.summary_list, 
+    "classes": 'app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
+    }) 
+  }}
 {% endfor %}

--- a/app/templates/_brief_attributes.html
+++ b/app/templates/_brief_attributes.html
@@ -19,11 +19,11 @@
   "attributes": {
     "id": "opportunity-important-dates"
   }, 
-  "classes": 'app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
+  "classes": 'app-govuk-summary-list app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
 }) }}
 
 {% for section in brief_content_summary %}
-  <h2 id="{{ 'opportunity-attributes-{}'.format(loop.index) }}" class="govuk-heading-m govuk-!-font-size-27">{{ section.name }}</h2>
+  <h2 id="{{ 'opportunity-attributes-{}'.format(loop.index) }}" class="govuk-heading-m">{{ section.name }}</h2>
   {% if section.summary_page_description %}
   <p class="govuk-body govuk-!-margin-top-3">{{ section.summary_page_description }}</p>
   {# DISPLAY MANDATORY EVALUATION METHODS #}
@@ -32,7 +32,7 @@
   {% endif %}
   {{ govukSummaryList({
     "rows": section.summary_list, 
-    "classes": 'app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
+    "classes": 'app-govuk-summary-list app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
     }) 
   }}
 {% endfor %}

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -1,7 +1,7 @@
-{% import "toolkit/summary-table.html" as summary %}
+{% from "govuk-frontend/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% if brief.status == 'live' and not brief.clarificationQuestionsAreClosed and brief.questionAndAnswerSessionDetails %}
-  {{ summary.heading("Question and answer session", id="question-and-answer-session") }}
+  <h2 id="question-and-answer-session" class="govuk-heading-m govuk-!-font-size-27">Question and answer session</h2>
   <a class="govuk-link" href="/suppliers/opportunities/{{ brief.id }}/question-and-answer-session">
     {% if current_user.is_authenticated and current_user.role == 'supplier' %}
       View question and answer session details
@@ -11,25 +11,16 @@
   </a>
 {% endif %}
 
-{{ summary.heading("Questions asked by suppliers", id="clarification-questions") }}
-{% call(question) summary.list_table(
-  brief.clarificationQuestions,
-  caption="Questions asked by suppliers",
-  field_headings=[
-    "Supplier question",
-    "Buyer answer"
-    ],
-    field_headings_visible=False,
-    empty_message="No questions have been answered yet"
-) %}
-  {% call summary.row() %}
-    {% call summary.field(first=True, wide=False) -%}
-      <span aria-label="question">{{ question.number }}.</span>
-      {{ question.question | format_links | preserve_line_breaks }}
-    {%- endcall %}
-    {{ summary.text(question.answer | format_links | preserve_line_breaks) }}
-  {% endcall %}
-{% endcall %}
+<h2 id="clarification-questions" class="govuk-heading-m govuk-!-font-size-27">Questions asked by suppliers</h2>
+{% if brief.clarificationQuestions is undefined or brief.clarificationQuestions|length == 0 %} 
+<p class="summary-item-no-content">No questions have been answered yet</p>
+{% else %}
+{{ govukSummaryList({
+    "rows": brief.clarificationQuestions, 
+    "classes": 'app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
+  }) 
+}}
+{% endif %}
 
 {% if brief.status == 'live' and not brief.clarificationQuestionsAreClosed %}
   <a class="govuk-link" href="/suppliers/opportunities/{{ brief.id }}/ask-a-question">

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -1,7 +1,7 @@
 {% from "govuk-frontend/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% if brief.status == 'live' and not brief.clarificationQuestionsAreClosed and brief.questionAndAnswerSessionDetails %}
-  <h2 id="question-and-answer-session" class="govuk-heading-m govuk-!-font-size-27">Question and answer session</h2>
+  <h2 id="question-and-answer-session" class="govuk-heading-m">Question and answer session</h2>
   <a class="govuk-link" href="/suppliers/opportunities/{{ brief.id }}/question-and-answer-session">
     {% if current_user.is_authenticated and current_user.role == 'supplier' %}
       View question and answer session details
@@ -11,13 +11,13 @@
   </a>
 {% endif %}
 
-<h2 id="clarification-questions" class="govuk-heading-m govuk-!-font-size-27">Questions asked by suppliers</h2>
+<h2 id="clarification-questions" class="govuk-heading-m">Questions asked by suppliers</h2>
 {% if brief.clarificationQuestions is undefined or brief.clarificationQuestions|length == 0 %} 
 <p class="summary-item-no-content">No questions have been answered yet</p>
 {% else %}
 {{ govukSummaryList({
     "rows": brief.clarificationQuestions, 
-    "classes": 'app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
+    "classes": 'app-govuk-summary-list app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
   }) 
 }}
 {% endif %}

--- a/app/templates/_service_attributes.html
+++ b/app/templates/_service_attributes.html
@@ -7,10 +7,10 @@
     {% else %}
     <div class="scroll-tracking" id="{{ loop.index }}-{{ section.slug }}">
     {% endif %}
-      <h2 id="{{ section.slug }}" class="govuk-heading-m govuk-!-font-size-27">{{ section.name }}</h2>
+      <h2 id="{{ section.slug }}" class="govuk-heading-m">{{ section.name }}</h2>
       {{ govukSummaryList({
         "rows": section.summary_list, 
-        "classes": 'app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
+        "classes": 'app-govuk-summary-list app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
         }) 
       }}
     </div>

--- a/app/templates/_service_attributes.html
+++ b/app/templates/_service_attributes.html
@@ -1,28 +1,18 @@
-{% import "toolkit/summary-table.html" as summary %}
+{% from "govuk-frontend/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% for section in service.summary_manifest %}
   {% if not section.is_empty %}
     {% if loop.index < 10 %}
-      <div class="scroll-tracking" id="0{{ loop.index }}-{{ section.slug }}">
+    <div class="scroll-tracking" id="0{{ loop.index }}-{{ section.slug }}">
     {% else %}
-      <div class="scroll-tracking" id="{{ loop.index }}-{{ section.slug }}">
+    <div class="scroll-tracking" id="{{ loop.index }}-{{ section.slug }}">
     {% endif %}
-      {{ summary.heading(section.name, id=section.slug) }}
-
-      {% call(question) summary.list_table(
-        section.questions,
-        caption=section.name,
-        field_headings_visible=False
-      ) %}
-        {% if not question.is_empty %}
-          {% call summary.row() %}
-            {{ summary.field_name(question.label) }}
-            {% with item_value = summary[question.type](question.filter_value|capitalize_first, question.assurance) %}
-              {{ (item_value | preserve_line_breaks) if question.type == 'textbox_large' else item_value }}
-            {% endwith %}
-          {% endcall %}
-        {% endif %}
-      {% endcall %}
+      <h2 id="{{ section.slug }}" class="govuk-heading-m govuk-!-font-size-27">{{ section.name }}</h2>
+      {{ govukSummaryList({
+        "rows": section.summary_list, 
+        "classes": 'app-govuk-summary-list--top-border govuk-!-margin-bottom-8'
+        }) 
+      }}
     </div>
   {% endif %}
 {% endfor %}

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -65,7 +65,7 @@
     <h1 class="govuk-heading-l">{{ service.title }}</h1>
   </div>
 </div>
-<div class="govuk-grid-row">
+<div class="govuk-grid-row govuk-!-margin-bottom-9">
   <div class="govuk-grid-column-two-thirds">
     {% include '_service_summary_features_and_benefits.html' %}
   </div>

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,6 @@ itsdangerous==1.1.0
 lxml==4.5.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.6.2#egg=digitalmarketplace-content-loader==7.6.2
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.6.2#egg=digitalmarketplace-content-loader==7.6.2  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -549,19 +549,19 @@ class TestBriefPage(BaseBriefPageTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         brief_important_dates = document.xpath(
-            '(//table[@class="summary-item-body"])[1]/tbody/tr')
+            '(//dl[@id="opportunity-important-dates"]//div)')
         assert 3 == len(brief_important_dates)
-        assert brief_important_dates[0].xpath('td[@class="summary-item-field-first"]')[0].text_content().strip() \
+        assert brief_important_dates[0].xpath('dt')[0].text_content().strip() \
             == "Published"
-        assert brief_important_dates[0].xpath('td[@class="summary-item-field"]')[0].text_content().strip() \
+        assert brief_important_dates[0].xpath('dd')[0].text_content().strip() \
             == "Thursday 1 December 2016"
-        assert brief_important_dates[1].xpath('td[@class="summary-item-field-first"]')[0].text_content().strip() \
+        assert brief_important_dates[1].xpath('dt')[0].text_content().strip() \
             == "Deadline for asking questions"
-        assert brief_important_dates[1].xpath('td[@class="summary-item-field"]')[0].text_content().strip() \
+        assert brief_important_dates[1].xpath('dd')[0].text_content().strip() \
             == "Wednesday 14 December 2016 at 11:08am GMT"
-        assert brief_important_dates[2].xpath('td[@class="summary-item-field-first"]')[0].text_content().strip() \
+        assert brief_important_dates[2].xpath('dt')[0].text_content().strip() \
             == "Closing date for applications"
-        assert brief_important_dates[2].xpath('td[@class="summary-item-field"]')[0].text_content().strip() \
+        assert brief_important_dates[2].xpath('dd')[0].text_content().strip() \
             == "Thursday 15 December 2016 at 11:08am GMT"
 
     def test_dos_brief_with_daylight_savings_has_question_deadline_closing_date_forced_to_utc(self):
@@ -575,15 +575,15 @@ class TestBriefPage(BaseBriefPageTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         brief_important_dates = document.xpath(
-            '(//table[@class="summary-item-body"])[1]/tbody/tr')
+            '(//dl[@id="opportunity-important-dates"]//div)')
         assert 3 == len(brief_important_dates)
         # Publish date does not have UTC filter applied
-        assert brief_important_dates[0].xpath('td[@class="summary-item-field"]')[0].text_content().strip() \
+        assert brief_important_dates[0].xpath('dd')[0].text_content().strip() \
             == "Monday 1 August 2016"
         # Question deadline and closing date are forced to 11.59pm (UTC+00) on the correct day
-        assert brief_important_dates[1].xpath('td[@class="summary-item-field"]')[0].text_content().strip() \
+        assert brief_important_dates[1].xpath('dd')[0].text_content().strip() \
             == "Sunday 14 August 2016 at 11:59pm GMT"
-        assert brief_important_dates[2].xpath('td[@class="summary-item-field"]')[0].text_content().strip() \
+        assert brief_important_dates[2].xpath('dd')[0].text_content().strip() \
             == "Monday 15 August 2016 at 11:59pm GMT"
 
     def test_dos_brief_has_at_least_one_section(self):
@@ -593,21 +593,20 @@ class TestBriefPage(BaseBriefPageTest):
 
         document = html.fromstring(res.get_data(as_text=True))
 
-        section_heading = document.xpath('//h2[@class="summary-item-heading"]')[0]
-        section_attributes = section_heading.xpath('following-sibling::table[1]/tbody/tr')
+        section_heading = document.xpath('//h2[@id="opportunity-attributes-1"]')[0]
+        section_attributes = section_heading.xpath('following-sibling::dl[1]/div')
 
-        start_date_key = section_attributes[2].xpath('td[1]/span/text()')
-        start_date_value = section_attributes[2].xpath('td[2]/span/text()')
+        start_date_key = section_attributes[2].xpath('dt/text()')
+        start_date_value = section_attributes[2].xpath('dd/text()')
 
-        contract_length_key = section_attributes[3].xpath('td[1]/span/text()')
-        contract_length_value = section_attributes[3].xpath('td[2]/span/text()')
+        contract_length_key = section_attributes[3].xpath('dt/text()')
+        contract_length_value = section_attributes[3].xpath('dd/text()')
 
-        assert section_heading.get('id') == 'opportunity-attributes-1'
         assert section_heading.text.strip() == 'Overview'
-        assert start_date_key[0] == 'Latest start date'
-        assert start_date_value[0] == 'Wednesday 1 March 2017'
-        assert contract_length_key[0] == 'Expected contract length'
-        assert contract_length_value[0] == '4 weeks'
+        assert start_date_key[0].strip() == 'Latest start date'
+        assert start_date_value[0].strip() == 'Wednesday 1 March 2017'
+        assert contract_length_key[0].strip() == 'Expected contract length'
+        assert contract_length_value[0].strip() == '4 weeks'
 
     @pytest.mark.parametrize(
         'lot_slug, assessment_type', [
@@ -631,7 +630,7 @@ class TestBriefPage(BaseBriefPageTest):
 
         document = html.fromstring(res.get_data(as_text=True))
         section_heading = document.xpath(
-            '//h2[@class="summary-item-heading"][contains(text(), "How suppliers will be evaluated")]'
+            '//h2[contains(text(), "How suppliers will be evaluated")]'
         )[0]
         section_description = section_heading.xpath('following-sibling::p')[0]
         assert section_description.text.strip() == f'All suppliers will be asked to provide a {assessment_type}.'
@@ -643,15 +642,14 @@ class TestBriefPage(BaseBriefPageTest):
 
         document = html.fromstring(res.get_data(as_text=True))
 
-        xpath = '//h2[@id="clarification-questions"]/following-sibling::table/tbody/tr'
+        xpath = '//h2[@id="clarification-questions"]/following-sibling::dl/div'
         clarification_questions = document.xpath(xpath)
 
-        number = clarification_questions[0].xpath('td[1]/span/span/text()')[0].strip()
-        question = clarification_questions[0].xpath('td[1]/span/text()')[0].strip()
-        answer = clarification_questions[0].xpath('td[2]/span/text()')[0].strip()
+        question = clarification_questions[0].xpath('dt')[0].text_content().strip()
+        answer = clarification_questions[0].xpath('dd')[0].text_content().strip()
 
-        assert number == "1."
-        assert question == "Why?"
+        assert question.startswith("1.")
+        assert question.endswith("Why?")
         assert answer == "Because"
 
     def test_can_apply_to_live_brief(self):


### PR DESCRIPTION
https://trello.com/c/CXGExCLO/55-3-replace-summary-table-with-summary-list-on-g-cloud-service-page-and-dos-opportunity-page

This update replaces `toolkit/summary-table` with the [GOV.UK Design System Summary List](https://design-system.service.gov.uk/components/summary-list/) on G-Cloud service pages (/g-cloud/services/<service_id>) and DOS Opportunity pages (/digital-outcomes-and-specialists/opportunities/<brief_id>).