### PR TITLE
Replace flash messages with alert component

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -648,7 +648,7 @@ def update_project(framework_family, project_id):
             user_email=current_user.email_address,
             project_data={'readyToAssess': True}
         )
-        flash(CONFIRM_START_ASSESSING_MESSAGE)
+        flash(CONFIRM_START_ASSESSING_MESSAGE, 'success')
     return redirect(url_for('.view_project',
                             framework_family=framework_family,
                             project_id=project_id))
@@ -857,7 +857,7 @@ def why_did_you_not_award_the_contract(framework_family, project_id):
             data_api_client.create_direct_award_project_outcome_none_suitable(
                 project_id=project_id,
                 user_email=current_user.email_address)
-        flash("You’ve updated ‘{}’".format(project['name']))
+        flash("You’ve updated ‘{}’".format(project['name']), 'success')
         return redirect(url_for('.view_project', framework_family=framework_family, project_id=project['id']))
 
     errors = get_errors_from_wtform(form)

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -10,6 +10,7 @@
 {# Import DM Components #}
 {% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader%}
+{% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter%}
 {% from "digitalmarketplace/components/banner/macro.njk" import dmBanner %}
 
@@ -42,7 +43,20 @@
 {% endblock %}
 
 {% block content %}
-  {% include "toolkit/flash_messages.html" %}
+  {% block flashMessages %}
+    {% with
+       messages = get_flashed_messages(with_categories=True),
+       titles = {"error": "There is a problem"}
+    %}
+      {% for category, message in messages %}
+        {{ dmAlert({
+          "titleHtml": titles.get(category) or message,
+          "html": message if category in titles else None,
+          "type": category,
+        }) }}
+      {% endfor %}
+    {% endwith %}
+  {% endblock flashMessages %}
   {% block errorSummary %}
     {% if errors %}
       {{ govukErrorSummary({

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -746,7 +746,7 @@ class TestDirectAwardReadyToAssess(TestDirectAwardBase):
         assert res.location.endswith('/buyers/direct-award/g-cloud/projects/1')
         self.data_api_client.update_direct_award_project.assert_called_once_with(
             project_data={'readyToAssess': True}, project_id=1, user_email='buyer@email.com')
-        self.assert_flashes(html_escape(CONFIRM_START_ASSESSING_MESSAGE))
+        self.assert_flashes(html_escape(CONFIRM_START_ASSESSING_MESSAGE), expected_category='success')
 
 
 class TestDirectAwardAwardContract(TestDirectAwardBase):

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 import json
-import re
 from urllib.parse import urlparse, parse_qs
 
 from flask import current_app
@@ -42,21 +41,6 @@ class TestApplication(APIClientMixin, BaseApplicationTest):
 
 
 class TestHomepageAccountCreationVirtualPageViews(APIClientMixin, BaseApplicationTest):
-
-    def test_data_analytics_track_page_view_is_shown_if_account_created_flash_message(self):
-        with self.client.session_transaction() as session:
-            session['_flashes'] = [('track-page-view', 'buyers?account-created=true')]
-
-        res = self.client.get("/")
-        data = res.get_data(as_text=True)
-
-        assert 'data-analytics="trackPageView" data-url="buyers?account-created=true"' in data
-        # however this should not be shown as a regular flash message
-        flash_banner_match = re.search(r'<p class="banner-message">\s*(.*)', data, re.MULTILINE)
-        assert flash_banner_match is None, "Unexpected flash banner message '{}'.".format(
-            flash_banner_match.groups()[0])
-
-        assert len(self.data_api_client.find_frameworks.call_args_list) == 2
 
     def test_data_analytics_track_page_view_not_shown_if_no_account_created_flash_message(self):
         res = self.client.get("/")


### PR DESCRIPTION
https://trello.com/c/cl5dUeWD/120-2-replace-flash-messages-with-alert-component-in-buyer-frontend

We're replacing our flash messages with the [alert component](https://github.com/alphagov/digitalmarketplace-govuk-frontend/tree/master/src/digitalmarketplace/components/alert).

I've deleted `test_data_analytics_track_page_view_is_shown_if_account_created_flash_message`, since by removing flash messages this case doesn't occur - as far as I can tell.