### PR TITLE
Replace govukTable with govukSummaryList

### DIFF
--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -40,19 +40,21 @@ Cookies - Digital Marketplace
     <p class="govuk-body">
       We store a session cookie on your device to help keep your information secure while you use the service.
     </p>
-
-    {{ govukTable({
-      "head": [
-        {"text": "Name", "classes": "govuk-body-s"},
-        {"text": "Purpose", "classes": "govuk-body-s"},
-        {"text": "Expires", "classes": "govuk-body-s"}
-      ],
+    
+    {{ govukSummaryList({
       "rows": [
-        [
-          {"text": "dm_session", "classes": "govuk-body-s"},
-          {"text": "Stores encrypted session data", "classes": "govuk-body-s"},
-          {"text": "1 hour", "classes": "govuk-body-s"}
-        ],
+        {
+          "key": {"text": "Name"},
+          "value": {"text": "dm_session"},
+        },
+        {
+          "key": {"text": "Purpose"},
+          "value": {"text": "Stores encrypted session data"},
+        },
+        {
+          "key": {"text": "Expires"},
+          "value": {"text": "1 hour"},
+        }
       ]
     }) }}
 
@@ -62,19 +64,21 @@ Cookies - Digital Marketplace
       We test whether your browser is accepting cookies from Digital Marketplace, by setting a cookie.
       This cookie allows us to give useful error messages when things go wrong.
     </p>
-
-    {{ govukTable({
-      "head": [
-        {"text": "Name", "classes": "govuk-body-s"},
-        {"text": "Purpose", "classes": "govuk-body-s"},
-        {"text": "Expires", "classes": "govuk-body-s"}
-      ],
+    
+    {{ govukSummaryList({
       "rows": [
-        [
-          {"text": "dm_cookie_probe", "classes": "govuk-body-s"},
-          {"text": "Tells us if your browser is accepting cookies", "classes": "govuk-body-s"},
-          {"text": "1 year", "classes": "govuk-body-s"}
-        ],
+        {
+          "key": {"text": "Name"},
+          "value": {"text": "dm_cookie_probe"},
+        },
+        {
+          "key": {"text": "Purpose"},
+          "value": {"text": "Tells us if your browser is accepting cookies"},
+        },
+        {
+          "key": {"text": "Expires"},
+          "value": {"text": "1 year"},
+        }
       ]
     }) }}
 
@@ -95,29 +99,57 @@ Cookies - Digital Marketplace
     <p class="govuk-body">
       We do not allow Google to use or share the data about how you use this site.
     </p>
-
-    {{ govukTable({
-      "head": [
-        {"text": "Name", "classes": "govuk-body-s"},
-        {"text": "Purpose", "classes": "govuk-body-s"},
-        {"text": "Expires", "classes": "govuk-body-s"}
-      ],
+    
+    {{ govukSummaryList({
+      "classes": "govuk-!-margin-bottom-7",
       "rows": [
-        [
-          {"text": "_ga", "classes": "govuk-body-s"},
-          {"text": "Helps us count how many people visit Digital Marketplace by tracking if you’ve visited the service before", "classes": "govuk-body-s"},
-          {"text": "2 years", "classes": "govuk-body-s"}
-        ],
-        [
-          {"text": "_gid", "classes": "govuk-body-s"},
-          {"text": "Helps us count how many people visit Digital Marketplace by tracking if you’ve visited the service before", "classes": "govuk-body-s"},
-          {"text": "24 hours", "classes": "govuk-body-s"}
-        ],
-        [
-          {"text": "_gat_govuk_shared", "classes": "govuk-body-s"},
-          {"html": 'Helps us count how many users visit <a class="govuk-link" href="http://www.gov.uk" rel=external>GOV.UK</a> after visiting Digital Marketplace', "classes": "govuk-body-s"},
-          {"text": "10 minutes", "classes": "govuk-body-s"}
-        ]
+        {
+          "key": {"text": "Name"},
+          "value": {"text": "_ga"},
+        },
+        {
+          "key": {"text": "Purpose"},
+          "value": {"text": "Helps us count how many people visit Digital Marketplace by tracking if you’ve visited the service before"},
+        },
+        {
+          "key": {"text": "Expires"},
+          "value": {"text": "2 years"},
+        }
+      ]
+    }) }}
+    
+    {{ govukSummaryList({
+      "classes": "govuk-!-margin-bottom-7",
+      "rows": [
+        {
+          "key": {"text": "Name"},
+          "value": {"text": "_gid"},
+        },
+        {
+          "key": {"text": "Purpose"},
+          "value": {"text": "Helps us count how many people visit Digital Marketplace by tracking if you’ve visited the service before"},
+        },
+        {
+          "key": {"text": "Expires"},
+          "value": {"text": "24 hours"}
+        }
+      ]
+    }) }}
+    
+    {{ govukSummaryList({
+      "rows": [
+        {
+          "key": {"text": "Name"},
+          "value": {"text": "_gat_govuk_shared"},
+        },
+        {
+          "key": {"text": "Purpose"},
+          "value": {"html": 'Helps us count how many users visit <a class="govuk-link" href="http://www.gov.uk" rel=external>GOV.UK</a> after visiting Digital Marketplace'},
+        },
+        {
+          "key": {"text": "Expires"},
+          "value": {"text": "10 minutes"}
+        }
       ]
     }) }}
 
@@ -133,18 +165,21 @@ Cookies - Digital Marketplace
       You can <a href="{{ url_for('external.cookie_settings')}}" class="govuk-link">change your analytics
         settings</a> at any time.
     </p>
-    {{ govukTable({
-      "head": [
-        {"text": "Name", "classes": "govuk-body-s"},
-        {"text": "Purpose", "classes": "govuk-body-s"},
-        {"text": "Expires", "classes": "govuk-body-s"}
-      ],
+    
+    {{ govukSummaryList({
       "rows": [
-        [
-          {"text": "dm_cookie_policy", "classes": "govuk-body-s"},
-          {"text": "Tells us that you have seen our cookie message", "classes": "govuk-body-s"},
-          {"text": "1 year", "classes": "govuk-body-s"}
-        ],
+        {
+          "key": {"text": "Name"},
+          "value": {"text": "dm_cookie_policy"},
+        },
+        {
+          "key": {"text": "Purpose"},
+          "value": {"text": "Tells us that you have seen our cookie message"},
+        },
+        {
+          "key": {"text": "Expires"},
+          "value": {"text": "1 year"}
+        }
       ]
     }) }}
   </div>

--- a/app/templates/content/cookies.html
+++ b/app/templates/content/cookies.html
@@ -45,7 +45,7 @@ Cookies - Digital Marketplace
       "rows": [
         {
           "key": {"text": "Name"},
-          "value": {"text": "dm_session"},
+          "value": {"html": "<strong>dm_session</strong>"},
         },
         {
           "key": {"text": "Purpose"},
@@ -69,7 +69,7 @@ Cookies - Digital Marketplace
       "rows": [
         {
           "key": {"text": "Name"},
-          "value": {"text": "dm_cookie_probe"},
+          "value": {"html": "<strong>dm_cookie_probe</strong>"},
         },
         {
           "key": {"text": "Purpose"},
@@ -105,7 +105,7 @@ Cookies - Digital Marketplace
       "rows": [
         {
           "key": {"text": "Name"},
-          "value": {"text": "_ga"},
+          "value": {"html": "<strong>_ga</strong>"},
         },
         {
           "key": {"text": "Purpose"},
@@ -123,7 +123,7 @@ Cookies - Digital Marketplace
       "rows": [
         {
           "key": {"text": "Name"},
-          "value": {"text": "_gid"},
+          "value": {"html": "<strong>_gid</strong>"},
         },
         {
           "key": {"text": "Purpose"},
@@ -140,7 +140,7 @@ Cookies - Digital Marketplace
       "rows": [
         {
           "key": {"text": "Name"},
-          "value": {"text": "_gat_govuk_shared"},
+          "value": {"html": "<strong>_gat_govuk_shared</strong>"},
         },
         {
           "key": {"text": "Purpose"},
@@ -170,7 +170,7 @@ Cookies - Digital Marketplace
       "rows": [
         {
           "key": {"text": "Name"},
-          "value": {"text": "dm_cookie_policy"},
+          "value": {"html": "<strong>dm_cookie_policy</strong>"},
         },
         {
           "key": {"text": "Purpose"},


### PR DESCRIPTION
On mobile/small screens, table text gets pretty squashed. This solves that since summary lists are stacked.

However, the summary lists are also not particularly visually distinct when multiple are stacked.

It might be worth considering revisiting this page when the summary_card component is fully adopted: https://github.com/alphagov/govuk-design-system-backlog/issues/210

![Screenshot 2020-11-13 at 16 10 31](https://user-images.githubusercontent.com/22524634/99093751-d3aec580-25ca-11eb-843b-178f14c24ad4.png)


![Screenshot 2020-11-19 at 09 47 46](https://user-images.githubusercontent.com/22524634/99649609-5234b880-2a4c-11eb-9fa2-646b0f9dae18.png)
