### PR TITLE
Pull in fix for 'a instance'

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,6 @@ itsdangerous==1.1.0
 lxml==4.6.1
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@55.1.1#egg=digitalmarketplace-utils==55.1.1
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.0#egg=digitalmarketplace-content-loader==7.26.0
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.2#egg=digitalmarketplace-content-loader==7.26.2
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.6-alpha#egg=govuk-frontend-jinja==0.5.6-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==3.2.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.0#egg=digitalmarketplace-content-loader==7.26.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.2#egg=digitalmarketplace-content-loader==7.26.2  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-utils.git@55.1.1#egg=digitalmarketplace-utils==55.1.1  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore


### PR DESCRIPTION
Trello: https://trello.com/c/RlNy5WlG/2074-ccsrequests-re-listing-correction

From https://github.com/alphagov/digitalmarketplace-content-loader/pull/118

I've confirmed that this fixes things:

![image](https://user-images.githubusercontent.com/15256121/99790790-7f509c00-2b1c-11eb-8092-036aca8e43b5.png)
