### PR TITLE
Replace radios in search G-Cloud services journey

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-09-04T09:47:27Z",
+  "generated_at": "2020-10-28T09:56:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -86,14 +86,14 @@
         "hashed_secret": "7fdcc2ca8d31036191dc585103afd9a36d528458",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 94,
+        "line_number": 97,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "fa2e2ce16e875b194857d4a6a7a7ae2695d4c284",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 100,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/app/assets/scss/application.scss
+++ b/app/assets/scss/application.scss
@@ -78,6 +78,7 @@ $govuk-global-styles: true;
 @import "overrides/_notification-banners.scss";
 @import "overrides/_temporary-messages.scss";
 @import "overrides/_summary-list.scss";
+@import "overrides/_radios.scss";
 
 // Misc styles
 // TODO: Move misc styling into their own partial files or the Digital Marketplace FE Toolkit

--- a/app/assets/scss/overrides/_radios.scss
+++ b/app/assets/scss/overrides/_radios.scss
@@ -1,0 +1,16 @@
+/* On the "Which service won the contract page", we want to display hints for each options, but
+there are potentially a LOT of options, which is a lot of text to parse. We can make this easier
+by making the hint text a little smaller. We apply this style generically to achieve consistency
+across other pages. We can review this when updated to Design System 3 to decide if we still want
+the font size to be smaller */
+.govuk-radios__hint {
+    @include core-16;
+}
+
+/* On the choose-lot page, options have both a description and a hint. Before we review this
+content, we style the description so that it matches the previous styling */
+.dm-options__description {
+    display: inline-block;
+    color: $govuk-text-colour;
+    padding-bottom: govuk-spacing(2);
+}

--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 
-from wtforms.validators import DataRequired, Length, NumberRange, InputRequired, ValidationError
+from wtforms.validators import DataRequired, Length, NumberRange, InputRequired
 
 from dmutils.forms.fields import (
     DMBooleanField,
@@ -41,17 +41,14 @@ class CreateProjectForm(FlaskForm):
             }
         })
 
-        # href for name field is assigned by digitalmarketplace-frontend-toolkit
-        # based on how many options there are above
-        self.name.href = f"input-save_search_selection-{len(self.save_search_selection.options)}-name"
 
-    def validate_name(form, field):
-        if form.save_search_selection.data == "new_search":
-            try:
-                Length(min=1, max=100, message="Search name must be between 1 and 100 characters")(form, field)
-            except ValidationError as e:
-                form.save_search_selection.options[-1]["reveal"]["error"] = e.args[0]
-                raise
+class CreateNewProjectForm(FlaskForm):
+    project_name = DMStripWhitespaceStringField(
+        "Name your search. A reference number or short description of what you want to buy makes a good name.",
+        validators=[
+            Length(min=1, max=100, message="Enter a name for your search between 1 and 100 characters")
+        ],
+    )
 
 
 class DidYouAwardAContractForm(FlaskForm):

