### PR TITLE
Replace statistics component with GOV.UK FE styles

### DIFF
--- a/app/assets/scss/_brief_page.scss
+++ b/app/assets/scss/_brief_page.scss
@@ -1,0 +1,5 @@
+.app-stat-block {
+    @include govuk-media-query($from: tablet) {
+        width: 30%;
+    }
+}

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -63,6 +63,7 @@ $govuk-global-styles: true;
 
 // App specific styles
 @import "_atoz_navigation.scss";
+@import "_brief_page.scss";
 @import "_end-your-search-page.scss";
 @import "_error-pages.scss";
 @import "_gcloud_browse_list.scss";

--- a/app/templates/_brief_applications_stats.html
+++ b/app/templates/_brief_applications_stats.html
@@ -1,22 +1,49 @@
-{% import "toolkit/statistics.html" as statistics %}
+<div class="govuk-grid-column-one-third app-stat-block" id="incomplete-applications">
+   <h2>
+      <span class="govuk-!-font-size-36 govuk-!-display-block">{{- brief_responses_stats.incomplete_responses_total }}</span>
+      <span>
+         {{- 
+            pluralize(
+               brief_responses_stats.incomplete_responses_total,
+               "Incomplete application",
+               "Incomplete applications"
+            ) 
+         -}}
+      </span>
+   </h2>
+   <p class="govuk-body govuk-!-font-size-16">
+      {%- if brief_responses_stats.incomplete_responses_total %}
+         {{- 
+            "%d SME, %d large" | format(
+               brief_responses_stats.incomplete_sme_responses,
+               brief_responses_stats.incomplete_large_responses
+            ) 
+         -}}
+      {% endif -%}
+   </p>
+</div>
+<div class="govuk-grid-column-one-third app-stat-block" id="completed-applications">
+   <h2>
+      <span class="govuk-!-font-size-36 govuk-!-display-block">{{- brief_responses_stats.completed_responses_total }}</span>
+      <span>
+         {{- 
+            pluralize(
+               brief_responses_stats.completed_responses_total,
+               "Completed application",
+               "Completed applications"
+            ) 
+         -}}
+      </span>
+   </h2>
+   <p class="govuk-body govuk-!-font-size-16">
+      {%- if brief_responses_stats.completed_responses_total %}
+         {{- 
+            "%d SME, %d large" | format(
+               brief_responses_stats.completed_sme_responses,
+               brief_responses_stats.completed_large_responses
+            ) 
+         -}}
+      {% endif -%}
+   </p>
+</div>
 
-{{ statistics.big_stat(
-     brief_responses_stats.incomplete_responses_total,
-     pluralize(brief_responses_stats.incomplete_responses_total, "Incomplete application", "Incomplete applications"),
-     "%d SME, %d large" | format(
-        brief_responses_stats.incomplete_sme_responses,
-        brief_responses_stats.incomplete_large_responses
-     ) if brief_responses_stats.incomplete_responses_total else None,
-     id="incomplete-applications"
-   )
-}}
-{{ statistics.big_stat(
-     brief_responses_stats.completed_responses_total,
-     pluralize(brief_responses_stats.completed_responses_total, "Completed application", "Completed applications"),
-     "%d SME, %d large" | format(
-     brief_responses_stats.completed_sme_responses,
-     brief_responses_stats.completed_large_responses
-     ) if brief_responses_stats.completed_responses_total else None,
-     id="completed-applications"
-   )
-}}

--- a/app/templates/brief.html
+++ b/app/templates/brief.html
@@ -106,10 +106,8 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    {% include '_brief_applications_stats.html' %}
-  </div>
+<div class="govuk-grid-row govuk-!-margin-bottom-9">
+  {% include '_brief_applications_stats.html' %}
 </div>
 
 <div class="govuk-grid-row">

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -462,13 +462,13 @@ class TestBriefPage(BaseBriefPageTest):
         incomplete_responses_section = document.xpath('//div[@id="incomplete-applications"]')[0]
         completed_responses_section = document.xpath('//div[@id="completed-applications"]')[0]
 
