### PR TITLE
Escape user input saved search name

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -410,7 +410,7 @@ def saved_search_overview(framework_family):
     projects = get_direct_award_projects(data_api_client, current_user.id, latest_first=True)
     projects['closed_projects'].sort(key=itemgetter('lockedAt'), reverse=True)
 
-    # Format saved searches for display
+    # Format saved searches in format expected by govukTable rows
     open_projects = []
     for project in projects['open_projects']:
         view_project_url = url_for(
@@ -425,7 +425,7 @@ def saved_search_overview(framework_family):
             ]
         )
 
-    # Format closed searches for display
+    # Format closed searches in format expected by govukTable rows
     closed_projects = []
     for project in projects['closed_projects']:
         view_project_url = url_for(

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -453,7 +453,7 @@ def saved_search_overview(framework_family):
 
         closed_projects.append(
             [
-                {'html': f'<a href="{view_project_url}">{project["name"]}</a>'},
+                {'html': f'<a href="{view_project_url}">{escape(project["name"])}</a>'},
                 {'text': datetimeformat(project['lockedAt'])},
                 {'html': project_status}
             ]

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import inflection
 from operator import itemgetter
 
-from flask import abort, request, redirect, current_app, url_for, flash
+from flask import abort, request, redirect, current_app, url_for, flash, escape
 from flask_login import current_user
 from werkzeug.urls import Href, url_encode, url_decode
 
@@ -420,7 +420,7 @@ def saved_search_overview(framework_family):
         )
         open_projects.append(
             [
-                {'html': f'<a href="{view_project_url}">{project["name"]}</a>'},
+                {'html': f'<a href="{view_project_url}">{escape(project["name"])}</a>'},
                 {'text': datetimeformat(project['createdAt'])}
             ]
         )

--- a/tests/fixtures/direct_award_project_list_xss_fixture.json
+++ b/tests/fixtures/direct_award_project_list_xss_fixture.json
@@ -1,0 +1,20 @@
+{
+  "links": {
+    "self": "http://localhost:5000/direct-award/projects?latest-first=1&user-id=19175"
+  },
+  "meta": {
+    "total": 1
+  },
+  "projects": [
+    {
+      "active": true,
+      "createdAt": "2018-06-22T10:41:31.281853Z",
+      "downloadedAt": null,
+      "id": 731851428862851,
+      "lockedAt": null,
+      "name": "\\<a onmouseover=\"alert(document.cookie)\">xxs link\\</a>",
+      "readyToAssessAt": null,
+      "outcome": null
+    }
+  ]
+}

--- a/tests/fixtures/direct_award_project_list_xss_fixture.json
+++ b/tests/fixtures/direct_award_project_list_xss_fixture.json
@@ -3,7 +3,7 @@
     "self": "http://localhost:5000/direct-award/projects?latest-first=1&user-id=19175"
   },
   "meta": {
-    "total": 1
+    "total": 2
   },
   "projects": [
     {
@@ -15,6 +15,41 @@
       "name": "\\<a onmouseover=\"alert(document.cookie)\">xxs link\\</a>",
       "readyToAssessAt": null,
       "outcome": null
+    },
+    {
+      "active": true,
+      "createdAt": "2018-06-19T13:36:37.557144Z",
+      "downloadedAt": "2018-06-19T13:37:30.849304Z",
+      "id": 272774709812396,
+      "lockedAt": "2018-06-19T13:37:03.176398Z",
+      "readyToAssessAt": "2018-06-22T10:41:31.281853Z",
+      "name": "\\<a onmouseover=\"alert(document.cookie)\">xxs link CLOSED\\</a>",
+      "outcome": {
+        "award": {
+          "awardValue": "1234.00",
+          "awardingOrganisationName": "123321",
+          "endDate": "2020-12-12",
+          "startDate": "2002-12-12"
+        },
+        "completed": true,
+        "completedAt": "2018-06-19T13:37:59.713497Z",
+        "id": 680306864633356,
+        "result": "awarded",
+        "resultOfDirectAward": {
+          "archivedService": {
+            "id": 266018,
+            "service": {
+              "id": "316684326093280"
+            }
+          },
+          "project": {
+            "id": 272774709812396
+          },
+          "search": {
+            "id": 3706
+          }
+        }
+      }
     }
   ]
 }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -292,6 +292,10 @@ class BaseApplicationTest(object):
         return BaseApplicationTest._get_fixture_data('direct_award_project_list_fixture.json')
 
     @staticmethod
+    def _get_direct_award_project_list_xss_fixture(**kwargs):
+        return BaseApplicationTest._get_fixture_data('direct_award_project_list_xss_fixture.json')
+
+    @staticmethod
     def _get_direct_award_project_fixture(**kwargs):
         project = BaseApplicationTest._get_fixture_data('direct_award_project_fixture.json')
 

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -89,6 +89,18 @@ class TestDirectAward(TestDirectAwardBase):
                     assert parser.parse(previous_date) >= parser.parse(current_date)
                 previous_date = current_date
 
