### PR TITLE
Use Search API results_per_page setting if available

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -275,11 +275,13 @@ def search_services():
         )),
     )
 
-    # the search api doesn't supply its own pagination information: use this `pagination` function to figure out what
-    # links to show
+    # Get the results per page from the Search API meta data (or fall back to Buyer FE config setting)
+    results_per_page = search_api_response['meta'].get('results_per_page', current_app.config["DM_SEARCH_PAGE_SIZE"])
+
+    # Get prev/next link info and number of pages
     pagination_config = pagination(
         search_results_obj.total,
-        current_app.config["DM_SEARCH_PAGE_SIZE"],
+        results_per_page,
         get_page_from_request(request)
     )
 

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -261,9 +261,13 @@ def list_opportunities(framework_family):
         )),
     )
 
+    # Get the results per page from the Search API meta data (or fall back to Buyer FE config setting)
+    results_per_page = search_api_response['meta'].get('results_per_page', current_app.config["DM_SEARCH_PAGE_SIZE"])
+
+    # Get prev/next link info and number of pages
     pagination_config = pagination(
         search_results_obj.total,
-        current_app.config["DM_SEARCH_PAGE_SIZE"],
+        results_per_page,
         get_page_from_request(request)
     )
 

--- a/tests/fixtures/dos_brief_search_api_response.json
+++ b/tests/fixtures/dos_brief_search_api_response.json
@@ -158,6 +158,7 @@
       "filter_status": "live,closed,unsuccessful,cancelled"
     },
     "took": 7,
-    "total": 864
+    "total": 864,
+    "results_per_page": 100
   }
 }

--- a/tests/fixtures/dos_multiple_briefs_fixture.json
+++ b/tests/fixtures/dos_multiple_briefs_fixture.json
@@ -306,6 +306,7 @@
     "next":"http://localhost:5000/briefs?status=live%2Cclosed&framework=digital-outcomes-and-specialists&page=3"
   },
   "meta":{
-    "total":6
+    "total":6,
+    "results_per_page": 100
   }
 }

--- a/tests/fixtures/g9_search_results_fixture.json
+++ b/tests/fixtures/g9_search_results_fixture.json
@@ -9,7 +9,8 @@
       "filter_webChatSupport":"yes"
     },
     "took":8,
-    "total":1150
+    "total":1150,
+    "results_per_page": 100
   },
   "documents":[
     {

--- a/tests/fixtures/search_results_fixture.json
+++ b/tests/fixtures/search_results_fixture.json
@@ -5,7 +5,8 @@
       "filter_lot": "saas"
     },
     "total": 9,
-    "took": 13
+    "took": 13,
+    "results_per_page": 100
   },
   "documents": [
     {

--- a/tests/fixtures/search_results_multiple_pages_fixture.json
+++ b/tests/fixtures/search_results_multiple_pages_fixture.json
@@ -1,12 +1,13 @@
 {
-    "meta": {
+  "meta": {
     "query": {
       "q": "CDN",
       "filter_lot": "saas",
       "page": "20"
     },
     "total": 19981,
-    "took": 13
+    "took": 13,
+    "results_per_page": 100
   },
   "documents": [
     {

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -714,7 +714,8 @@ class TestDirectAwardEndSearch(TestDirectAwardBase):
             "meta": {
                 "query": {},
                 "total": END_SEARCH_LIMIT + 1,
-                "took": 3
+                "took": 3,
+                "results_per_page": 100
             },
             "links": {}
         }

--- a/tests/main/views/test_search.py
+++ b/tests/main/views/test_search.py
@@ -26,7 +26,8 @@ def get_0_results_search_response():
         "meta": {
             "query": {},
             "total": 0,
-            "took": 3
+            "took": 3,
+            "results_per_page": 100
         },
         "links": {}
     }
@@ -205,7 +206,8 @@ class TestSearchResults(APIClientMixin, BaseApplicationTest):
             "meta": {
                 "query": {},
                 "total": 2,
-                "took": 3
+                "took": 3,
+                "results_per_page": 30
             },
             "links": {}
         }


### PR DESCRIPTION
https://trello.com/c/vZ1ol94X/168-1-reduce-number-of-results-per-page-to-30

See http://github.com/alphagov/digitalmarketplace-search-api/pull/263/ for explanation.

This PR prepares the Buyer FE for a change in the Search API's `DM_SEARCH_PAGE_SIZE` setting. This will affect both the G-Cloud search and DOS opportunities search. 

Once we reduce the limit from 100 to 30 we can update the test fixtures if necessary (to make our tests closer to reality), but the Buyer FE code should ideally be agnostic about what the Search API setting is.