### PR TITLE
Take latest version of frameworks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2051,8 +2051,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "github:alphagov/digitalmarketplace-frameworks#c10a8faf10bc7fe17a59dcade058be166d1867b8",
-      "from": "github:alphagov/digitalmarketplace-frameworks#v17.13.1"
+      "version": "github:alphagov/digitalmarketplace-frameworks#dfd3eda5704977e2685543760f06f21c9155cbe8",
+      "from": "github:alphagov/digitalmarketplace-frameworks#v17.17.8"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.13.1",
+    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.17.8",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^2.4.0",
     "govuk-frontend": "^2.13.0",


### PR DESCRIPTION
Should fix the date on the homepage (currently 2525), and hopefully no other effects.