### PR TITLE
Move search box above filters and results

### DIFF
--- a/app/assets/javascripts/_live-search.js
+++ b/app/assets/javascripts/_live-search.js
@@ -1,0 +1,228 @@
+/*
+Key components:
+ - Div wrapping all content that might change, and the form to be monitored.
+   - Required id: js-dm-live-search-wrapper
+ - The form to be monitored for changes
+   - Required id: js-dm-live-search-form
+ - The form's submission button
+   - Required css selector: `button.button-save.js-dm-live-search`
+ - An arbitrary number of elements which should get updated.
+   - Requires a unique selector (recommend an id with prefix `js-dm-live-search-`)
+   - Required class: js-dm-live-search-fade (to hook into fade in/out functionality that telegraphs new content)
+
+This module enables updating arbitrary elements on the page after changes to checkboxes/radios/search inputs within the
+form on the page. The entire form, including elements which are going to change, must be wrapped within a div with the
+id `js-dm-live-search-wrapper`. The form inside must have the id `js-dm-live-search-form`. Arbitrary elements within the
+wrapper should be tagged with ids in a similar vein, e.g. with the prefix `js-dm-live-search-*`. Any elements whose
+content will change should have the class `js-dm-live-search-fade` to capture the fade in/out used to telegraph new
+content. The form's submit button (`button.button-save.js-dm-live-search`) should have the `js-hidden` class by default;
+this will be removed if the browser's Javascript does not support accessing history.
+
+When the form detects a change, it will post to the form's associated endpoint after injecting a `live-results=true`
+query parameter. The view must intercept this and return a JSON blob with the below structure:
+
+endpoint response (application/json):
+  {
+    "example-1": {
+      "selector": "#example1-selector",
+      "html": "<HTML>"
+    }
+    "example-2": {
+      "selector": "#example2-selector",
+      "html": "<HTML>"
+    }
+  }
+
+*/
+
+(function ($) {
+    "use strict";
+  
+    var LiveSearch = function($wrapper){
+      // Attach filter-on-click functionality if this page has a live-search form.
+      this.$wrapper = $wrapper;
+      this.$form = this.$wrapper.find('#js-dm-live-search-form');
+      this.$options = this.$form.find('.govuk-option-select').find("input[type='checkbox']");
+      this.$searchSubmitButton = this.$form.find('.dm-keyword-search__submit');
+      this.$searchInput = this.$form.find('.dm-keyword-search__input');
+      this.$saveSearchButton = this.$form.find('button#save-search')
+  
+      this.state = false;
+      this.previousState = false;
+      this.resultsCache = {};
+  
+      if(GOVUK.GDM.support.history()) {
+        this.originalState = this.$form.serializeArray();
+        this.saveState();
+        this.$form.on('change', 'input[type=checkbox], input[type=search], input[type=radio]', this.formChange.bind(this));
+        $(window).on('popstate', this.popState.bind(this));
+  
+        this.$searchSubmitButton.on('click',
+          function(e){
+            this.formChange();
+            e.preventDefault();
+          }.bind(this)
+        );
+        this.$searchInput.keypress(
+          function(e){
+            if(e.keyCode == 13) {
+              // 13 is the return key
+              this.formChange();
+              e.preventDefault();
+            }
+          }.bind(this)
+        );
+      } else {
+        this.$form.find('button.button-save.js-dm-live-search').removeClass('js-hidden');
+      }
+    }
+  
+    LiveSearch.init = function() {}
+  
+    LiveSearch.prototype.saveState = function saveState(state){
+      if(typeof state === 'undefined'){
+        state = this.$form.serializeArray();
+      }
+      this.previousState = this.state;
+      this.state = state;
+    };
+  
+    LiveSearch.prototype.popState = function popState(event){
+      if(event.originalEvent.state){
+        this.saveState(event.originalEvent.state);
+      } else {
+        this.saveState(this.originalState);
+      }
+  
+      this.restoreBooleans();
+      this.restoreSearchInputs();
+      this.updateResults();
+    };
+  
+    LiveSearch.prototype.formChange = function formChange(e){
+      var pageUpdated;
+      if(this.isNewState()){
+        this.saveState();
+        pageUpdated = this.updateResults();
+        pageUpdated.done(
+          function(){
+            var newPath = window.location.origin + window.location.pathname + "?" + $.param(this.state);
+            history.pushState(this.state, '', newPath);
+            if (GOVUK.analytics && GOVUK.analytics.trackPageview) {
+              GOVUK.analytics.trackPageview(newPath);
+            }
+          }.bind(this)
+        );
+      }
+    };
+  
+    LiveSearch.prototype.cache = function cache(slug, data) {
+      if(typeof data === 'undefined'){
+        return this.resultsCache[slug];
+      } else {
+        this.resultsCache[slug] = data;
+      }
+    };
+  
+    LiveSearch.prototype.isNewState = function isNewState(){
+      return $.param(this.state) !== this.$form.serialize();
+    };
+  
+    LiveSearch.prototype.updateResults = function updateResults(){
+      this.showLoadingIndicators();
+  
+      var liveSearch = this;
+      var searchState = $.param(this.state);
+      var liveState = this.$form.serializeArray();
+      var cachedResultData = this.cache(searchState);
+  
+      liveState.push({'name': 'live-results', 'value': true})
+  
+      if(typeof(cachedResultData) === 'undefined') {
+        return $.ajax({
+          url: this.$form.attr('action'),
+          data: $.param(liveState),
+          searchState: searchState
+  
+        }).done(function(response){
+          liveSearch.cache(this.searchState, response);
+          liveSearch.displayFilterResults(response, this.searchState);
+  
+        }).fail(function(response){
+          liveSearch.showErrorIndicator();
+  
+        })
+      } else {
+        this.displayFilterResults(cachedResultData, searchState);
+        var out = new $.Deferred();
+        return out.resolve();
+      }
+    };
+  
+    LiveSearch.prototype.showLoadingIndicators = function showLoadingIndicators() {
+      $('div[class=js-dm-live-search-fade]').css('opacity', '0.25')
+      $('#js-dm-live-search-info').text('Loading...');
+    }
+  
+    LiveSearch.prototype.showErrorIndicator = function showErrorIndicator() {
+      $('#js-dm-live-search-info').text('Error. Please try modifying your search and trying again.');
+    }
+  
+    LiveSearch.prototype.displayFilterResults = function displayFilterResults(response, state) {
+      // The !(state === "") is required for browser versions which trigger the popstate event on first pageload
+      if(state == $.param(this.state) && !(state === "")) {
+        for (var blockToReplace in response) {
+          this.replaceBlock(response[blockToReplace]['selector'], response[blockToReplace]['html']);
+        }
+  
+        $('div[class=js-dm-live-search-fade]').css('opacity', '1')
+      }
+    }
+  
+    LiveSearch.prototype.replaceBlock = function replaceBlock(selector, html) {
+      $(selector)[0].outerHTML = html;
+    }
+  
+    LiveSearch.prototype.restoreBooleans = function restoreBooleans(){
+      var that = this;
+      this.$form.find('input[type=checkbox], input[type=radio]').each(function(i, el){
+        var $el = $(el);
+        $el.prop('checked', that.isBooleanSelected($el.attr('name'), $el.attr('value')));
+      });
+    };
+  
+    LiveSearch.prototype.isBooleanSelected = function isBooleanSelected(name, value){
+      var i, _i;
+      for(i=0,_i=this.state.length; i<_i; i++){
+        if(this.state[i].name === name && this.state[i].value === value){
+          return true;
+        }
+      }
+      return false;
+    };
+  
+    LiveSearch.prototype.restoreSearchInputs = function restoreSearchInputs(){
+      var that = this;
+      this.$form.find('input[type=search]').each(function(i, el){
+        var $el = $(el);
+        $el.val(that.getTextInputValue($el.attr('name')));
+      });
+    };
+  
+    LiveSearch.prototype.getTextInputValue = function getTextInputValue(name){
+      var i, _i;
+      for(i=0,_i=this.state.length; i<_i; i++){
+        if(this.state[i].name === name){
+          return this.state[i].value
+        }
+      }
+      return '';
+    };
+  
+    GOVUK = GOVUK || {};
+    GOVUK.GDM = GOVUK.GDM || {};
+    GOVUK.GDM.LiveSearch = LiveSearch;
+  
+    // Instantiate an option select for each one found on the page
+    var form = new GOVUK.GDM.LiveSearch($('#js-dm-live-search-wrapper'));
+  })(jQuery);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,7 +8,6 @@
 //= require ../../../node_modules/scrolldepth/jquery.scrolldepth.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/option-select.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/support.js
