### PR TITLE
Replace Contact Details

### DIFF
--- a/app/assets/scss/_atoz_navigation.scss
+++ b/app/assets/scss/_atoz_navigation.scss
@@ -47,12 +47,3 @@
     }
   }
 }
-
-.supplier-profile {
-  padding-top: $gutter * 1.5;
-}
-
-.supplier-description {
-  @include core-19;
-  margin: 0 0 $gutter 0;
-}

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -1,7 +1,7 @@
 <div id="meta">
   <h2 class="govuk-visually-hidden">Pricing</h2>
-  <p class="price">{{ service.meta.price }}</p>
-  <ul class="govuk-list">
+  <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1">{{ service.meta.price }}</p>
+  <ul class="govuk-list govuk-body-s">
   {% for caveat in service.meta.priceCaveats %}
     <li>
       {% if caveat['link'] %}
@@ -16,8 +16,8 @@
     </li>
   {% endfor %}
   </ul>
-  <h2>Service documents</h2>
-  <ul class="govuk-list">
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Service documents</h2>
+  <ul class="govuk-list govuk-body-s">
   {% for document in service.meta.documents %}
     <li class="govuk-!-margin-bottom-2">
       <a href="{{ document.url }}" class="govuk-link">
@@ -26,24 +26,30 @@
     </li>
   {% endfor %}
   </ul>
-  <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Framework</h2>
-  <p class="framework-name">{{ service.frameworkName }}</p>
-  <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Service ID</h2>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Framework</h2>
+  <p class="govuk-body-s">{{ service.frameworkName }}</p>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Service ID</h2>
   <p class="govuk-visually-hidden">{{ (service.meta.serviceId|join(''))|join(' ') }}</p>
-  <p aria-hidden="true">
+  <p aria-hidden="true" class="govuk-body-s">
     {% for chunk in service.meta.serviceId -%}
     <span class="{% if not loop.first %} govuk-!-padding-left-1 {% endif %}">{{chunk}}</span>
     {%- endfor %}
   </p>
-  <h2 class="govuk-!-font-size-4 govuk-!-margin-bottom-1">Contact</h2>
-  {%
-    with
-    organisation_type="supplier",
-    organisation=service.supplierName,
-    telephone=service.meta.contact.phone or None,
-    contact_name=service.meta.contact.name,
-    email_address=service.meta.contact.email
-  %}
-    {% include "toolkit/contact-details.html" %}
-  {% endwith %}
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Contact</h2>
+  <p class="govuk-body-s">
+    <span class="govuk-visually-hidden">{{ service.supplierName }}</span>
+    {% if service.meta.contact.name %}
+    {{ service.meta.contact.name }}<br />
+    {% endif %}
+    {% if service.meta.contact.phone %}
+    <span class="govuk-visually-hidden">Telephone: </span>{{ service.meta.contact.phone }}<br />
+    {% endif %}
+    {% if service.meta.contact.email %}
+    <a 
+      href="mailto:{{ service.meta.contact.email }}"
+      data-event-category="Email a supplier"
+      data-event-label="{{ service.supplierName }}"
+    ><span class="govuk-visually-hidden">Email: </span>{{ service.meta.contact.email }}</a><br />
+    {% endif %}
+  </p>
 </div>

--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -32,35 +32,35 @@
 <span class="govuk-caption-l">Digital Marketplace supplier</span>
 <h1 class="govuk-heading-l">{{ supplier.name }}</h1>
 
-<div class="govuk-grid-row supplier-profile">
-    {% if supplier.description or supplier.clients %}
-      <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-body">
-              {{ supplier.description }}
-          </p>
-      </div>
-    {% endif %}
-
-    <aside id="meta" role="complementary" class="govuk-grid-column-one-third" aria-label="Supplier contact">
-      <h2 class="sidebar-heading">Contact</h2>
+<div class="govuk-grid-row">
+  {% if supplier.description or supplier.clients %}
+    <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body">
-        <span class="govuk-visually-hidden">{{ supplier.name }}</span>
-        {% if supplier.contactInformation[0].contactName %}
-        {{ supplier.contactInformation[0].contactName }}<br />
-        {% endif %}
-        {% if supplier.contactInformation[0].phoneNumber %}
-        <span class="govuk-visually-hidden">Telephone: </span>
-        {{ supplier.contactInformation[0].phoneNumber }}<br />
-        {% endif %}
-        {% if supplier.contactInformation[0].email %}
-        <a 
-          href="mailto:{{ service.meta.contact.email }}"
-          data-event-category="Email a supplier"
-          data-event-label="{{ service.supplierName }}"
-        ><span class="govuk-visually-hidden">Email: </span>{{ supplier.contactInformation[0].email }}</a><br />
-        {% endif %}
+        {{ supplier.description }}
       </p>
-    </aside>
+    </div>
+  {% endif %}
+
+  <aside id="meta" role="complementary" class="govuk-grid-column-one-third" aria-label="Supplier contact">
+    <h2 class="sidebar-heading">Contact</h2>
+    <p class="govuk-body">
+      <span class="govuk-visually-hidden">{{ supplier.name }}</span>
+      {% if supplier.contactInformation[0].contactName %}
+      {{ supplier.contactInformation[0].contactName }}<br />
+      {% endif %}
+      {% if supplier.contactInformation[0].phoneNumber %}
+      <span class="govuk-visually-hidden">Telephone: </span>
+      {{ supplier.contactInformation[0].phoneNumber }}<br />
+      {% endif %}
+      {% if supplier.contactInformation[0].email %}
+      <a 
+        href="mailto:{{ supplier.contactInformation[0].email }}"
+        data-event-category="Email a supplier"
+        data-event-label="{{ supplier.name }}"
+      ><span class="govuk-visually-hidden">Email: </span>{{ supplier.contactInformation[0].email }}</a><br />
+      {% endif %}
+    </p>
+  </aside>
 </div>
 
 {% endblock %}

