### PR TITLE
Fix error summary href for hidden input on save your search page

### DIFF
--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -41,6 +41,10 @@ class CreateProjectForm(FlaskForm):
             }
         })
 
+        # href for name field is assigned by digitalmarketplace-frontend-toolkit
+        # based on how many options there are above
+        self.name.href = f"input-save_search_selection-{len(self.save_search_selection.options)}-name"
+
     def validate_name(form, field):
         if form.save_search_selection.data == "new_search":
             try:


### PR DESCRIPTION
Ticket: https://trello.com/c/u5CoMrCP/19-1-replace-validation-banner-with-govuk-frontend-error-summary-component-in-the-buyer-frontend

Found I'd missed one while QAing on preview

![Kapture 2020-06-11 at 15 47 15](https://user-images.githubusercontent.com/503614/84401237-f5aab300-abfa-11ea-8498-01bc41317f8e.gif)