-//= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/live-search.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/list-entry.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/clear-filters.js
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/word-counter.js
@@ -20,6 +19,7 @@
 //= require ../../../node_modules/digitalmarketplace-frontend-toolkit/toolkit/javascripts/show-hide-content.js
 //= require _onready.js'
 //= require _selection-buttons.js
+//= require _live-search.js
 
 GOVUKFrontend.initAll();
 DMGOVUKFrontend.initAll();

--- a/app/templates/search/_filters.html
+++ b/app/templates/search/_filters.html
@@ -5,9 +5,9 @@
     {{ dmOptionSelect({
       "name": filter.slug,
       "title": filter.label,
-      "options_container_id": filter.slug,
+      "optionsContainerId": filter.slug,
       "items": filter.filters,
-      "closed_on_load": true
+      "closedOnLoad": true
     })}}
   {% endfor %}
   {{ govukButton({

--- a/app/templates/search/_filters_and_categories_wrapper.html
+++ b/app/templates/search/_filters_and_categories_wrapper.html
@@ -1,13 +1,3 @@
-{%
-  with
-  id = "keywords",
-  name = "q",
-  label = "Keyword search",
-  value = search_keywords
-%}
-  {% include "toolkit/forms/keyword-search.html" %}
-{% endwith %}
-
 {% include 'search/_categories_wrapper.html' %}
 
 {% for f in filter_form_hidden_fields %}

--- a/app/templates/search/_search_layout.html
+++ b/app/templates/search/_search_layout.html
@@ -1,4 +1,5 @@
 {% extends "_base_page.html" %}
+{% from "digitalmarketplace/components/keyword-search/macro.njk" import dmKeywordSearch %}
 
 {% block head %}
   <meta name="robots" content="noindex">
@@ -11,34 +12,48 @@
 {% block page_heading %}{% endblock %}
 </section>
 
-<div id="js-dm-live-search-wrapper" class="govuk-grid-row search-results-page">
+<div id="js-dm-live-search-wrapper" class="search-results-page">
   {% block post_heading %}{% endblock %}
-
+      
   <form action="{{ form_action }}" method="get" id="js-dm-live-search-form">
-    <section class="govuk-grid-column-one-third search-page-filters" aria-label="Search filters" role="search">
-          {% include 'search/_filters_and_categories_wrapper.html' %}
-          {% block post_filters %}{% endblock %}
-    </section>
-  </form>
-
-  <section class="govuk-grid-column-two-thirds" aria-label="Search results">
-    {#
-      the element referenced by an `aria-controls=` seems to need to be persistent -
-      at least I wasn't able to get it to work by just re-using a fragment of the
-      existing search summary text, as it gets removed and replaced wholesale by
-      the javascript when a new set of results is fetched.
-
-      instead, we have this dedicated (and more importantly, persistent) wrapper
-      element, which itself can be the target of `aria-controls=`
-    #}
-    <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="additions text">
-      {% include 'search/_summary_accessible_hint.html' %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {{ dmKeywordSearch({
+          "id": "search-keywords",
+          "ariaLabel": "keywords",
+          "label": "Keyword search",
+          "inputId": "keywords",
+          "inputLabel": "Keyword search",
+          "inputName": "q",
+          "inputValue": search_keywords,
+          "inputAriaControls": "search-summary-accessible-hint-wrapper"
+        })}}
+      </div>
     </div>
-    {% block pre_results %}
-      {% include 'search/_summary.html' %}
-    {% endblock %}
-    {% include 'search/_results_wrapper.html' %}
-  </section>
+    <div class="govuk-grid-row">
+      <section class="govuk-grid-column-one-third search-page-filters" aria-label="Search filters" role="search">
+        {% include 'search/_filters_and_categories_wrapper.html' %}
+        {% block post_filters %}{% endblock %}
+      </section>  
+      <section class="govuk-grid-column-two-thirds" aria-label="Search results">
+        {#
+          the element referenced by an `aria-controls=` seems to need to be persistent -
+          at least I wasn't able to get it to work by just re-using a fragment of the
+          existing search summary text, as it gets removed and replaced wholesale by
+          the javascript when a new set of results is fetched.
 
+          instead, we have this dedicated (and more importantly, persistent) wrapper
+          element, which itself can be the target of `aria-controls=`
+        #}
+        <div id="search-summary-accessible-hint-wrapper" class="search-summary-accessible-hint-wrapper" aria-atomic="true" aria-live="polite" aria-relevant="additions text">
+          {% include 'search/_summary_accessible_hint.html' %}
+        </div>
+        {% block pre_results %}
+          {% include 'search/_summary.html' %}
+        {% endblock %}
+        {% include 'search/_results_wrapper.html' %}
+      </section>
+    </div>
+  </form>
 </div>
 {% endblock %}

--- a/app/templates/search/_search_layout.html
+++ b/app/templates/search/_search_layout.html
@@ -1,5 +1,5 @@
 {% extends "_base_page.html" %}
-{% from "digitalmarketplace/components/keyword-search/macro.njk" import dmKeywordSearch %}
+{% from "digitalmarketplace/components/search-box/macro.njk" import dmSearchBox %}
 
 {% block head %}
   <meta name="robots" content="noindex">
@@ -18,7 +18,7 @@
   <form action="{{ form_action }}" method="get" id="js-dm-live-search-form">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        {{ dmKeywordSearch({
+        {{ dmSearchBox({
           "id": "search-keywords",
           "ariaLabel": "keywords",
           "label": "Keyword search",

--- a/app/templates/search/_services_save_search.html
+++ b/app/templates/search/_services_save_search.html
@@ -1,19 +1,11 @@
 {# this file can be used from contexts that don't inherit from _base_page.html, so we must ensure we have all imports we need #}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-
 <div id="js-dm-live-save-search-form">
-  <form action="{{ url_for('direct_award.save_search', framework_family=framework_family) }}">
-    <input type="hidden" name="search_query" value="{{ search_query_url }}">
-        {{ govukButton({
-          "text": "Save your search",
-          "attributes": {
-            "id": "save-search",
-            "role": "button",
-            "data-analytics": "trackEvent",
-            "data-analytics-category": "Direct Award",
-            "data-analytics-action": "Save search",
-            "data-analytics-label": search_count|string(),
-          },
-        }) }}
-  </form>
+  <a 
+    class="govuk-button"
+    href="{{ url_for('direct_award.save_search', framework_family=framework_family) }}?search_query={{ search_query_url | urlencode }}"
+    data-analytics="trackEvent"
+    data-analytics-category="Direct Award"
+    data-analytics-action="Save search"
+    data-analytics-label="{{ search_count | string() }}"
+  >Save your search</a>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,9 +2063,9 @@
       }
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.2.0.tgz",
-      "integrity": "sha512-tJFw3sO31YCoyLtL5pBDVTjdfaqMGZ1lWMun2lBRTM5xPbiYJ3T58Uitm9tXqK87U9jNo8QEcroSzhbAQU9qQg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/digitalmarketplace-govuk-frontend/-/digitalmarketplace-govuk-frontend-2.3.0.tgz",
+      "integrity": "sha512-iee9PwxuiTYGyr4VWVAQ/xg4NZBhcDp6S0b8DNOVWVeS/vy2ZU+w5bSd8+ToJiav0IjROyNup6wGQbxLIJSwfA=="
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.13.1",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
-    "digitalmarketplace-govuk-frontend": "^2.2.0",
+    "digitalmarketplace-govuk-frontend": "^2.3.0",
     "govuk-frontend": "^2.13.0",
     "govuk-elements-sass": "3.0.3",
     "govuk_frontend_toolkit": "5.0.3",

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -129,17 +129,16 @@ class TestDirectAward(TestDirectAwardBase):
                     "The work has been cancelled"
                 ]
 
-    def test_renders_save_search_button(self):
+    def test_renders_save_search_link(self):
         self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get(self.SEARCH_URL)
         assert res.status_code == 200
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('id("js-dm-live-save-search-form")//input[@name="search_query"]'
-                         '/@value')[0] == self.SIMPLE_SEARCH_PARAMS
-        assert doc.xpath('id("js-dm-live-save-search-form")//form/@action')[0] == self.SAVE_SEARCH_URL
-        assert len(doc.xpath('id("js-dm-live-save-search-form")//form//button[@type="submit"]')) > 0
+        href = self.SAVE_SEARCH_URL + '?search_query=' + quote_plus(self.SIMPLE_SEARCH_PARAMS)
+        assert doc.xpath('id("js-dm-live-save-search-form")//a[@class="govuk-button"]'
+                         '/@href')[0] == href
 
     def test_save_search_redirects_to_login(self):
         res = self.client.get(self.SIMPLE_SAVE_SEARCH_URL)

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1249,7 +1249,7 @@ class TestCatalogueOfBriefsPage(APIClientMixin, BaseApplicationTest):
         }
 
         q_inputs = document.xpath("//form[@method='get']//input[@name='q']")
-        assert tuple(element.get("value") for element in q_inputs) == ("",)
+        assert tuple(element.get("value") for element in q_inputs) == (None,)
 
         ss_elem = document.xpath("//p[@class='search-summary']")[0]
         assert self._normalize_whitespace(self._squashed_element_text(ss_elem)) == "864 results found in All categories"
@@ -1336,7 +1336,7 @@ class TestCatalogueOfBriefsPage(APIClientMixin, BaseApplicationTest):
         }
 
         q_inputs = document.xpath("//form[@method='get']//input[@name='q']")
-        assert tuple(element.get("value") for element in q_inputs) == ("",)
+        assert tuple(element.get("value") for element in q_inputs) == (None,)
 
         parsed_original_url = urlparse(original_url)
         parsed_prev_url = urlparse(document.xpath("//li[@class='previous']/a/@href")[0])
@@ -1512,7 +1512,7 @@ class TestCatalogueOfBriefsPage(APIClientMixin, BaseApplicationTest):
         }
 
         q_inputs = document.xpath("//form[@method='get']//input[@name='q']")
-        assert tuple(element.get("value") for element in q_inputs) == ("",)
+        assert tuple(element.get("value") for element in q_inputs) == (None,)
 
         parsed_original_url = urlparse(original_url)
         parsed_next_url = urlparse(document.xpath("//li[@class='next']/a/@href")[0])


### PR DESCRIPTION
https://trello.com/c/IskqE8Gy/167-2-move-search-box-to-top-of-page

Makes use of the new search box component https://github.com/alphagov/digitalmarketplace-govuk-frontend/pull/185

Moving the search button resulted in needing to have the form element cover the filters _and_ results (like GOV.UK, but unlike this page initially, where the form just covered the filters and not the results).

This created some issues with the "Save your search" button, which was previously contained in its own form, but is now contained within the overarching form. I've solved this by converting it to a "Save your search" link, since its only purpose was to redirect to another URL.

I've also had to take the live search script out of dm-frontend-toolkit and make some tweaks. I'd like to edit it to remove the jQuery dependency and move it into digitalmarketplace-govuk-frontend, but that's a task for another day.

![Screenshot 2020-10-01 at 09 48 11](https://user-images.githubusercontent.com/22524634/94788263-3d806080-03cb-11eb-97fa-3fb01f219d66.png)

