### PR TITLE
Use govuk-frontend heading styles on Crown Hosting page

### DIFF
--- a/app/templates/content/index-crown-hosting.html
+++ b/app/templates/content/index-crown-hosting.html
@@ -39,7 +39,7 @@
           to talk about your datacentre hosting needs.
 
         </p>
-        <h2 class='summary-item-heading'>
+        <h2 class='govuk-heading-m'>
           Features
         </h2>
         <p class="govuk-body">
@@ -62,7 +62,7 @@
             leading environmental performance
           </li>
         </ul>
-        <h2 class='summary-item-heading'>
+        <h2 class='govuk-heading-m'>
           Benefits
         </h2>
         <p class="govuk-body">
@@ -96,7 +96,7 @@
         </ul>
       </div>
       <div class="govuk-grid-column-one-third">
-        <h2>
+        <h2 class="govuk-heading-m">
           Crown Hosting contact
         </h2>
         <p class="govuk-body">

--- a/app/templates/content/index-crown-hosting.html
+++ b/app/templates/content/index-crown-hosting.html
@@ -33,12 +33,7 @@
           The Crown Hosting Data Centres framework is available to all central
           government departments, arm’s length bodies and the wider public sector.
         </p>
-        <p class="govuk-body">
 
-          Email <a class="govuk-link" href="mailto:crownhosting@crowncommercial.gov.uk">crownhosting@crowncommercial.gov.uk</a>
-          to talk about your datacentre hosting needs.
-
-        </p>
         <h2 class='govuk-heading-m'>
           Features
         </h2>
@@ -94,21 +89,16 @@
             strong step-in rights for government to ensure continuity of service if needed
           </li>
         </ul>
-      </div>
-      <div class="govuk-grid-column-one-third">
+        <p class="govuk-body">
+          Read more about the <a class="govuk-link" href="/crown-hosting/framework">Crown Hosting Data Centres framework</a>.
+        </p>
+
         <h2 class="govuk-heading-m">
           Crown Hosting contact
         </h2>
         <p class="govuk-body">
-          <strong>Crown Commercial Service</strong>
-        </p>
-        <p class="govuk-body">
-          <a class="govuk-link" href="mailto:crownhosting@crowncommercial.gov.uk">crownhosting@crowncommercial.gov.uk</a>
-        </p>
-      </div>
-      <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">
-          Read more about the <a class="govuk-link" href="/crown-hosting/framework">Crown Hosting Data Centres framework</a>.
+          Email <a class="govuk-link" href="mailto:crownhosting@crowncommercial.gov.uk">crownhosting@crowncommercial.gov.uk</a>
+          if you need support buying or selling on the Crown Hosting Data Centres framework.
         </p>
       </div>
 


### PR DESCRIPTION
Small fix for headings on the Crown Hosting page that I noticed needed doing.

### Screenshot

![Screenshot of the crown hosting page after PR changes](https://user-images.githubusercontent.com/503614/85991699-b696a300-b9eb-11ea-9a3f-b822bb46211b.png)
