### PR TITLE
Replace date input component with govukDateInput

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -6,6 +6,7 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -40,9 +40,69 @@
       <form method="POST" action="{{ url_for('direct_award.tell_us_about_contract', framework_family=framework.family, project_id=project.id, outcome_id=outcome_id) }}" class="tell-us-about-contract-form" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-        {{ form.start_date}}
+        {{ govukDateInput ({
+          "id": "input-start_date",
+          "namePrefix": "start_date",
+          "fieldset": {
+            "legend": {
+              "text": form.start_date.question,
+              "classes": "govuk-fieldset__legend--m"
+            }
+          },
+          "hint": {
+            "text": form.start_date.hint
+          } if form.start_date.hint,
+          "errorMessage": errors.start_date.errorMessage if errors.start_date.errorMessage,
+          "items": [
+            {
+              "classes": "govuk-input--width-2",
+              "name": "day",
+              "value": form.start_date.value['start_date-day'] if form.start_date.value['start_date-day']
+            },
+            {
+              "classes": "govuk-input--width-2",
+              "name": "month",
+              "value": form.start_date.value['start_date-month'] if form.start_date.value['start_date-month']
+            },
+            {
+              "classes": "govuk-input--width-4",
+              "name": "year",
+              "value": form.start_date.value['start_date-year'] if form.start_date.value['start_date-year']
+            }
+          ]
+        })}}
 
-        {{ form.end_date }}
+        {{ govukDateInput ({
+          "id": "input-end_date",
+          "namePrefix": "end_date",
+          "fieldset": {
+            "legend": {
+              "text": form.end_date.question,
+              "classes": "govuk-fieldset__legend--m"
+            }
+          },
+          "hint": {
+            "text": form.end_date.hint
+          } if form.end_date.hint,
+          "errorMessage": errors.end_date.errorMessage if errors.end_date.errorMessage,
+          "items": [
+            {
+              "classes": "govuk-input--width-2",
+              "name": "day",
+              "value": form.end_date.value['end_date-day'] if form.end_date.value['end_date-day']
+            },
+            {
+              "classes": "govuk-input--width-2",
+              "name": "month",
+              "value": form.end_date.value['end_date-month'] if form.end_date.value['end_date-month']
+            },
+            {
+              "classes": "govuk-input--width-4",
+              "name": "year",
+              "value": form.end_date.value['end_date-year'] if form.end_date.value['end_date-year']
+            }
+          ]
+        })}}
 
         {{ form.value_in_pounds }}
 

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -55,17 +55,17 @@
           "errorMessage": errors.start_date.errorMessage if errors.start_date.errorMessage,
           "items": [
             {
-              "classes": "govuk-input--width-2" + (' govuk-input--error' if errors.start_date.errorMessage),
+              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if errors.start_date.errorMessage),
               "name": "day",
               "value": form.start_date.value['start_date-day'] if form.start_date.value['start_date-day']
             },
             {
-              "classes": "govuk-input--width-2" + (' govuk-input--error' if errors.start_date.errorMessage),
+              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if errors.start_date.errorMessage),
               "name": "month",
               "value": form.start_date.value['start_date-month'] if form.start_date.value['start_date-month']
             },
             {
-              "classes": "govuk-input--width-4" + (' govuk-input--error' if errors.start_date.errorMessage),
+              "classes": "govuk-input--width-4" ~ (' govuk-input--error' if errors.start_date.errorMessage),
               "name": "year",
               "value": form.start_date.value['start_date-year'] if form.start_date.value['start_date-year']
             }
