### PR TITLE
Review search result items

### DIFF
--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -83,6 +83,7 @@ $govuk-global-styles: true;
 @import "overrides/_notification-banners.scss";
 @import "overrides/_temporary-messages.scss";
 @import "overrides/_summary-list.scss";
+@import "overrides/_search-result.scss";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_search-result.scss
+++ b/app/assets/scss/overrides/_search-result.scss
@@ -1,0 +1,19 @@
+/**
+ * To remove our reliance on the Toolkit classes, we copy this style
+ */
+ .app-search-result {
+     padding: 0 0 15px;
+     margin: 0 0 15px;
+     border-bottom: 1px solid $govuk-border-colour;
+     @include core-16;
+     // Automatic wrapping for unbreakable text (e.g. URLs)
+     word-wrap: break-word; // Fallback for older browsers only
+     overflow-wrap: break-word;
+ }
+
+ /**
+  * Decrease the size of metadata text to match the Finder app.
+  */
+ .app-search-result__metadata {
+    @include core-14;
+ }

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -1,50 +1,51 @@
-{% for brief in briefs %}
-<div class="search-result">
-    <h2 class="search-result-title">
-        <a class="govuk-link" href="{{ url_for('.get_brief_by_id', framework_family=framework_family, brief_id=brief.id) }}">{{ brief.title }}</a>
-    </h2>
+<ul>
+    {% for brief in briefs %}
+    <li class="search-result">
+        <h2 class="search-result-title">
+            <a class="govuk-link" href="{{ url_for('.get_brief_by_id', framework_family=framework_family, brief_id=brief.id) }}">{{ brief.title }}</a>
+        </h2>
 
-    <ul class="search-result-important-metadata">
-        <li class="search-result-metadata-item">
-            {{ brief.organisation }}
-        </li>
-        <li class="search-result-metadata-item">
-            {{ brief.location }}
-        </li>
-    </ul>
-
-    <ul class="search-result-metadata">
-        <li class="search-result-metadata-item-inline">
-            {{ brief.lot.name }}
-        </li>
-        {% if 'specialistRole' in brief %}
-        <li class="search-result-metadata-item-inline">
-            {{ brief.specialistRole | capitalize() }}
-        </li>
-        {% endif %}
-    </ul>
-
-    <ul class="search-result-metadata">
-        {% if brief.status in outcomes.keys() %}
+        <ul class="search-result-important-metadata">
             <li class="search-result-metadata-item">
-                Closed: {{ outcomes[brief.status] }}
-            </li>
-        {% else %}
-            <li class="search-result-metadata-item">
-                Published: {{ brief.publishedAt|dateformat }}
+                {{ brief.organisation }}
             </li>
             <li class="search-result-metadata-item">
-                Deadline for asking questions: {{ brief.clarificationQuestionsClosedAt|dateformat }}
+                {{ brief.location }}
             </li>
-            <li class="search-result-metadata-item">
-                Closing: {{ brief.applicationsClosedAt|dateformat }}
+        </ul>
+
+        <ul class="search-result-metadata">
+            <li class="search-result-metadata-item-inline">
+                {{ brief.lot.name }}
             </li>
-        {% endif %}
-    </ul>
+            {% if 'specialistRole' in brief %}
+            <li class="search-result-metadata-item-inline">
+                {{ brief.specialistRole | capitalize() }}
+            </li>
+            {% endif %}
+        </ul>
 
-    <p class="search-result-excerpt">
-        {{ brief.summary }}
-    </p>
-</div>
+        <ul class="search-result-metadata">
+            {% if brief.status in outcomes.keys() %}
+                <li class="search-result-metadata-item">
+                    Closed: {{ outcomes[brief.status] }}
+                </li>
+            {% else %}
+                <li class="search-result-metadata-item">
+                    Published: {{ brief.publishedAt|dateformat }}
+                </li>
+                <li class="search-result-metadata-item">
+                    Deadline for asking questions: {{ brief.clarificationQuestionsClosedAt|dateformat }}
+                </li>
+                <li class="search-result-metadata-item">
+                    Closing: {{ brief.applicationsClosedAt|dateformat }}
+                </li>
+            {% endif %}
+        </ul>
 
-{% endfor %}
+        <p class="search-result-excerpt">
+            {{ brief.summary }}
+        </p>
+    </li>
+    {% endfor %}
+</ul>

--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -1,49 +1,49 @@
 <ul>
     {% for brief in briefs %}
-    <li class="search-result">
-        <h2 class="search-result-title">
+    <li class="app-search-result">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
             <a class="govuk-link" href="{{ url_for('.get_brief_by_id', framework_family=framework_family, brief_id=brief.id) }}">{{ brief.title }}</a>
         </h2>
 
