### PR TITLE
Replace text input on search for G-Cloud services journey

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -79,6 +79,7 @@ $govuk-global-styles: true;
 @import "_help-page.scss";
 
 // Overrides
+@import "overrides/_text-input.scss";
 @import "overrides/_notification-banners.scss";
 @import "overrides/_temporary-messages.scss";
 @import "overrides/_summary-list.scss";

--- a/app/assets/scss/overrides/_text-input.scss
+++ b/app/assets/scss/overrides/_text-input.scss
@@ -1,0 +1,20 @@
+
+/**
+ *  govUkInputs are shorter than our toolkit inputs, so while they're on pages
+ *  which mix and match Toolkit and GOVUK Frontend, this class will make them
+ *  conform to the Toolkit look.
+ *
+ *  I've created the class rather than applied it generally because we have lots
+ *  of forms and I can't be sure I wouldn't be messing up the styling in other
+ *  places. This does have the slightly inconvenient side effect of needing to
+ *  remove instances of the classes in templates, etc when we remove this class.
+ *  
+ *  TODO: Remove this style and any instances of this class when we have fully
+ *  migrated our forms to GOVUK Frontend.
+ */
+.app-text-input--height-compatible {
+    height: 50px;
+    @if $govuk-typography-use-rem {
+      height: govuk-px-to-rem(50px);
+    }
+}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -6,6 +6,7 @@
 {% from "components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk-frontend/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk-frontend/components/input/macro.njk" import govukInput %}
 
 {# Import DM Components #}
 {% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -37,7 +37,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Tell us about your contract</h1>
 
-      <form method="POST" action="{{ url_for('direct_award.tell_us_about_contract', framework_family=framework.family, project_id=project.id, outcome_id=outcome_id) }}" class="tell-us-about-contract-form">
+      <form method="POST" action="{{ url_for('direct_award.tell_us_about_contract', framework_family=framework.family, project_id=project.id, outcome_id=outcome_id) }}" class="tell-us-about-contract-form" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
         {{ form.start_date}}
@@ -46,7 +46,21 @@
 
         {{ form.value_in_pounds }}
 
-        {{ form.buying_organisation }}
+        {{ govukInput ({
+          "classes": "app-text-input--height-compatible",
+          "errorMessage": errors.buying_organisation.errorMessage,
+          "hint": {
+            "text": form.buying_organisation.hint,
+          },
+          "id": "input-buying_organisation",
+          "label": {
+            "text": form.buying_organisation.label.text,
+            "classes": 'govuk-label--m'
+          },
+          "name": "buying_organisation",
+          "type": "text",
+          "value": form.buying_organisation.data
+        }) }}
 
         {{ govukButton({
           "text": "Submit",

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -1049,13 +1049,18 @@ class TestDirectAwardTellUsAboutContract(TestDirectAwardBase):
         assert res.status_code == 400
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('count(//span[@class="validation-message"])') == 1
+        assert (doc.xpath('count(//span[@class="validation-message"])') == 1 or
+                doc.xpath('count(//span[@class="govuk-error-message"])') == 1)
         errors = doc.cssselect('div.govuk-error-summary a')
         assert len(errors) == 1
         assert len(errors[0].text_content()) > 0
 
         for field, value in data.items():
-            assert doc.xpath(f'//input[@name="{field}"]/@value')[0] == value
+            input_element = doc.xpath(f'//input[@name="{field}"]')[0]
+            if not value:
+                assert('value' not in input_element.attrib)
+            else:
+                assert input_element.attrib['value'] == value
 
     def test_if_end_date_is_before_start_date_raise_400_and_show_validation_message(self, client, data):
         data.update({'end_date-year': str(int(data['start_date-year']) - 1)})


### PR DESCRIPTION
https://trello.com/c/GRm5KiLE/111-2-replace-text-input-component-in-search-for-g-cloud-services-journey-except-keyword-search

Walked through this journey and there's only one form which directly uses text inputs.

* `/buyers/direct-award/g-cloud/save-search` uses `toolkit/forms/selection-buttons.html` which reveals an inner text input.
* `/buyers/direct-award/g-cloud/projects/<id>/did-you-award-contract` has two text inputs:
  * One is for currency. I've not converted this one because the [Design System Form input prefix/suffix variant](https://github.com/alphagov/govuk-design-system-backlog/issues/134#issuecomment-654968716) is due to be published soon, and we should use that to display the currency symbols.
  * The other field I've replaced directly with a `govukInput` macro using existing form data.

- [x] Have run local tests
- [x] Have run functional tests locally