-        assert incomplete_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '3'
-        assert incomplete_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Incomplete applications"
-        assert incomplete_responses_section.xpath('div[@class="statistic-description"]/text()')[0] == "3 SME, 0 large"
+        assert incomplete_responses_section.xpath('h2//span[1]/text()')[0] == '3'
+        assert incomplete_responses_section.xpath('h2//span[2]/text()')[0] == "Incomplete applications"
+        assert incomplete_responses_section.xpath('p[1]/text()')[0] == "3 SME, 0 large"
 
-        assert completed_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '5'
-        assert completed_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Completed applications"
-        assert completed_responses_section.xpath('div[@class="statistic-description"]/text()')[0] == "4 SME, 1 large"
+        assert completed_responses_section.xpath('h2//span[1]/text()')[0] == '5'
+        assert completed_responses_section.xpath('h2//span[2]/text()')[0] == "Completed applications"
+        assert completed_responses_section.xpath('p[1]/text()')[0] == "4 SME, 1 large"
 
         self._assert_all_normal_api_calls()
 
@@ -504,13 +504,13 @@ class TestBriefPage(BaseBriefPageTest):
         incomplete_responses_section = document.xpath('//div[@id="incomplete-applications"]')[0]
         completed_responses_section = document.xpath('//div[@id="completed-applications"]')[0]
 
-        assert incomplete_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '1'
-        assert incomplete_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Incomplete application"
-        assert incomplete_responses_section.xpath('div[@class="statistic-description"]/text()')[0] == "1 SME, 0 large"
+        assert incomplete_responses_section.xpath('h2//span[1]/text()')[0] == '1'
+        assert incomplete_responses_section.xpath('h2//span[2]/text()')[0] == "Incomplete application"
+        assert incomplete_responses_section.xpath('p[1]/text()')[0] == "1 SME, 0 large"
 
-        assert completed_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '1'
-        assert completed_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Completed application"
-        assert completed_responses_section.xpath('div[@class="statistic-description"]/text()')[0] == "0 SME, 1 large"
+        assert completed_responses_section.xpath('h2//span[1]/text()')[0] == '1'
+        assert completed_responses_section.xpath('h2//span[2]/text()')[0] == "Completed application"
+        assert completed_responses_section.xpath('p[1]/text()')[0] == "0 SME, 1 large"
 
     def test_dos_brief_displays_application_stats_correctly_when_no_applications(self):
         brief_id = self.brief['briefs']['id']
@@ -522,12 +522,12 @@ class TestBriefPage(BaseBriefPageTest):
         incomplete_responses_section = document.xpath('//div[@id="incomplete-applications"]')[0]
         completed_responses_section = document.xpath('//div[@id="completed-applications"]')[0]
 
-        assert incomplete_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '0'
-        assert completed_responses_section.xpath('div[@class="big-statistic"]/text()')[0] == '0'
-        assert incomplete_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Incomplete applications"
-        assert completed_responses_section.xpath('div[@class="statistic-name"]/text()')[0] == "Completed applications"
-        assert len(incomplete_responses_section.xpath('div[@class="statistic-description"]/text()')) == 0
-        assert len(completed_responses_section.xpath('div[@class="statistic-description"]/text()')) == 0
+        assert incomplete_responses_section.xpath('h2//span[1]/text()')[0] == '0'
+        assert completed_responses_section.xpath('h2//span[1]/text()')[0] == '0'
+        assert incomplete_responses_section.xpath('h2//span[2]/text()')[0] == "Incomplete applications"
+        assert completed_responses_section.xpath('h2//span[2]/text()')[0] == "Completed applications"
+        assert len(incomplete_responses_section.xpath('p[1]/text()')) == 0
+        assert len(completed_responses_section.xpath('p[1]/text()')) == 0
 
     def test_dos_brief_has_lot_analytics_string(self):
         brief = self.brief['briefs']


### PR DESCRIPTION
https://trello.com/c/ECAfNadJ/94-1-remove-statistics-card-component-from-buyer-frontend

This replaces the [statistics component](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/toolkit/templates/statistics.html) with plain HTML and GOV.UK FE classes.

The Summary List's first column width is set to 30%, whereas standard GOV.UK spacing is 33.3333%. This means that when we [switch to the Summary List](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/1041) on this page, the alignment will be slightly out, hence the added SCSS to adjust.

However, if we do that, those same styles will be needed on the Briefs FE preview DOS opportunity page as well, so suggestions welcome.