-        <ul class="search-result-important-metadata">
-            <li class="search-result-metadata-item">
-                {{ brief.organisation }}
+        <ul>
+            <li class="govuk-!-font-weight-bold">
+                <span class="govuk-visually-hidden">Organisation: </span>{{ brief.organisation }}
             </li>
-            <li class="search-result-metadata-item">
-                {{ brief.location }}
+            <li class="govuk-!-font-weight-bold">
+                <span class="govuk-visually-hidden">Location: </span>{{ brief.location }}
             </li>
         </ul>
 
-        <ul class="search-result-metadata">
-            <li class="search-result-metadata-item-inline">
+        <ul class="app-search-result__metadata">
+            <li class="govuk-!-display-inline-block">
                 {{ brief.lot.name }}
             </li>
             {% if 'specialistRole' in brief %}
-            <li class="search-result-metadata-item-inline">
-                {{ brief.specialistRole | capitalize() }}
+            <li class="govuk-!-display-inline-block">
+                - {{ brief.specialistRole | capitalize() }}
             </li>
             {% endif %}
         </ul>
 
-        <ul class="search-result-metadata">
+        <ul class="app-search-result__metadata">
             {% if brief.status in outcomes.keys() %}
-                <li class="search-result-metadata-item">
+                <li>
                     Closed: {{ outcomes[brief.status] }}
                 </li>
             {% else %}
-                <li class="search-result-metadata-item">
+                <li>
                     Published: {{ brief.publishedAt|dateformat }}
                 </li>
-                <li class="search-result-metadata-item">
+                <li>
                     Deadline for asking questions: {{ brief.clarificationQuestionsClosedAt|dateformat }}
                 </li>
-                <li class="search-result-metadata-item">
+                <li>
                     Closing: {{ brief.applicationsClosedAt|dateformat }}
                 </li>
             {% endif %}
         </ul>
 
-        <p class="search-result-excerpt">
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-0 govuk-!-margin-top-1">
             {{ brief.summary }}
         </p>
     </li>

--- a/app/templates/search/_services_results.html
+++ b/app/templates/search/_services_results.html
@@ -1,23 +1,25 @@
-{% for service in services %}
-<div class="search-result">
-  <h2 class="search-result-title">
-        <a class="govuk-link" href="{{ url_for('.get_service_by_id', service_id=service.id) }}">{{ service.serviceName }}</a>
-    </h2>
+<ul>
+    {% for service in services %}
+    <li class="search-result">
+    <h2 class="search-result-title">
+            <a class="govuk-link" href="{{ url_for('.get_service_by_id', service_id=service.id) }}">{{ service.serviceName }}</a>
+        </h2>
 
-    <p class="search-result-supplier">
-        {{ service.supplierName }}
-    </p>
+        <p class="search-result-supplier">
+            {{ service.supplierName }}
+        </p>
 
