### PR TITLE
Adds todo comment to remove app-break-link class

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -95,6 +95,10 @@ $govuk-global-styles: true;
   }
 }
 
+/*
+ * TODO: Remove this class once the Brief opportunity page and the Preview Brief opportunity page
+ * have been swapped from DM FE Toolkit summary tables to DS summary lists
+ */
 .app-break-link {
   display: inline-block;
   word-break: break-all;


### PR DESCRIPTION
This adds a TODO to remove the `app-break-link` class once the following two tickets are complete:

1. [Replace summary table on DOS opportunity page](https://trello.com/c/CXGExCLO/55-3-replace-summary-table-with-summary-list-on-g-cloud-service-page-and-dos-opportunity-page).
2. [Preview DOS opportunity before publishing](https://trello.com/c/BpDhnaYa/88-preview-dos-opportunity-before-publishing)