--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -22,6 +22,7 @@ from app import search_api_client, data_api_client, content_loader
 from ..exceptions import AuthException
 from ..forms.direct_award_forms import (
     CreateProjectForm,
+    CreateNewProjectForm,
     BeforeYouDownloadForm,
     DidYouAwardAContractForm,
     TellUsAboutContractForm,
@@ -512,20 +513,28 @@ def save_search(framework_family):
 
     default_selection = {"save_search_selection": "new_search"} if not projects else {}
     form = CreateProjectForm(projects, data=default_selection)
-
-    save_search_options = govuk_options(form.save_search_selection.options)
-    save_search_options.insert(len(save_search_options) - 1, {"divider": "or"})
+    save_search_options = []
+    for project in projects:
+        save_search_options.append({
+            "text": project["name"] or f"Untitled project {project['id']}",
+            "value": str(project["id"])
+        })
+    if len(save_search_options) > 0:
+        save_search_options.append({"divider": "or"})
+    save_search_options.append({
+        "text": "Save a new search",
+        "value": "new_search"
+    })
 
     if form.validate_on_submit():
         if form.save_search_selection.data == "new_search":
-            try:
-                api_project = data_api_client.create_direct_award_project(user_id=current_user.id,
-                                                                          user_email=current_user.email_address,
-                                                                          project_name=form.name.data)
-            except HTTPError as e:
-                abort(e.status_code)
-
-            project = api_project['project']
+            return redirect(
+                url_for(
+                    '.save_new_search',
+                    framework_family=framework_family,
+                    search_query=request.values['search_query']
+                )
+            )
         else:
             project = data_api_client.get_direct_award_project(project_id=form.save_search_selection.data)['project']
             if not project or not is_direct_award_project_accessible(project, current_user.id):
@@ -567,6 +576,82 @@ def save_search(framework_family):
                                save_search_options=save_search_options,
                                search_summary_sentence=search_summary.markup(),
                                search_query=url_encode(search_query),
+                               search_url=url_for('main.search_services', **search_query),
+                               framework_family=framework_family), 400 if request.method == 'POST' else 200
+
+
+@direct_award.route('/<string:framework_family>/save-new-search', methods=['GET', 'POST'])
+def save_new_search(framework_family):
+    if "search_query" not in request.values:
+        abort(400)
+
+    # Get core data
+    all_frameworks = data_api_client.find_frameworks().get('frameworks')
+    framework = framework_helpers.get_latest_live_framework_or_404(all_frameworks, framework_family)
+    lots_by_slug = framework_helpers.get_lots_by_slug(framework)
+
+    search_query = url_decode(request.values['search_query'])
+
+    current_lot_slug = get_valid_lot_from_args_or_none(search_query, lots_by_slug)
+
+    content_manifest = content_loader.get_manifest(framework['slug'], 'services_search_filters')
+    filters = filters_for_lot(current_lot_slug, content_manifest, all_lots=framework['lots'])
+    clean_request_query_params = clean_request_args(search_query, filters.values(), lots_by_slug)
+
+    form = CreateNewProjectForm()
+
+    if form.validate_on_submit():
+        try:
+            api_project = data_api_client.create_direct_award_project(user_id=current_user.id,
+                                                                      user_email=current_user.email_address,
+                                                                      project_name=form.project_name.data)
+        except HTTPError as e:
+            abort(e.status_code)
+
+        project = api_project['project']
+
+        search_api_url = search_api_client.get_search_url(
+            index=framework['slug'],
+            **build_search_query(search_query, filters.values(), content_manifest, lots_by_slug)
+        )
+        try:
+            data_api_client.create_direct_award_project_search(user_id=current_user.id,
+                                                               user_email=current_user.email_address,
+                                                               project_id=project['id'],
+                                                               search_url=search_api_url)
+
+        except HTTPError as e:
+            abort(e.status_code)
+
+        flash(PROJECT_SAVED_MESSAGE, 'success')
+
+        return redirect(url_for('.view_project',
+                                framework_family=framework_family,
+                                project_id=project['id']
+                                ), code=303)
+    else:
+        # Retrieve results so we can display SearchSummary
+        search_api_response = search_api_client.search(
+            index=framework['slug'],
+            doc_type='services',
+            **build_search_query(search_query, filters.values(), content_manifest, lots_by_slug)
+        )
+        search_summary = SearchSummary(search_api_response['meta']['total'], clean_request_query_params.copy(),
+                                       filters.values(), lots_by_slug)
+
+        return render_template('direct-award/save-new-search.html',
+                               errors=get_errors_from_wtform(form),
+                               form=form,
+                               search_summary_sentence=search_summary.markup(),
+                               action_url=url_for(
+                                   '.save_new_search',
+                                   framework_family=framework_family,
+                                   search_query=url_encode(search_query)
+                               ),
+                               save_search_url=url_for(
+                                   '.save_search',
+                                   framework_family=framework_family,
+                                   search_query=request.values['search_query']),
                                search_url=url_for('main.search_services', **search_query),
                                framework_family=framework_family), 400 if request.method == 'POST' else 200
 

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -8,6 +8,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -23,6 +23,10 @@
 
 {% set assetPath = '/static' %}
 
+{% block pageTitle %}
+  {% if errors %}Error: {% endif %}{{ page_name }} - Digital Marketplace
+{% endblock %}
+
 {% block head %}
   {% include "digitalmarketplace/templates/layouts/_custom_dimensions.html" %}
   {% include "digitalmarketplace/templates/layouts/_site_verification.html" %}

--- a/app/templates/choose-lot.html
+++ b/app/templates/choose-lot.html
@@ -24,43 +24,28 @@
 
 {% block mainContent %}
 
+{% set question = title|capitalize %}
+{% set errorMessage = errors.get("lot", {}).get("message", None) %}
+
 <div>