-    <p class="search-result-excerpt">
-        {{ service.serviceSummary or service.serviceDescription }} {# G-Cloud 9 uses serviceDescription, not serviceSummary. #}
-    </p>
-    <ul aria-label="tags" class="search-result-metadata">
-        <li class="search-result-metadata-item-inline">
-            {{ service.lot.name }}
-        </li>
-        <li class="search-result-metadata-item-inline">
-            {{ service.frameworkName }}
-        </li>
-    </ul>
-</div>
+        <p class="search-result-excerpt">
+            {{ service.serviceSummary or service.serviceDescription }} {# G-Cloud 9 uses serviceDescription, not serviceSummary. #}
+        </p>
+        <ul aria-label="tags" class="search-result-metadata">
+            <li class="search-result-metadata-item-inline">
+                {{ service.lot.name }}
+            </li>
+            <li class="search-result-metadata-item-inline">
+                {{ service.frameworkName }}
+            </li>
+        </ul>
+    </li>
+</ul>
 {% endfor %}

--- a/app/templates/search/_services_results.html
+++ b/app/templates/search/_services_results.html
@@ -1,25 +1,25 @@
 <ul>
     {% for service in services %}
-    <li class="search-result">
-    <h2 class="search-result-title">
+    <li class="app-search-result">
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-1">
             <a class="govuk-link" href="{{ url_for('.get_service_by_id', service_id=service.id) }}">{{ service.serviceName }}</a>
         </h2>
 
-        <p class="search-result-supplier">
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-font-weight-bold">
             {{ service.supplierName }}
         </p>
 
-        <p class="search-result-excerpt">
+        <p class="govuk-body govuk-!-font-size-16">
             {{ service.serviceSummary or service.serviceDescription }} {# G-Cloud 9 uses serviceDescription, not serviceSummary. #}
         </p>
-        <ul aria-label="tags" class="search-result-metadata">
-            <li class="search-result-metadata-item-inline">
+        <ul aria-label="tags" class="app-search-result__metadata">
+            <li class="govuk-!-display-inline govuk-!-padding-right-4">
                 {{ service.lot.name }}
             </li>
-            <li class="search-result-metadata-item-inline">
+            <li class="govuk-!-display-inline">
                 {{ service.frameworkName }}
             </li>
         </ul>
     </li>
+    {% endfor %}
 </ul>
-{% endfor %}

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1254,10 +1254,10 @@ class TestCatalogueOfBriefsPage(APIClientMixin, BaseApplicationTest):
         ss_elem = document.xpath("//p[@class='search-summary']")[0]
         assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "864 results found in All categories"
 
-        specialist_role_labels = document.xpath("//div[@class='search-result']/ul[2]/li[2]/text()")
+        specialist_role_labels = document.xpath("//li[@class='app-search-result']/ul[2]/li[2]/text()")
         assert len(specialist_role_labels) == 2  # only two briefs has a specialist role so only one label should exist
-        assert specialist_role_labels[0].strip() == "Developer"
-        assert specialist_role_labels[1].strip() == "Technical architect"
+        assert specialist_role_labels[0].strip() == "- Developer"
+        assert specialist_role_labels[1].strip() == "- Technical architect"
 
     def test_catalogue_of_briefs_page_filtered(self):
         original_url = "/digital-outcomes-and-specialists/opportunities?page=2"\
@@ -1615,37 +1615,37 @@ class TestCatalogueOfBriefsPage(APIClientMixin, BaseApplicationTest):
         document = html.fromstring(res.get_data(as_text=True))
 
         live_opportunity_published_at = document.xpath(
-            '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'
+            '//li[@class="app-search-result"][1]//ul[@class="app-search-result__metadata"]//li'
         )[-3].text_content().strip()
         assert live_opportunity_published_at == "Published: Friday 17 November 2017"
 
         live_opportunity_qs_closing_at = document.xpath(
-            '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'
+            '//li[@class="app-search-result"][1]//ul[@class="app-search-result__metadata"]//li'
         )[-2].text_content().strip()
         assert live_opportunity_qs_closing_at == "Deadline for asking questions: Sunday 26 November 2017"
 
         live_opportunity_closing_at = document.xpath(
-            '//div[@class="search-result"][1]//li[@class="search-result-metadata-item"]'
+            '//li[@class="app-search-result"][1]//ul[@class="app-search-result__metadata"]//li'
         )[-1].text_content().strip()
         assert live_opportunity_closing_at == "Closing: Friday 1 December 2017"
 
         closed_opportunity_status = document.xpath(
-            '//div[@class="search-result"][2]//li[@class="search-result-metadata-item"]'
+            '//li[@class="app-search-result"][2]//ul[@class="app-search-result__metadata"]//li'
         )[-1].text_content().strip()
         assert closed_opportunity_status == "Closed: awaiting outcome"
 
         unsuccessful_opportunity_status = document.xpath(
-            '//div[@class="search-result"][3]//li[@class="search-result-metadata-item"]'
+            '//li[@class="app-search-result"][3]//ul[@class="app-search-result__metadata"]//li'
         )[-1].text_content().strip()
         assert unsuccessful_opportunity_status == "Closed: no suitable suppliers"
 
         cancelled_opportunity_status = document.xpath(
-            '//div[@class="search-result"][4]//li[@class="search-result-metadata-item"]'
+            '//li[@class="app-search-result"][4]//ul[@class="app-search-result__metadata"]//li'
         )[-1].text_content().strip()
         assert cancelled_opportunity_status == "Closed: cancelled"
 
         awarded_opportunity_status = document.xpath(
-            '//div[@class="search-result"][6]//li[@class="search-result-metadata-item"]'
+            '//li[@class="app-search-result"][6]//ul[@class="app-search-result__metadata"]//li'
         )[-1].text_content().strip()
         assert awarded_opportunity_status == "Closed: awarded"
 


### PR DESCRIPTION
https://trello.com/c/ybGmz7dL/180-1-review-colour-size-of-text-on-search-result-items

We want to make sure our search result items meet WCAG colour and contrast guidelines.

* Use main text colour for metadata, but keep it sized a bit smaller - as per the Finder application.
* Wrap long words/urls so there's no horizontal scroll bar on small screens (addresses https://trello.com/c/GcVtrFWc/218-1-defect-26-search-page-horizontal-scroll-bar-appears-at-400)
* Make search results a list, rather than a number of divs.
* Underline title link (addresses https://trello.com/c/fHamN4xH/215-2-defect-23-search-item-description-text-contrast)
* Removes toolkit classes from search result items.

### Pages affected
`/g-cloud/search`
`/digital-outcomes-and-specialists/opportunities`