--- a/app/templates/suppliers_details.html
+++ b/app/templates/suppliers_details.html
@@ -43,16 +43,23 @@
 
     <aside id="meta" role="complementary" class="govuk-grid-column-one-third" aria-label="Supplier contact">
       <h2 class="sidebar-heading">Contact</h2>
-      {%
-        with
-        organisation_type = "supplier",
-        organisation = supplier.name,
-        telephone = supplier.contactInformation[0].phoneNumber,
-        contact_name = supplier.contactInformation[0].contactName,
-        email_address = supplier.contactInformation[0].email
-      %}
-        {% include "toolkit/contact-details.html" %}
-      {% endwith %}
+      <p class="govuk-body">
+        <span class="govuk-visually-hidden">{{ supplier.name }}</span>
+        {% if supplier.contactInformation[0].contactName %}
+        {{ supplier.contactInformation[0].contactName }}<br />
+        {% endif %}
+        {% if supplier.contactInformation[0].phoneNumber %}
+        <span class="govuk-visually-hidden">Telephone: </span>
+        {{ supplier.contactInformation[0].phoneNumber }}<br />
+        {% endif %}
+        {% if supplier.contactInformation[0].email %}
+        <a 
+          href="mailto:{{ service.meta.contact.email }}"
+          data-event-category="Email a supplier"
+          data-event-label="{{ service.supplierName }}"
+        ><span class="govuk-visually-hidden">Email: </span>{{ supplier.contactInformation[0].email }}</a><br />
+        {% endif %}
+      </p>
     </aside>
 </div>
 

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -50,20 +50,18 @@ class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
         contact_info = self.supplier['suppliers']['contactInformation'][0]
 
         meta = document.xpath('//div[@id="meta"]')[0]
-        contact_heading = meta.xpath('//div/p[@class="contact-details-organisation"]/span/text()')[0]  # noqa
-        ps = [
-            p.text_content().strip()
-            for p in meta.xpath('//div[@class="contact-details"]//p')
-        ]
+        contact_details_p = meta.xpath('//h2[text()="Contact"]/following-sibling::p[1]')[0].text_content()
+        contact_heading = meta.xpath('//h2[text()="Contact"]/following-sibling::p[1]/span/text()')[0]
 
         assert contact_heading == supplier_name
 
         for contact_detail in [
+            supplier_name,
             contact_info['contactName'],
             contact_info['phoneNumber'],
             contact_info['email']
         ]:
-            assert "{}".format(contact_detail) in ps
+            assert contact_detail in contact_details_p
 
     def _assert_document_links(self, document):
 
@@ -78,7 +76,9 @@ class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
         ]
 
         doc_hrefs = [a.get('href') for a in document.xpath(
-            '//div[@id="meta"]//ul[@class="govuk-list"]//li/a')]
+            '//div[@id="meta"]//ul[contains(@class, "govuk-list")]//li/a')]
+
+        print(str(doc_hrefs))
 
         for url_key in url_keys:
             if url_key in self.service['services']:

--- a/tests/main/views/test_suppliers.py
+++ b/tests/main/views/test_suppliers.py
@@ -236,15 +236,16 @@ class TestSuppliersPage(DataAPIClientMixin, BaseApplicationTest):
 
         assert res.status_code == 200
         assert self._strip_whitespace(
-            '<span itemprop="name">John Example</span>'
+            'John Example'
         ) in self._strip_whitespace(res.get_data(as_text=True))
         assert self._strip_whitespace(
-            '<span itemprop="telephone">07309404738</span>'
+            '07309404738'
         ) in self._strip_whitespace(res.get_data(as_text=True))
 
         email_html = '''<a href="mailto:j@examplecompany.biz"
         data-event-category="Email a supplier"
-        data-event-label="Example Company Limited">j@examplecompany.biz</a>'''
+        data-event-label="Example Company Limited">
+        <span class="govuk-visually-hidden">Email: </span>j@examplecompany.biz</a>'''
 
         assert self._strip_whitespace(email_html) in self._strip_whitespace(res.get_data(as_text=True))
 
@@ -255,12 +256,13 @@ class TestSuppliersPage(DataAPIClientMixin, BaseApplicationTest):
 
         assert res.status_code == 200
         assert self._strip_whitespace(
-            '<span itemprop="name">John Example</span>'
+            'John Example'
         ) in self._strip_whitespace(res.get_data(as_text=True))
 
         email_html = '''<a href="mailto:j@examplecompany.biz"
         data-event-category="Email a supplier"
-        data-event-label="Example Company Limited">j@examplecompany.biz</a>'''
+        data-event-label="Example Company Limited">
+        <span class="govuk-visually-hidden">Email: </span>j@examplecompany.biz</a>'''
 
         assert self._strip_whitespace(email_html) in self._strip_whitespace(res.get_data(as_text=True))
 


### PR DESCRIPTION
https://trello.com/c/TmFkHa5K/268-1-remove-contact-details-component-from-buyer-frontend

Replace uses of https://trello.com/c/CHscCdOh/81-contact-details with [a `<p>` tag with some breaks](https://trello.com/c/CHscCdOh/81-contact-details#comment-5eafd8133d38676a7c134366) as the Design System suggests.

The old component adds analytics tracking to the email link, and some structured data.

I've kept the analytics, but removed the structured data - it's the only instance of microdata across our site, so seems like an outlier.