### PR TITLE
Fix malformed HTML for guidance link

### DIFF
--- a/app/templates/direct-award/view-project.html
+++ b/app/templates/direct-award/view-project.html
@@ -128,7 +128,7 @@ Follow the <a href="https://www.gov.uk/guidance/g-cloud-buyers-guide#review-and-
               data-analytics-action="External Link">guidance for assessing services</a>. Choose the one that best meets
             your budget and requirements.'},
             {"type": "text", "text": 'Do not hold a competition to decide the winner. You can
-<a href="https://www.gov.uk/guidance/g-cloud-buyers-guide#what-to-do-if-you-have-a-question-for-the-suppliers
+<a href="https://www.gov.uk/guidance/g-cloud-buyers-guide#what-to-do-if-you-have-a-question-for-the-suppliers"
    data-analytics="trackEvent"
    class="govuk-link"
    data-analytics-category="Direct Award"


### PR DESCRIPTION
A missing '"' was causing problems. It didn't affect users - the link still worked fine. However, it looked really weird and probably messed up the analytics.

Now matches the form of the link just above it in the file