### PR TITLE
Add override classes for briefs stat block font

### DIFF
--- a/app/templates/_brief_applications_stats.html
+++ b/app/templates/_brief_applications_stats.html
@@ -1,7 +1,7 @@
 <div class="govuk-grid-column-one-third app-stat-block" id="incomplete-applications">
-   <h2>
-      <span class="govuk-!-font-size-36 govuk-!-display-block">{{- brief_responses_stats.incomplete_responses_total }}</span>
-      <span>
+   <h2 class="govuk-!-margin-bottom-0">
+      <span class="govuk-body govuk-!-margin-bottom-0 govuk-!-font-weight-bold govuk-!-font-size-36 govuk-!-display-block">{{- brief_responses_stats.incomplete_responses_total }}</span>
+      <span class="govuk-body govuk-!-font-weight-bold">
          {{- 
             pluralize(
                brief_responses_stats.incomplete_responses_total,
@@ -23,9 +23,9 @@
    </p>
 </div>
 <div class="govuk-grid-column-one-third app-stat-block" id="completed-applications">
-   <h2>
-      <span class="govuk-!-font-size-36 govuk-!-display-block">{{- brief_responses_stats.completed_responses_total }}</span>
-      <span>
+   <h2 class="govuk-!-margin-bottom-0">
+      <span class="govuk-body govuk-!-margin-bottom-0  govuk-!-font-weight-bold govuk-!-font-size-36 govuk-!-display-block">{{- brief_responses_stats.completed_responses_total }}</span>
+      <span class="govuk-body govuk-!-font-weight-bold ">
          {{- 
             pluralize(
                brief_responses_stats.completed_responses_total,


### PR DESCRIPTION
@fajerq caught this font mismatch on Brief pages. Rather than introducing css to cover it, I've used some override styles, because the hope is we can remove all custom styles for this component some time in the future.

### Before
![Screenshot 2020-11-27 at 15 37 23](https://user-images.githubusercontent.com/22524634/100465448-3aea7080-30c7-11eb-8589-7e1252f64ce5.png)

### After
![Screenshot 2020-11-27 at 15 37 38](https://user-images.githubusercontent.com/22524634/100465456-3de56100-30c7-11eb-9096-b7349e586a95.png)
