### PR TITLE
Update DOS5 closing date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2051,8 +2051,8 @@
       "dev": true
     },
     "digitalmarketplace-frameworks": {
-      "version": "github:alphagov/digitalmarketplace-frameworks#dfd3eda5704977e2685543760f06f21c9155cbe8",
-      "from": "github:alphagov/digitalmarketplace-frameworks#v17.17.8"
+      "version": "github:alphagov/digitalmarketplace-frameworks#7bb133aaaaa069fd58d8db0ba9a3c866f7feab8d",
+      "from": "github:alphagov/digitalmarketplace-frameworks#v17.17.10"
     },
     "digitalmarketplace-frontend-toolkit": {
       "version": "git+https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#323b3d4b704e33782df6cdae7b105a2a9237a594",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "del": "^5.1.0",
-    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.17.8",
+    "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.17.10",
     "digitalmarketplace-frontend-toolkit": "https://github.com/alphagov/digitalmarketplace-frontend-toolkit.git#v36.1.0",
     "digitalmarketplace-govuk-frontend": "^2.6.0",
     "govuk-frontend": "^2.13.0",


### PR DESCRIPTION
Ticket: https://trello.com/c/asxyMFgq/2078-change-the-homepage-banner-regarding-dos5-closing-to-1pm-on-17th-nov

Bumps digitalmarketplace-frameworks from 17.17.8 to 17.17.10