-
-  <h1 class="govuk-heading-xl">
-    {{ title|capitalize }}
-  </h1>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ url_for('direct_award_public.choose_lot', framework_family=framework_family)}}" method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-        {%
-           with
-           error = errors.get("lot", {}).get("message", None),
-           hint = "or",
-           hint_underneath = true,
-           name = "lot",
-           type = "radio",
-           options = lots
-        %}
-          {% include "toolkit/forms/selection-buttons.html" %}
-        {% endwith %}
-
-        <div class="question first-question">
-          {%
-            with
-            name = "lot",
-            id = "input-lot-100",
-            input_type = "radio",
-            input_value = "",
-            option = {
-              "label": "All categories"
+        {{ govukRadios({
+          "idPrefix": "input-lot",
+          "name": "lot",
+          "fieldset": {
+            "legend": {
+              "classes": "govuk-fieldset__legend--xl",
+              "text": question,
+              "isPageHeading": true
             }
-          %}
-            {% include "toolkit/forms/_selection-button.html" %}
-          {% endwith %}
-        </div>
+          },
+          "errorMessage": {"text": errorMessage} if errorMessage,
+          "items": lots
+        })}}
 
         {{ govukButton({
           "text": "Search for services",

--- a/app/templates/choose-lot.html
+++ b/app/templates/choose-lot.html
@@ -30,7 +30,7 @@
 <div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ url_for('direct_award_public.choose_lot', framework_family=framework_family)}}" method="post">
+      <form action="{{ url_for('direct_award_public.choose_lot', framework_family=framework_family)}}" method="post" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
         {{ govukRadios({

--- a/app/templates/choose-lot.html
+++ b/app/templates/choose-lot.html
@@ -1,8 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block pageTitle %}
-  G-Cloud - Digital Marketplace
-{% endblock %}
+{% set page_name = title|capitalize %}
 
 {% block breadcrumb %}
 {{ govukBreadcrumbs({
@@ -27,32 +25,30 @@
 {% set question = title|capitalize %}
 {% set errorMessage = errors.get("lot", {}).get("message", None) %}
 
-<div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <form action="{{ url_for('direct_award_public.choose_lot', framework_family=framework_family)}}" method="post" novalidate>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form action="{{ url_for('direct_award_public.choose_lot', framework_family=framework_family)}}" method="post" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-        {{ govukRadios({
-          "idPrefix": "input-lot",
-          "name": "lot",
-          "fieldset": {
-            "legend": {
-              "classes": "govuk-fieldset__legend--xl",
-              "text": question,
-              "isPageHeading": true
-            }
-          },
-          "errorMessage": {"text": errorMessage} if errorMessage,
-          "items": lots
-        })}}
+      {{ govukRadios({
+        "idPrefix": "input-lot",
+        "name": "lot",
+        "fieldset": {
+          "legend": {
+            "classes": "govuk-fieldset__legend--xl",
+            "text": question,
+            "isPageHeading": true
+          }
+        },
+        "errorMessage": {"text": errorMessage} if errorMessage,
+        "items": lots
+      })}}
 
-        {{ govukButton({
-          "text": "Search for services",
-        }) }}
+      {{ govukButton({
+        "text": "Search for services",
+      }) }}
 
-      </form>
-    </div>
+    </form>
   </div>
 </div>
 {% endblock %}

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -1,8 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block pageTitle %}
-  {% if errors %}Error: {% endif %}Did you award a contract? - Digital Marketplace
-{% endblock %}
+{% set page_name = 'Did you award a contract?' %}
 
 {% block breadcrumb %}
 {{ govukBreadcrumbs({
@@ -24,7 +22,7 @@
       "text": project.name
     },
     {
-      "text": "Did you award a contract?"
+      "text": page_name
     }
   ]
 }) }}
@@ -32,55 +30,51 @@
 
 
 {% block mainContent %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Did you award a contract for ‘{{ project.name }}’?</h1>
 
-<div class="did-you-award-contract-page">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Did you award a contract for ‘{{ project.name }}’?</h1>
+    <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-      <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}" novalidate>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-
-        {{ govukRadios({
-          "idPrefix": "input-did_you_award_a_contract",
-          "name": "did_you_award_a_contract",
-          "fieldset": {
-            "legend": {
-              "classes": "govuk-fieldset__legend--m",
-              "text": "Did you award a contract?"
-            }
+      {{ govukRadios({
+        "idPrefix": "input-did_you_award_a_contract",
+        "name": "did_you_award_a_contract",
+        "fieldset": {
+          "legend": {
+            "classes": "govuk-fieldset__legend--m",
+            "text": "Did you award a contract?"
+          }
+        },
+        "errorMessage": errors.did_you_award_a_contract.errorMessage if errors.did_you_award_a_contract.errorMessage,
+        "items": [
+          { 
+            "value": "yes",
+            "text": "Yes"
           },
-          "errorMessage": errors.did_you_award_a_contract.errorMessage if errors.did_you_award_a_contract.errorMessage,
-          "items": [
-            { 
-              "value": "yes",
-              "text": "Yes"
-            },
-            { 
-              "value": "no",
-              "text": "No"
-            },
-            { 
-              "value": "still-assessing",
-              "text": "We are still assessing services"
-            }
-          ]
-        })}}
-
-        {{ govukButton({
-          "text": "Save and continue",
-          "attributes": {
-            "data-analytics": "trackEvent",
-            "data-analytics-category": "did-you-award-a-contract",
-            "data-analytics-action": "Save and continue",
-            "data-analytics-target-selector": "input[name=did_you_award_a_contract]:checked",
+          { 
+            "value": "no",
+            "text": "No"
           },
-        }) }}
-      </form>
+          { 
+            "value": "still-assessing",
+            "text": "We are still assessing services"
+          }
+        ]
+      })}}
 
-      <p class="govuk-body"><a class="govuk-link" href="{{ url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id) }}">Return to your task list</a></p>
-    </div>
+      {{ govukButton({
+        "text": "Save and continue",
+        "attributes": {
+          "data-analytics": "trackEvent",
+          "data-analytics-category": "did-you-award-a-contract",
+          "data-analytics-action": "Save and continue",
+          "data-analytics-target-selector": "input[name=did_you_award_a_contract]:checked",
+        },
+      }) }}
+    </form>
+
+    <p class="govuk-body"><a class="govuk-link" href="{{ url_for('direct_award.view_project', framework_family=framework.family, project_id=project.id) }}">Return to your task list</a></p>
   </div>
-
 </div>
 {% endblock %}

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -38,7 +38,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Did you award a contract for ‘{{ project.name }}’?</h1>
 
-      <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">
+      <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
         {{ govukRadios({

--- a/app/templates/direct-award/did-you-award-contract.html
+++ b/app/templates/direct-award/did-you-award-contract.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
-  Did you award a contract? - Digital Marketplace
+  {% if errors %}Error: {% endif %}Did you award a contract? - Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -41,7 +41,31 @@
       <form method="POST" action="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-        {{ form.did_you_award_a_contract }}
+        {{ govukRadios({
+          "idPrefix": "input-did_you_award_a_contract",
+          "name": "did_you_award_a_contract",
+          "fieldset": {
+            "legend": {
+              "classes": "govuk-fieldset__legend--m",
+              "text": "Did you award a contract?"
+            }
+          },
+          "errorMessage": errors.did_you_award_a_contract.errorMessage if errors.did_you_award_a_contract.errorMessage,
+          "items": [
+            { 
+              "value": "yes",
+              "text": "Yes"
+            },
+            { 
+              "value": "no",
+              "text": "No"
+            },
+            { 
+              "value": "still-assessing",
+              "text": "We are still assessing services"
+            }
+          ]
+        })}}
 
         {{ govukButton({
           "text": "Save and continue",

--- a/app/templates/direct-award/end-search.html
+++ b/app/templates/direct-award/end-search.html
@@ -48,6 +48,7 @@
       <form
         action="{{ url_for('direct_award.end_search', framework_family=framework.family, project_id=project.id) }}"
         method="POST"
+        novalidate
         >
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 

--- a/app/templates/direct-award/save-new-search.html
+++ b/app/templates/direct-award/save-new-search.html
@@ -1,0 +1,66 @@
+{% extends "_base_page.html" %}
+
+{% set page_name = "Save a new search" %}
+
+{% block pageTitle %}
+  {% if errors %}Error: {% endif %}{{ page_name }} - Digital Marketplace
+{% endblock %}
+
+{% block breadcrumb %}
+{{ govukBreadcrumbs({
+  "items": [
+    {
+      "href": url_for('main.index'),
+      "text": "Digital Marketplace"
+    },
+    {
+      "href": search_url,
+      "text": "Search"
+    },
+    {
+      "href": save_search_url,
+      "text": "Save your search"
+    },
+    {
+      "text": page_name
+    },
+  ]
+}) }}
+{% endblock breadcrumb %}
+
+{% block mainContent %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form action="{{ action_url }}" method="post" id="createNewProjectForm" novalidate>
+      <h1 class="govuk-heading-l">{{ page_name }}</h1>
+      <div class="search-summary-panel panel panel-border-wide">
+        {% with content = search_summary_sentence %}
+          {% include "toolkit/search-summary.html" %}
+        {% endwith %}
+      </div>
+
+      {{ govukInput({
+        "label": {
+          "text": "Name your search. A reference number or short description of what you want to buy makes a good name."
+        },
+        "id": "input-project_name",
+        "name": "project_name",
+        "hint": {
+          "text": "100 characters maximum"
+        },
+        "errorMessage": errors['project_name']['errorMessage'] if errors['project_name'],
+        "value": form.project_name.data
+      }) }}
+
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <input type="hidden" name="search_query" value="{{ search_query }}"/>
+      {{ govukButton({
+        "text": "Save and continue",
+        "name": "return_to_overview",
+        "value": "Save and continue",
+      }) }}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/direct-award/save-new-search.html
+++ b/app/templates/direct-award/save-new-search.html
@@ -2,10 +2,6 @@
 
 {% set page_name = "Save a new search" %}
 
-{% block pageTitle %}
-  {% if errors %}Error: {% endif %}{{ page_name }} - Digital Marketplace
-{% endblock %}
-
 {% block breadcrumb %}
 {{ govukBreadcrumbs({
   "items": [

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -2,10 +2,6 @@
 
 {% set page_name = "Save your search" %}
 
-{% block pageTitle %}
-  {% if errors %}Error: {% endif %}{{ page_name }} - Digital Marketplace
-{% endblock %}
-
 {% block breadcrumb %}
 {{ govukBreadcrumbs({
   "items": [
@@ -26,46 +22,39 @@
 
 {% block mainContent %}
 
-<div class="single-question-page save-search-page">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
-        {{ page_name }}
-      </h1>
-    </div>
-  </div>
-  <form method="post" action="" id="createProjectForm" novalidate>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <div class="search-summary-panel panel panel-border-wide">
-          {% with content = search_summary_sentence %}
-            {% include "toolkit/search-summary.html" %}
-          {% endwith %}
-        </div>
-
-        {{ govukRadios({
-          "idPrefix": "input-" + form.save_search_selection.name,
-          "name": form.save_search_selection.name,
-          "fieldset": {
-            "legend": {
-              "text": "Save your search",
-              "classes": "govuk-visually-hidden"
-            }
-          },
-          "errorMessage": {"text": form.save_search_selection.errors[0]} if form.save_search_selection.errors[0],
-          "items": save_search_options
-        })}}
-
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <input type="hidden" name="search_query" value="{{ search_query }}"/>
-        {{ govukButton({
-          "text": "Save and continue",
-          "name": "return_to_overview",
-          "value": "Save and continue",
-        }) }}
-
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      {{ page_name }}
+    </h1>
+    <form method="post" action="" id="createProjectForm" novalidate>
+      <div class="search-summary-panel panel panel-border-wide">
+        {% with content = search_summary_sentence %}
+          {% include "toolkit/search-summary.html" %}
+        {% endwith %}
       </div>
-    </div>
-  </form>
+
+      {{ govukRadios({
+        "idPrefix": "input-" + form.save_search_selection.name,
+        "name": form.save_search_selection.name,
+        "fieldset": {
+          "legend": {
+            "text": "Save your search",
+            "classes": "govuk-visually-hidden"
+          }
+        },
+        "errorMessage": {"text": form.save_search_selection.errors[0]} if form.save_search_selection.errors[0],
+        "items": save_search_options
+      })}}
+
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      <input type="hidden" name="search_query" value="{{ search_query }}"/>
+      {{ govukButton({
+        "text": "Save and continue",
+        "name": "return_to_overview",
+        "value": "Save and continue",
+      }) }}
+    </form>
+  </div>
 </div>
 {% endblock %}

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -3,7 +3,7 @@
 {% set page_name = "Save your search" %}
 
 {% block pageTitle %}
-  {{ page_name }} - Digital Marketplace
+  {% if errors %}Error: {% endif %}{{ page_name }} - Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -43,19 +43,18 @@
           {% endwith %}
         </div>
 
-        {%
-          with
-          type = "radio",
-          name = form.save_search_selection.name,
-          finally = "or",
-          value = form.save_search_selection.data,
-          options = form.save_search_selection.options,
-          error = form.save_search_selection.errors[0]
-        %}
-          {% include "toolkit/forms/selection-buttons.html" %}
-        {% endwith %}
-
-        <br>
+        {{ govukRadios({
+          "idPrefix": "input-" + form.save_search_selection.name,
+          "name": form.save_search_selection.name,
+          "fieldset": {
+            "legend": {
+              "text": "Save your search",
+              "classes": "govuk-visually-hidden"
+            }
+          },
+          "errorMessage": {"text": form.save_search_selection.errors[0]} if form.save_search_selection.errors[0],
+          "items": save_search_options
+        })}}
 
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="search_query" value="{{ search_query }}"/>

--- a/app/templates/direct-award/save-search.html
+++ b/app/templates/direct-award/save-search.html
@@ -34,7 +34,7 @@
       </h1>
     </div>
   </div>
-  <form method="post" action="" id="createProjectForm">
+  <form method="post" action="" id="createProjectForm" novalidate>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="search-summary-panel panel panel-border-wide">

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
-  Which service won the contract? - Digital Marketplace
+  {% if errors %}Error: {% endif %}Which service won the contract? - Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -43,7 +43,18 @@
         <form method="POST" action="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-          {{ form.which_service_won_the_contract }}
+          {{ govukRadios({
+            "idPrefix": "input-which_service_won_the_contract",
+            "name": "which_service_won_the_contract",
+            "fieldset": {
+              "legend": {
+                "classes": "govuk-fieldset__legend--m",
+                "text": "Which service won the contract?"
+              }
+            },
+            "errorMessage": errors.which_service_won_the_contract.errorMessage if errors.which_service_won_the_contract.errorMessage,
+            "items": service_options
+          })}}
 
           {{ govukButton({
             "text": "Save and continue",

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -1,8 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block pageTitle %}
-  {% if errors %}Error: {% endif %}Which service won the contract? - Digital Marketplace
-{% endblock %}
+{% set page_name = 'Which service won the contract?' %}
 
 {% block breadcrumb %}
 {{ govukBreadcrumbs({
@@ -24,51 +22,45 @@
       "text": project.name
     },
     {
-      "text": "Which service won the contract?"
+      "text": page_name
     },
   ]
 }) }}
 {% endblock breadcrumb %}
 
 {% block mainContent %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+      {% if form.which_service_won_the_contract.options %}
+      <form method="POST" action="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id) }}" novalidate>
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-<div class="which-service-won-contract-page">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+        {{ govukRadios({
+          "idPrefix": "input-which_service_won_the_contract",
+          "name": "which_service_won_the_contract",
+          "fieldset": {
+            "legend": {
+              "classes": "govuk-fieldset__legend--l",
+              "text": page_name,
+              "isPageHeading": True
+            }
+          },
+          "errorMessage": errors.which_service_won_the_contract.errorMessage if errors.which_service_won_the_contract.errorMessage,
+          "items": service_options
+        })}}
 
-      <h1 class="govuk-heading-xl">Which service won the contract?</h1>
+        {{ govukButton({
+          "text": "Save and continue",
+        }) }}
+      </form>
 
-        {% if form.which_service_won_the_contract.options %}
+      {% else %}
+        <h1 class="govuk-heading-xl">{{ page_name }}</h1>
+        <p class="govuk-body">You cannot award this contract as there were no services matching your requirements.</p>
+      {% endif %}
 
-        <form method="POST" action="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id) }}" novalidate>
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-
-          {{ govukRadios({
-            "idPrefix": "input-which_service_won_the_contract",
-            "name": "which_service_won_the_contract",
-            "fieldset": {
-              "legend": {
-                "classes": "govuk-fieldset__legend--m",
-                "text": "Which service won the contract?"
-              }
-            },
-            "errorMessage": errors.which_service_won_the_contract.errorMessage if errors.which_service_won_the_contract.errorMessage,
-            "items": service_options
-          })}}
-
-          {{ govukButton({
-            "text": "Save and continue",
-          }) }}
-        </form>
-
-        {% else %}
-          <p class="govuk-body">You cannot award this contract as there were no services matching your requirements.</p>
-        {% endif %}
-
-        <p class="govuk-body"><a class="govuk-link" href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">Previous page</a></p>
-      </div>
+      <p class="govuk-body"><a class="govuk-link" href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">Previous page</a></p>
     </div>
   </div>
-
 </div>
 {% endblock %}

--- a/app/templates/direct-award/which-service-won-contract.html
+++ b/app/templates/direct-award/which-service-won-contract.html
@@ -40,7 +40,7 @@
 
         {% if form.which_service_won_the_contract.options %}
 
-        <form method="POST" action="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id) }}">
+        <form method="POST" action="{{ url_for('direct_award.which_service_won_contract', framework_family=framework.family, project_id=project.id) }}" novalidate>
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
           {{ govukRadios({

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -1,8 +1,6 @@
 {% extends "_base_page.html" %}
 
-{% block pageTitle %}
-  {% if errors %}Error: {% endif %}Why didn’t you award a contract? - Digital Marketplace
-{% endblock %}
+{% set page_name = "Why didn’t you award a contract?" %}
 
 {% block breadcrumb %}
 {{ govukBreadcrumbs({
@@ -24,49 +22,45 @@
       "text": project.name
     },
     {
-      "text": "Why didn’t you award a contract?"
+      "text": page_name
     },
   ]
 }) }}
 {% endblock breadcrumb %}
 
 {% block mainContent %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">{{ page_name }}</h1>
 
-<div class="why-didnt-you-award-contract-page">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Why didn’t you award a contract?</h1>
+    <form method="POST" action="{{ url_for('direct_award.why_did_you_not_award_the_contract', framework_family=framework.family, project_id=project.id) }}" novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-      <form method="POST" action="{{ url_for('direct_award.why_did_you_not_award_the_contract', framework_family=framework.family, project_id=project.id) }}" novalidate>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+      {{ govukRadios({
+        "idPrefix": "input-why_did_you_not_award_the_contract",
+        "name": "why_did_you_not_award_the_contract",
+        "fieldset": {
+          "legend": {
+            "classes": "govuk-fieldset__legend--m",
+            "text": "Why didn’t you award a contract?"
+          }
+        },
+        "errorMessage": errors.why_did_you_not_award_the_contract.errorMessage if errors.why_did_you_not_award_the_contract.errorMessage,
+        "items": form_options
+      })}}
 
-        {{ govukRadios({
-          "idPrefix": "input-why_did_you_not_award_the_contract",
-          "name": "why_did_you_not_award_the_contract",
-          "fieldset": {
-            "legend": {
-              "classes": "govuk-fieldset__legend--m",
-              "text": "Why didn’t you award a contract?"
-            }
-          },
-          "errorMessage": errors.why_did_you_not_award_the_contract.errorMessage if errors.why_did_you_not_award_the_contract.errorMessage,
-          "items": form_options
-        })}}
+      {{ govukButton({
+        "text": "Save and continue",
+        "attributes": {
+          "data-analytics": "trackEvent",
+          "data-analytics-category": "why-didnt-you-award",
+          "data-analytics-action": "Save and continue",
+          "data-analytics-target-selector": "input[name={}]:checked".format(form.why_did_you_not_award_the_contract.name),
+        },
+      }) }}
+    </form>
 
-        {{ govukButton({
-          "text": "Save and continue",
-          "attributes": {
-            "data-analytics": "trackEvent",
-            "data-analytics-category": "why-didnt-you-award",
-            "data-analytics-action": "Save and continue",
-            "data-analytics-target-selector": "input[name={}]:checked".format(form.why_did_you_not_award_the_contract.name),
-          },
-        }) }}
-      </form>
-
-      <p class="govuk-body"><a class="govuk-link" href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">Previous page</a></p>
-    </div>
+    <p class="govuk-body"><a class="govuk-link" href="{{ url_for('direct_award.did_you_award_contract', framework_family=framework.family, project_id=project.id) }}">Previous page</a></p>
   </div>
-
 </div>
 {% endblock %}

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -1,7 +1,7 @@
 {% extends "_base_page.html" %}
 
 {% block pageTitle %}
-  Why didn’t you award a contract? - Digital Marketplace
+  {% if errors %}Error: {% endif %}Why didn’t you award a contract? - Digital Marketplace
 {% endblock %}
 
 {% block breadcrumb %}
@@ -40,7 +40,18 @@
       <form method="POST" action="{{ url_for('direct_award.why_did_you_not_award_the_contract', framework_family=framework.family, project_id=project.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-        {{ form.why_did_you_not_award_the_contract }}
+        {{ govukRadios({
+          "idPrefix": "input-why_did_you_not_award_the_contract",
+          "name": "why_did_you_not_award_the_contract",
+          "fieldset": {
+            "legend": {
+              "classes": "govuk-fieldset__legend--m",
+              "text": "Why didn’t you award a contract?"
+            }
+          },
+          "errorMessage": errors.why_did_you_not_award_the_contract.errorMessage if errors.why_did_you_not_award_the_contract.errorMessage,
+          "items": form_options
+        })}}
 
         {{ govukButton({
           "text": "Save and continue",

--- a/app/templates/direct-award/why-didnt-you-award-contract.html
+++ b/app/templates/direct-award/why-didnt-you-award-contract.html
@@ -37,7 +37,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Why didn’t you award a contract?</h1>
 
-      <form method="POST" action="{{ url_for('direct_award.why_did_you_not_award_the_contract', framework_family=framework.family, project_id=project.id) }}">
+      <form method="POST" action="{{ url_for('direct_award.why_did_you_not_award_the_contract', framework_family=framework.family, project_id=project.id) }}" novalidate>
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
         {{ govukRadios({

--- a/requirements.in
+++ b/requirements.in
@@ -10,4 +10,4 @@ lxml==4.5.2
 git+https://github.com/alphagov/digitalmarketplace-utils.git@54.0.2#egg=digitalmarketplace-utils==54.0.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.0#egg=digitalmarketplace-content-loader==7.26.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.5-alpha#egg=govuk-frontend-jinja==0.5.5-alpha
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.6-alpha#egg=govuk-frontend-jinja==0.5.6-alpha

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 lxml==4.5.2
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@54.0.1#egg=digitalmarketplace-utils==54.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@54.0.2#egg=digitalmarketplace-utils==54.0.2
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.0#egg=digitalmarketplace-content-loader==7.26.0
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.5-alpha#egg=govuk-frontend-jinja==0.5.5-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ fleep==1.0.1              # via digitalmarketplace-utils
 future==0.18.2            # via notifications-python-client
 gds-metrics==0.2.0        # via digitalmarketplace-utils
 govuk-country-register==0.5.0  # via digitalmarketplace-utils
-git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.5-alpha#egg=govuk-frontend-jinja==0.5.5-alpha  # via -r requirements.in
+git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.6-alpha#egg=govuk-frontend-jinja==0.5.6-alpha  # via -r requirements.in
 idna==2.9                 # via cryptography, requests
 inflection==0.3.1         # via digitalmarketplace-content-loader
 itsdangerous==1.1.0       # via -r requirements.in, flask, flask-wtf

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@54.0.1#egg=digitalmarketplace-utils==54.0.1  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-utils.git@54.0.2#egg=digitalmarketplace-utils==54.0.2  # via -r requirements.in, digitalmarketplace-content-loader
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.0#egg=digitalmarketplace-content-loader==7.26.0  # via -r requirements.in
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -810,7 +810,8 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
         assert res.status_code == 400
 
         doc = html.fromstring(res.get_data(as_text=True))
-        assert len(doc.xpath('//legend[contains(normalize-space(), "Select if you have awarded your contract")]')) == 1
+        error_message = doc.cssselect('.govuk-error-message')[0].text_content().strip()
+        assert error_message == "Error: Select if you have awarded your contract"
         errors = doc.cssselect('div.govuk-error-summary a')
         assert len(errors) == 1
         assert errors[0].text_content() == 'Select if you have awarded your contract'
@@ -898,7 +899,8 @@ class TestDirectAwardAwardContract(TestDirectAwardBase):
         assert len(doc.xpath(
             '//input[@type="radio"][contains(following-sibling::label, "Service name")]')) == 1
         assert len(doc.xpath(
-            '//span[contains(normalize-space(text()), "Supplier name")][contains(parent::label, "Service name")]')) == 1
+            '//span[contains(normalize-space(text()), "Supplier name")]'
+            '[contains(preceding-sibling::label, "Service name")]')) == 1
         assert len(
             doc.xpath('//button[normalize-space(string())=$t]', t="Save and continue")) == 1
 
@@ -1126,12 +1128,12 @@ class TestDirectAwardNonAwardContract(TestDirectAwardBase):
             '//input[@type="radio"][contains(following-sibling::label, "The work has been cancelled")]')) == 1
         assert len(doc.xpath(
             '//span[contains(normalize-space(text()), "For example, because you no longer have the budget")]\
-            [contains(parent::label, "The work has been cancelled")]')) == 1
+            [contains(preceding-sibling::label, "The work has been cancelled")]')) == 1
         assert len(doc.xpath(
             '//input[@type="radio"][contains(following-sibling::label, "The work has been cancelled")]')) == 1
         assert len(doc.xpath(
             '//span[contains(normalize-space(text()), "The services in your search results did not meet your requirements")]\
-            [contains(parent::label, "There were no suitable services")]')) == 1
+            [contains(preceding-sibling::label, "There were no suitable services")]')) == 1
         assert len(
             doc.xpath('//button[normalize-space(string())=$t]', t="Save and continue")) == 1
 

--- a/tests/main/views/test_direct_award.py
+++ b/tests/main/views/test_direct_award.py
@@ -50,11 +50,14 @@ class TestDirectAward(TestDirectAwardBase):
 
         cls.SAVE_SEARCH_OVERVIEW_URL = '/buyers/direct-award/g-cloud'
         cls.SAVE_SEARCH_URL = '/buyers/direct-award/g-cloud/save-search'
+        cls.SAVE_NEW_SEARCH_URL = '/buyers/direct-award/g-cloud/save-new-search'
         cls.SIMPLE_SEARCH_PARAMS = 'lot=cloud-software'
         cls.SEARCH_URL = '/g-cloud/search?' + cls.SIMPLE_SEARCH_PARAMS
         cls.PROJECT_CREATE_URL = '/buyers/direct-award/g-cloud/projects/create'
         cls.SIMPLE_SAVE_SEARCH_URL = '{}?search_query={}'.format(
             cls.SAVE_SEARCH_URL, quote_plus(cls.SIMPLE_SEARCH_PARAMS))
+        cls.SIMPLE_SAVE_NEW_SEARCH_URL = '{}?search_query={}'.format(
+            cls.SAVE_NEW_SEARCH_URL, quote_plus(cls.SIMPLE_SEARCH_PARAMS))
         cls.SEARCH_API_URL = 'g-cloud-9/services/search'
 
     def test_invalid_framework_family(self):
@@ -145,11 +148,27 @@ class TestDirectAward(TestDirectAwardBase):
         assert res.status_code == 302
         assert res.location == 'http://localhost/user/login?next={}'.format(quote_plus(self.SIMPLE_SAVE_SEARCH_URL))
 
+    def test_save_new_search_redirects_to_login(self):
+        res = self.client.get(self.SIMPLE_SAVE_NEW_SEARCH_URL)
+        assert res.status_code == 302
+        assert res.location == 'http://localhost/user/login?next={}'.format(quote_plus(self.SIMPLE_SAVE_NEW_SEARCH_URL))
+
     def test_save_search_renders_summary_on_page(self):
         self.login_as_buyer()
         self.search_api_client.search.return_value = self.g9_search_results
 
         res = self.client.get(self.SIMPLE_SAVE_SEARCH_URL)
+
+        assert res.status_code == 200
+
+        summary = self.find_search_summary(res.get_data(as_text=True))[0]
+        assert '<span class="search-summary-count">1150</span> results found in <em>Cloud software</em>' in summary
+
+    def test_save_new_search_renders_summary_on_page(self):
+        self.login_as_buyer()
+        self.search_api_client.search.return_value = self.g9_search_results
+
+        res = self.client.get(self.SIMPLE_SAVE_NEW_SEARCH_URL)
 
         assert res.status_code == 200
 
@@ -165,6 +184,15 @@ class TestDirectAward(TestDirectAwardBase):
 
         assert "Sorry, there was a problem with your request" in res.get_data(as_text=True)
 
+    def test_save_new_search_view_raises_400_if_no_search(self):
+        self.login_as_buyer()
+
+        res = self.client.get(self.SAVE_NEW_SEARCH_URL)
+
+        assert res.status_code == 400
+
+        assert "Sorry, there was a problem with your request" in res.get_data(as_text=True)
+
     def _save_search(self, name, save_search_selection="new_search"):
         self.login_as_buyer()
         self.search_api_client.search.return_value = self.g9_search_results
@@ -172,12 +200,19 @@ class TestDirectAward(TestDirectAwardBase):
         self.data_api_client.create_direct_award_project_search.return_value = \
             self._get_direct_award_project_searches_fixture()['searches'][0]
 
-        return self.client.post(self.SAVE_SEARCH_URL,
-                                data={
-                                    'name': name,
-                                    'search_query': self.SIMPLE_SEARCH_PARAMS,
-                                    'save_search_selection': save_search_selection
-                                })
+        if save_search_selection == "new_search":
+            return self.client.post(self.SAVE_NEW_SEARCH_URL,
+                                    data={
+                                        'project_name': name,
+                                        'search_query': self.SIMPLE_SEARCH_PARAMS
+                                    })
+        else:
+            return self.client.post(self.SAVE_SEARCH_URL,
+                                    data={
+                                        'name': name,
+                                        'search_query': self.SIMPLE_SEARCH_PARAMS,
+                                        'save_search_selection': save_search_selection
+                                    })
 
     def _update_existing_project(self, save_search_selection):
         return self._save_search(None, save_search_selection)
@@ -190,7 +225,7 @@ class TestDirectAward(TestDirectAwardBase):
         errors = html.fromstring(doc)
         assert len(errors.cssselect("div.govuk-error-summary a")) == 1
         assert errors.cssselect("div.govuk-error-summary a")[0].text_content() == \
-            "Search name must be between 1 and 100 characters"
+            "Enter a name for your search between 1 and 100 characters"
 
     def test_save_search_submit_success(self):
         res = self._save_search('some name " foo bar \u2016')


### PR DESCRIPTION
https://trello.com/c/UQtUlH0n/207-2-replace-radios-with-govuk-frontend-radios-component-in-search-g-cloud-services-journey

For the most part, these were straightforward, but the save search form made use of conditional reveal. This has [outstanding accessibility issues](https://github.com/alphagov/govuk-frontend/issues/1991) so I've moved that field to a new page instead.

The code is quite repetitive - I could achieve the same effect by putting conditional logic on the template itself, but I thought it best to keep the urls discrete. Additionally, I've used WTForms as this seemed like the most efficient way to handle submission and validation - thinking about how we replace 'em is probably a future task.

Functional tests: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/813