### PR TITLE
Revert "Bump lxml from 4.5.0 to 4.5.1"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ Flask==1.0.4
 Flask-Login==0.5.0
 Flask-WTF==0.14.3
 itsdangerous==1.1.0
-lxml==4.5.1
+lxml==4.5.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,25 +4,56 @@
 #
 #    pip-compile requirements.in
 #
+asn1crypto==1.3.0         # via cryptography
+blinker==1.4              # via gds-metrics
+boto3==1.12.3             # via digitalmarketplace-utils
+botocore==1.15.3          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via flask
+contextlib2==0.6.0.post1  # via digitalmarketplace-utils
+cryptography==2.3.1       # via digitalmarketplace-utils
+defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.1.1#egg=digitalmarketplace-content-loader==7.1.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0  # via -r requirements.in, digitalmarketplace-content-loader
-flask-login==0.5.0        # via -r requirements.in
-flask-wtf==0.14.3         # via -r requirements.in
-flask==1.0.4              # via -r requirements.in, digitalmarketplace-content-loader, flask-login, flask-wtf
+docopt==0.6.2             # via notifications-python-client
+docutils==0.15.2          # via botocore
+flask-gzip==0.2           # via digitalmarketplace-utils
+flask-login==0.5.0        # via -r requirements.in, digitalmarketplace-utils
+flask-script==2.0.6       # via digitalmarketplace-utils
+flask-wtf==0.14.3         # via -r requirements.in, digitalmarketplace-utils
+flask==1.0.4              # via -r requirements.in, digitalmarketplace-content-loader, digitalmarketplace-utils, flask-gzip, flask-login, flask-script, flask-wtf, gds-metrics
+fleep==1.0.1              # via digitalmarketplace-utils
+future==0.18.2            # via notifications-python-client
+gds-metrics==0.2.0        # via digitalmarketplace-utils
+govuk-country-register==0.5.0  # via digitalmarketplace-utils
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha  # via -r requirements.in
-idna==2.9                 # via requests
+idna==2.9                 # via cryptography, requests
 inflection==0.3.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf
 jinja2==2.10.3            # via digitalmarketplace-content-loader, flask, govuk-frontend-jinja
-lxml==4.5.1               # via -r requirements.in
+jmespath==0.9.4           # via boto3, botocore
+lxml==4.5.0               # via -r requirements.in
+mailchimp3==3.0.6         # via digitalmarketplace-utils
 markdown==2.6.11          # via digitalmarketplace-content-loader
 markupsafe==1.1.1         # via jinja2
+monotonic==1.5            # via notifications-python-client
+notifications-python-client==5.5.1  # via digitalmarketplace-utils
+odfpy==1.4.1              # via digitalmarketplace-utils
+prometheus-client==0.2.0  # via gds-metrics
+pycparser==2.19           # via cffi
+pyjwt==1.7.1              # via notifications-python-client
+python-dateutil==2.8.1    # via botocore
+python-json-logger==0.1.11  # via digitalmarketplace-utils
+pytz==2019.3              # via digitalmarketplace-utils
 pyyaml==5.3.1             # via digitalmarketplace-content-loader
-requests==2.23.0          # via digitalmarketplace-apiclient
-urllib3==1.25.8           # via requests
-werkzeug==1.0.0           # via flask
+requests==2.23.0          # via digitalmarketplace-apiclient, digitalmarketplace-utils, mailchimp3, notifications-python-client
+s3transfer==0.3.3         # via boto3
+six==1.14.0               # via cryptography, python-dateutil
+unicodecsv==0.14.1        # via digitalmarketplace-utils
+urllib3==1.25.8           # via botocore, requests
+werkzeug==1.0.0           # via digitalmarketplace-utils, flask
+workdays==1.4             # via digitalmarketplace-utils
 wtforms==2.2.1            # via flask-wtf


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-buyer-frontend#1039

The most recent Dependabot PR removed a whole load of dependencies for some reason. We should figure out why, and watch out for this in other repos.

Ticket: https://trello.com/c/eDgp5UHN/1714-dependabot-removed-dependencies-from-requirementstxt