### PR TITLE
display correct framework expiry date

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -206,6 +206,7 @@ def get_service_by_id(service_id):
             abort(e.status_code)
 
         service_unavailability_information = None
+        framework_expires_at_date = dateformat(framework['frameworkExpiresAtUTC'])
         status_code = 200
         if service['serviceMadeUnavailableAuditEvent'] is not None:
             service_unavailability_information = {
@@ -221,6 +222,7 @@ def get_service_by_id(service_id):
             service_unavailability_information=service_unavailability_information,
             lot=service_view_data.lot,
             gcloud_framework_description=framework_helpers.get_framework_description(data_api_client, 'g-cloud'),
+            framework_expires_at_date=framework_expires_at_date
         ), status_code
     except AuthException:
         abort(500, "Application error")

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -38,7 +38,7 @@
         heading = "This {} service is no longer available to buy.".format(service.frameworkName),
         message = " The {} framework expired on {}. Any existing contracts with {} are still valid.".format(
             service.frameworkName,
-            service_unavailability_information.date,
+            framework_expires_at_date,
             service.supplierName)
       %}
         {% include "toolkit/notification-banner.html" %}

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -273,7 +273,7 @@ class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
         assert unavailable_banner.body_text() == 'The {} framework expired on {}. Any existing contracts with {} are' \
             ' still valid.'.format(
                 self.service['services']['frameworkName'],
-                'Tuesday 5 January 2016',
+                'Thursday 6 January 2000',
                 self.service['services']['supplierName'],
         )
 

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -261,6 +261,9 @@ class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
         self.data_api_client.get_service.return_value = self.service
 
         service_id = self.service['services']['id']
+        framework_copy_with_updated_expiry_date = self.data_api_client.get_framework.return_value.copy()
+        framework_copy_with_updated_expiry_date['frameworks']['frameworkExpiresAtUTC'] = '2020-01-05T17:01:07.649587Z'
+        self.data_api_client.get_framework.return_value = framework_copy_with_updated_expiry_date
         res = self.client.get('/g-cloud/services/{}'.format(service_id))
         assert res.status_code == 410
 
@@ -273,7 +276,7 @@ class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
         assert unavailable_banner.body_text() == 'The {} framework expired on {}. Any existing contracts with {} are' \
             ' still valid.'.format(
                 self.service['services']['frameworkName'],
-                'Thursday 6 January 2000',
+                'Sunday 5 January 2020',
                 self.service['services']['supplierName'],
         )
 


### PR DESCRIPTION
https://trello.com/c/6mqoHNDb/125-1-expired-services-showing-wrong-framework-expiration-date-half-way-done

This fixes the unavailable banner to use the correct date from `frameworkExpiresAtUTC` field.
Before:
![expired-service-date](https://user-images.githubusercontent.com/1764158/84794201-df7f6700-afed-11ea-9a11-48896c475ef1.png)
After:
![Screenshot 2020-06-16 at 16 25 04](https://user-images.githubusercontent.com/1764158/84794265-f4f49100-afed-11ea-9d7f-9d8e54d24769.png)

