### PR TITLE
Fix bug in save search view

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -420,7 +420,10 @@ def save_search(framework_family):
     framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
     lots_by_slug = framework_helpers.get_lots_by_slug(framework)
 
-    search_query = url_decode(request.values.get('search_query'))
+    if "search_query" not in request.values:
+        abort(400)
+
+    search_query = url_decode(request.values['search_query'])
 
     current_lot_slug = get_valid_lot_from_args_or_none(search_query, lots_by_slug)
 

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -139,6 +139,15 @@ class TestDirectAward(TestDirectAwardBase):
         summary = self.find_search_summary(res.get_data(as_text=True))[0]
         assert '<span class="search-summary-count">1150</span> results found in <em>Cloud software</em>' in summary
 
+    def test_save_search_view_raises_400_if_no_search(self):
+        self.login_as_buyer()
+
+        res = self.client.get(self.SAVE_SEARCH_URL)
+
+        assert res.status_code == 400
+
+        assert "Sorry, there was a problem with your request" in res.get_data(as_text=True)
+
     def _save_search(self, name, save_search_selection="new_search"):
         self.login_as_buyer()
         self.search_api_client.search.return_value = self.g9_search_results


### PR DESCRIPTION
The HTTP request `GET /buyers/direct-award/g-cloud/save-search` (note no query string) from a logged in user causes a 500.

This PR catches the case where the required query param is not in the URL and raises a HTTP 400 instead.