### PR TITLE
Add commas to price formatting on G-Cloud service pages

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,6 @@ itsdangerous==1.1.0
 lxml==4.5.2
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@54.0.0#egg=digitalmarketplace-utils==54.0.0
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.8.1#egg=digitalmarketplace-content-loader==7.8.1
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.0#egg=digitalmarketplace-content-loader==7.26.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.5-alpha#egg=govuk-frontend-jinja==0.5.5-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,8 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.8.1#egg=digitalmarketplace-content-loader==7.8.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@54.0.0#egg=digitalmarketplace-utils==54.0.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.0#egg=digitalmarketplace-content-loader==7.26.0  # via -r requirements.in
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-gzip==0.2           # via digitalmarketplace-utils


### PR DESCRIPTION
Bump digitalmarketplace-content-loader version to pick up changes from https://github.com/alphagov/digitalmarketplace-content-loader/pull/115

Closes https://trello.com/c/UL5WzBD7/1412-add-commas-to-price-formatting-on-g-cloud-service-pages and https://github.com/alphagov/digitalmarketplace-frameworks/issues/626