### PR TITLE
Replace filters with Option Select component

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -329,6 +329,7 @@ def search_services():
             if 'label' in filter_instance:
                 filter_instance['label'] = capitalize_first(filter_instance['label'])
                 filter_instance['text'] = capitalize_first(filter_instance['label'])
+            filter_instance['attributes'] = {"aria-controls": "search-summary-accessible-hint-wrapper"}
 
     clear_filters_url = get_request_url_without_any_filters(request, filters, view_name)
     search_query = query_args_for_pagination(clean_request_query_params)

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -323,11 +323,12 @@ def search_services():
     # annotate `filters` with their values as set in this request for re-rendering purposes.
     set_filter_states(filters.values(), request)
 
-    # Uppercase first character of filter labels for display
+    # Create filters that can be used with GOV.UK components
     for filter_groups in filters.values():
         for filter_instance in filter_groups['filters']:
             if 'label' in filter_instance:
                 filter_instance['label'] = capitalize_first(filter_instance['label'])
+                filter_instance['text'] = capitalize_first(filter_instance['label'])
 
     clear_filters_url = get_request_url_without_any_filters(request, filters, view_name)
     search_query = query_args_for_pagination(clean_request_query_params)

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -311,6 +311,7 @@ def list_opportunities(framework_family):
         for filter_instance in filter_groups['filters']:
             if 'label' in filter_instance:
                 filter_instance['label'] = capitalize_first(filter_instance['label'])
+                filter_instance['text'] = capitalize_first(filter_instance['label'])
 
     clear_filters_url = get_request_url_without_any_filters(
         request, filters, view_name, framework_family=framework_family

--- a/app/main/views/marketplace.py
+++ b/app/main/views/marketplace.py
@@ -312,6 +312,7 @@ def list_opportunities(framework_family):
             if 'label' in filter_instance:
                 filter_instance['label'] = capitalize_first(filter_instance['label'])
                 filter_instance['text'] = capitalize_first(filter_instance['label'])
+            filter_instance['attributes'] = {'aria-controls': 'search-summary-accessible-hint-wrapper'}
 
     clear_filters_url = get_request_url_without_any_filters(
         request, filters, view_name, framework_family=framework_family

--- a/app/templates/search/_filters.html
+++ b/app/templates/search/_filters.html
@@ -1,16 +1,18 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 <div class="dm-filters">
   {% include "search/_filter_title.html" %}
   <div>
     {% for filter in filters %}
-      {%
-        with
-        label = filter.label,
-        options_container_id = filter.slug,
-        options = filter.filters,
-        aria_controls="search-summary-accessible-hint-wrapper"
-      %}
-        {% include "toolkit/forms/option-select.html" %}
-      {% endwith %}
+      {{ govukCheckboxes({
+        "idPrefix": filter.slug,
+        "name": filter.slug,
+        "fieldset": {
+          "legend": {
+            "text": filter.label
+          }
+        },
+        "items": filter.filters
+      })}}
     {% endfor %}
   </div>
   {{ govukButton({

--- a/app/templates/search/_filters.html
+++ b/app/templates/search/_filters.html
@@ -1,20 +1,15 @@
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "digitalmarketplace/components/option-select/macro.njk" import dmOptionSelect %}
 <div class="dm-filters">
   {% include "search/_filter_title.html" %}
-  <div>
-    {% for filter in filters %}
-      {{ govukCheckboxes({
-        "idPrefix": filter.slug,
-        "name": filter.slug,
-        "fieldset": {
-          "legend": {
-            "text": filter.label
-          }
-        },
-        "items": filter.filters
-      })}}
-    {% endfor %}
-  </div>
+  {% for filter in filters %}
+    {{ dmOptionSelect({
+      "name": filter.slug,
+      "title": filter.label,
+      "options_container_id": filter.slug,
+      "items": filter.filters,
+      "closed_on_load": true
+    })}}
+  {% endfor %}
   {{ govukButton({
     "text": "Filter",
     "classes": "js-hidden js-dm-live-search",

--- a/app/templates/search/_search_layout.html
+++ b/app/templates/search/_search_layout.html
@@ -15,7 +15,7 @@
   {% block post_heading %}{% endblock %}
 
   <form action="{{ form_action }}" method="get" id="js-dm-live-search-form">
-    <section class="govuk-grid-column-one-third search-page-filters" aria-label="Search filters">
+    <section class="govuk-grid-column-one-third search-page-filters" aria-label="Search filters" role="search">
           {% include 'search/_filters_and_categories_wrapper.html' %}
           {% block post_filters %}{% endblock %}
     </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,9 +2063,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.1.0.tgz",
-      "integrity": "sha512-vwObFfAr2c7HEYiw6OpM4YlPiWF4HkG6U0UDKpUrrxARMtD+HnX7HsuQDFBxPCeMAlMtSftIZlzydHe2GwvxZw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.2.0.tgz",
+      "integrity": "sha512-tJFw3sO31YCoyLtL5pBDVTjdfaqMGZ1lWMun2lBRTM5xPbiYJ3T58Uitm9tXqK87U9jNo8QEcroSzhbAQU9qQg=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.13.1",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^2.1.0",
+    "digitalmarketplace-govuk-frontend": "^2.2.0",
     "govuk-frontend": "^2.13.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",

--- a/requirements.in
+++ b/requirements.in
@@ -10,4 +10,4 @@ lxml==4.5.2
 git+https://github.com/alphagov/digitalmarketplace-utils.git@52.10.0#egg=digitalmarketplace-utils==52.10.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.8.1#egg=digitalmarketplace-content-loader==7.8.1
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.2-alpha#egg=govuk-frontend-jinja==0.5.2-alpha
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.5-alpha#egg=govuk-frontend-jinja==0.5.5-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ fleep==1.0.1              # via digitalmarketplace-utils
 future==0.18.2            # via notifications-python-client
 gds-metrics==0.2.0        # via digitalmarketplace-utils
 govuk-country-register==0.5.0  # via digitalmarketplace-utils
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.2-alpha#egg=govuk-frontend-jinja==0.5.2-alpha  # via -r requirements.in
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.5-alpha#egg=govuk-frontend-jinja==0.5.5-alpha  # via -r requirements.in
 idna==2.9                 # via cryptography, requests
 inflection==0.3.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf


### PR DESCRIPTION
https://trello.com/c/VCANsToa/233-3-replace-search-filters-with-govuk-checkbox-groups-option-select

Adding option select should resolve the accessibility issues attached to this ticket.

Uses the new option select component: https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/183