@@ -87,17 +87,17 @@
           "errorMessage": errors.end_date.errorMessage if errors.end_date.errorMessage,
           "items": [
             {
-              "classes": "govuk-input--width-2" + (' govuk-input--error' if errors.end_date.errorMessage),
+              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if errors.end_date.errorMessage),
               "name": "day",
               "value": form.end_date.value['end_date-day'] if form.end_date.value['end_date-day']
             },
             {
-              "classes": "govuk-input--width-2" + (' govuk-input--error' if errors.end_date.errorMessage),
+              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if errors.end_date.errorMessage),
               "name": "month",
               "value": form.end_date.value['end_date-month'] if form.end_date.value['end_date-month']
             },
             {
-              "classes": "govuk-input--width-4" + (' govuk-input--error' if errors.end_date.errorMessage),
+              "classes": "govuk-input--width-4" ~ (' govuk-input--error' if errors.end_date.errorMessage),
               "name": "year",
               "value": form.end_date.value['end_date-year'] if form.end_date.value['end_date-year']
             }

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -55,17 +55,17 @@
           "errorMessage": errors.start_date.errorMessage if errors.start_date.errorMessage,
           "items": [
             {
-              "classes": "govuk-input--width-2",
+              "classes": "govuk-input--width-2" + (' govuk-input--error' if errors.start_date.errorMessage),
               "name": "day",
               "value": form.start_date.value['start_date-day'] if form.start_date.value['start_date-day']
             },
             {
-              "classes": "govuk-input--width-2",
+              "classes": "govuk-input--width-2" + (' govuk-input--error' if errors.start_date.errorMessage),
               "name": "month",
               "value": form.start_date.value['start_date-month'] if form.start_date.value['start_date-month']
             },
             {
-              "classes": "govuk-input--width-4",
+              "classes": "govuk-input--width-4" + (' govuk-input--error' if errors.start_date.errorMessage),
               "name": "year",
               "value": form.start_date.value['start_date-year'] if form.start_date.value['start_date-year']
             }
@@ -87,17 +87,17 @@
           "errorMessage": errors.end_date.errorMessage if errors.end_date.errorMessage,
           "items": [
             {
-              "classes": "govuk-input--width-2",
+              "classes": "govuk-input--width-2" + (' govuk-input--error' if errors.end_date.errorMessage),
               "name": "day",
               "value": form.end_date.value['end_date-day'] if form.end_date.value['end_date-day']
             },
             {
-              "classes": "govuk-input--width-2",
+              "classes": "govuk-input--width-2" + (' govuk-input--error' if errors.end_date.errorMessage),
               "name": "month",
               "value": form.end_date.value['end_date-month'] if form.end_date.value['end_date-month']
             },
             {
-              "classes": "govuk-input--width-4",
+              "classes": "govuk-input--width-4" + (' govuk-input--error' if errors.end_date.errorMessage),
               "name": "year",
               "value": form.end_date.value['end_date-year'] if form.end_date.value['end_date-year']
             }

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -1003,8 +1003,8 @@ class TestDirectAwardTellUsAboutContract(TestDirectAwardBase):
         assert xpath('boolean(//h1[contains(normalize-space(), "Tell us about your contract")])')
 
     def test_tell_us_about_contract_form_fields(self, xpath):
-        assert len(xpath('//input[@type="text"][substring-after(@name, "start_date")]')) == 3
-        assert len(xpath('//input[@type="text"][substring-after(@name, "end_date")]')) == 3
+        assert len(xpath('//input[@type="number"][substring-after(@name, "start_date")]')) == 3
+        assert len(xpath('//input[@type="number"][substring-after(@name, "end_date")]')) == 3
         assert xpath('//input[@type="text"][contains(@name, "value_in_pounds")]')
         assert xpath('//input[@type="text"][contains(@name, "buying_organisation")]')
         assert xpath('//button[normalize-space(string())=$t]', t="Submit")
@@ -1086,7 +1086,7 @@ class TestDirectAwardTellUsAboutContract(TestDirectAwardBase):
         assert res.status_code == 400
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert doc.xpath('count(//span[@class="validation-message"])') == 1
+        assert doc.xpath('count(//span[@class="govuk-error-message"])') == 1
         errors = doc.cssselect('div.govuk-error-summary a')
         assert len(errors) == 1
         assert errors[0].text_content() == 'Your end date must be later than the start date.'


### PR DESCRIPTION
https://trello.com/c/iAataleT/209-2-replace-date-input-component-in-search-g-cloud-services-journey-2

This change does make the view template more verbose, but we could address this separately as a task to review how we generate presentation data for WTForm-based form questions.