### PR TITLE
Stop using invalid links

### DIFF
--- a/app/main/presenters/service_presenters.py
+++ b/app/main/presenters/service_presenters.py
@@ -120,8 +120,17 @@ class Meta(object):
         return documents
 
     def get_price_caveats(self, service_data):
+        def is_valid_link(link):
+            """
+            We can only accept links that begin with http/https. This is because we can't reliably distinguish between
+            links that have no scheme (such as www.gov.uk) and things that aren't links (such as www.gov@example.com).
+            """
+            return link and urlparse(link).scheme in ['http', 'https']
+
         def make_caveat(text, link=None):
-            return {'text': text, 'link': link} if link else {'text': text}
+            if is_valid_link(link):
+                return {'text': text, 'link': link}
+            return {'text': text}
 
         caveats = []
         main_caveats = [

--- a/tests/main/presenters/test_service_presenters.py
+++ b/tests/main/presenters/test_service_presenters.py
@@ -262,3 +262,12 @@ class TestMeta:
         free_trial_caveat = list(filter(lambda x: x['text'] == 'Free trial available', price_caveats))
         assert len(free_trial_caveat) == 1
         assert free_trial_caveat[0]['link'] == 'https://www.digitalmarketplace.service.gov.uk'
+
+    def test_caveat_links_must_be_valid_urls(self):
+        self.fixture['freeVersionTrialOption'] = True
+        self.fixture['freeVersionLink'] = 'www.gov.uk'
+        price_caveats = self.meta.get_price_caveats(self.fixture)
+
+        free_trial_caveat = list(filter(lambda x: x['text'] == 'Free trial available', price_caveats))
+        assert len(free_trial_caveat) == 1
+        assert 'link' not in free_trial_caveat[0]


### PR DESCRIPTION
Trello: https://trello.com/c/pVJs4sPT/1942-ccsrequests-re-digital-marketplace-feedback-changing-url-detection

Previously, we used whatever was in the 'link' field as a href. This is used for the free trial caveat to give a link to the page for the free trial for a service.

However, a significant minority of services that have a 'link' do not have a valid URL in the link. Some of these are missing the scheme (e.g. www.gov.uk), whilst others are not URLs at all (e.g. www.gov@example.com). It would be difficult and error-prone to try and be clever and detect scheme-less URLs and correct them. See https://www.digitalmarketplace.service.gov.uk/g-cloud/services/315054439576756 for an example.

So instead we only include the link if the link has a scheme and is thus valid as a link href.

~8% of services have a valid link. ~2% of services have an invalid link and will be impacted by this change. This change was triggered by a supplier noticing that their service had a broken link, so this clearly has some real impact.

Note that using user input as a href in this way does present a risk of XSS. There is an existing story in the product backlog to look into this. This change won't fix that, but should make any potential XSS attack a little bit harder.