+    def test_escapes_search_name(self):
+        self.data_api_client.find_direct_award_projects.return_value = self._get_direct_award_project_list_xss_fixture()
+        self.login_as_buyer()
+        res = self.client.get(self.SAVE_SEARCH_OVERVIEW_URL)
+        assert res.status_code == 200
+        result_html = res.get_data(as_text=True)
+        doc = html.fromstring(result_html)
+        search_name = doc.xpath('//*[@id="searching_table"]/tbody/tr[1]/td[1]/a')[0]
+        element_source = html.tostring(search_name)
+        assert element_source == (b'<a href="/buyers/direct-award/g-cloud/projects/731851428862851">\\&lt;a o'
+                                  b'nmouseover="alert(document.cookie)"&gt;xxs link\\&lt;/a&gt;</a>')
+
     def test_renders_outcome_column_for_search_ended(self):
         self.login_as_buyer()
         res = self.client.get(self.SAVE_SEARCH_OVERVIEW_URL)

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -89,21 +89,23 @@ class TestDirectAward(TestDirectAwardBase):
                     assert parser.parse(previous_date) >= parser.parse(current_date)
                 previous_date = current_date
 
-    def test_escapes_search_name(self):
+    @pytest.mark.parametrize("xpath,value",
+                             [('//*[@id="searching_table"]/tbody/tr[1]/td[1]/a',
+                              (b'<a href="/buyers/direct-award/g-cloud/projects/731851428862851">\\&lt;a o'
+                               b'nmouseover="alert(document.cookie)"&gt;xxs link\\&lt;/a&gt;</a>')),
+                              ('//*[@id="search_ended_table"]/tbody/tr/td[1]/a',
+                              (b'<a href="/buyers/direct-award/g-cloud/projects/272774709812396">\\&lt;a o'
+                               b'nmouseover="alert(document.cookie)"&gt;xxs link CLOSED\\&lt;/a&gt;</a>'))])
+    def test_escapes_search_name(self, xpath, value):
         self.data_api_client.find_direct_award_projects.return_value = self._get_direct_award_project_list_xss_fixture()
         self.login_as_buyer()
         res = self.client.get(self.SAVE_SEARCH_OVERVIEW_URL)
         assert res.status_code == 200
         result_html = res.get_data(as_text=True)
         doc = html.fromstring(result_html)
-        open_search_name = doc.xpath('//*[@id="searching_table"]/tbody/tr[1]/td[1]/a')[0]
-        open_element_source = html.tostring(open_search_name)
-        closed_search_name = doc.xpath('//*[@id="search_ended_table"]/tbody/tr/td[1]/a')[0]
-        closed_element_source = html.tostring(closed_search_name)
-        assert open_element_source == (b'<a href="/buyers/direct-award/g-cloud/projects/731851428862851">\\&lt;a o'
-                                       b'nmouseover="alert(document.cookie)"&gt;xxs link\\&lt;/a&gt;</a>')
-        assert closed_element_source == ((b'<a href="/buyers/direct-award/g-cloud/projects/272774709812396">\\&lt;a o'
-                                          b'nmouseover="alert(document.cookie)"&gt;xxs link CLOSED\\&lt;/a&gt;</a>'))
+        search_name = doc.xpath(xpath)[0]
+        element_source = html.tostring(search_name)
+        assert element_source == value
 
     def test_renders_outcome_column_for_search_ended(self):
         self.login_as_buyer()

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -96,10 +96,14 @@ class TestDirectAward(TestDirectAwardBase):
         assert res.status_code == 200
         result_html = res.get_data(as_text=True)
         doc = html.fromstring(result_html)
-        search_name = doc.xpath('//*[@id="searching_table"]/tbody/tr[1]/td[1]/a')[0]
-        element_source = html.tostring(search_name)
-        assert element_source == (b'<a href="/buyers/direct-award/g-cloud/projects/731851428862851">\\&lt;a o'
-                                  b'nmouseover="alert(document.cookie)"&gt;xxs link\\&lt;/a&gt;</a>')
+        open_search_name = doc.xpath('//*[@id="searching_table"]/tbody/tr[1]/td[1]/a')[0]
+        open_element_source = html.tostring(open_search_name)
+        closed_search_name = doc.xpath('//*[@id="search_ended_table"]/tbody/tr/td[1]/a')[0]
+        closed_element_source = html.tostring(closed_search_name)
+        assert open_element_source == (b'<a href="/buyers/direct-award/g-cloud/projects/731851428862851">\\&lt;a o'
+                                       b'nmouseover="alert(document.cookie)"&gt;xxs link\\&lt;/a&gt;</a>')
+        assert closed_element_source == ((b'<a href="/buyers/direct-award/g-cloud/projects/272774709812396">\\&lt;a o'
+                                          b'nmouseover="alert(document.cookie)"&gt;xxs link CLOSED\\&lt;/a&gt;</a>'))
 
     def test_renders_outcome_column_for_search_ended(self):
         self.login_as_buyer()


### PR DESCRIPTION
https://trello.com/c/sDrTpRsf/1810-self-xss-save-search
previously we did not escape the search name which thus was vulnerable to self-xss.

After:
![Screenshot 2020-07-30 at 11 47 26](https://user-images.githubusercontent.com/1764158/88914449-8b0d0f80-d25a-11ea-9025-17ed1604f887.png)


