### PR TITLE
set DM_REDIS_SERVICE_NAME to None

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,6 +29,7 @@ class Config(object):
     DM_SEARCH_API_URL = None
     DM_SEARCH_API_AUTH_TOKEN = None
     DM_MANDRILL_API_KEY = None
+    DM_REDIS_SERVICE_NAME = None
 
     # Used for generating absolute URLs from relative URLs when necessary
     DM_PATCH_FRONTEND_URL = 'http://localhost/'


### PR DESCRIPTION
https://trello.com/c/0XO8CHaP/381-05-stand-up-the-paas-infrastructure-for-the-preview-environment
We need to set this to `None` to stop it getting stripped out of the app config when set in an environment variable

Co-authored-by: Benjamin Gill <benjamin.gill@digital.cabinet-office.gov.uk>