### PR TITLE
Remove .app-break-link class

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -96,12 +96,3 @@ $govuk-global-styles: true;
     padding-bottom: 30px;
   }
 }
-
-/*
- * TODO: Remove this class once the Brief opportunity page and the Preview Brief opportunity page
- * have been swapped from DM FE Toolkit summary tables to DS summary lists
- */
-.app-break-link {
-  display: inline-block;
-  word-break: break-all;
-}

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 lxml==4.5.0
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.4.0#egg=digitalmarketplace-utils==52.4.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.6.0#egg=digitalmarketplace-utils==52.6.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.8.1#egg=digitalmarketplace-content-loader==7.8.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.1-alpha#egg=govuk-frontend-jinja==0.5.1-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.8.1#egg=digitalmarketplace-content-loader==7.8.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@52.4.0#egg=digitalmarketplace-utils==52.4.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.6.0#egg=digitalmarketplace-utils==52.6.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-gzip==0.2           # via digitalmarketplace-utils


### PR DESCRIPTION
The `app-break-link` class served to wrap long URLs in a summary table.

Since the upgrade to summary lists, we no longer need this class, as Summary Lists wrap text already.