### PR TITLE
Add attachment to service page and DOS search

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -19,6 +19,7 @@
 {% from "digitalmarketplace/components/cookie-banner/macro.njk" import dmCookieBanner %}
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader%}
 {% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
+{% from "digitalmarketplace/components/attachment/macro.njk" import dmAttachment%}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter%}
 {% from "digitalmarketplace/components/banner/macro.njk" import dmBanner %}
 {% from "digitalmarketplace/components/previous-next-pagination/macro.njk" import dmPreviousNextPagination %}

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -19,10 +19,17 @@
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Service documents</h2>
   <ul class="govuk-list govuk-body-s">
   {% for document in service.meta.documents %}
-    <li class="govuk-!-margin-bottom-2">
-      <a href="{{ document.url }}" class="govuk-link">
-        {{ document.name }} ({{ document.extension }})
-      </a>
+    <li class="gouk-!-margin-bottom-2">
+      {{dmAttachment({
+        "link": {
+          "classes": "govuk-!-font-size-16",
+          "href": document.url,
+          "text": document.name
+        },
+        "contentType": document.extension | upper,
+        "headingTag": 'p',
+        "thumbnailSize": "small"
+      })}}
     </li>
   {% endfor %}
   </ul>

--- a/app/templates/search/_opportunity_data.html
+++ b/app/templates/search/_opportunity_data.html
@@ -1,14 +1,22 @@
 <div>
   <h2 class="govuk-heading-s" id="opportunity-data-header">Opportunity data</h2>
   <p class="govuk-body" id="opportunity-data-description">Download data buyers have provided about closed opportunities. Some data may be missing.<p>
-  <p class="govuk-body govuk-!-margin-bottom-9">
-    <a class="govuk-link" 
-        href="{{ 'https://assets.digitalmarketplace.service.gov.uk/{}/communications/data/opportunity-data.csv'.format(framework.slug) }}"
-        download
-        data-analytics="trackEvent"
-        data-analytics-category="opportunity-data-csv"
-        data-analytics-action="download CSV"
-        data-analytics-label="Opportunity Data CSV"        
-    >Download data (CSV)</a>
-  </p>
+  {{dmAttachment({
+    "link": {
+      "classes": "govuk-!-font-size-19",
+      "href": 'https://assets.digitalmarketplace.service.gov.uk/{}/communications/data/opportunity-data.csv'.format(framework.slug),
+      "text": 'Download data',
+      "attributes": {
+        "download": "",
+        "data-analytics": "trackEvent",
+        "data-analytics-category": "opportunity-data-csv",
+        "data-analytics-action": "download CSV",
+        "data-analytics-label": "Opportunity Data CSV"
+      }
+    },
+    "contentType": 'text/csv',
+    "headingTag": 'p',
+    "thumbnailSize": "small"
+  })}}
+  <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-3">If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <span class="govuk-!-display-block govuk-!-margin-top-1 govuk-!-margin-bottom-2"><a href="mailto:help@digitalmarketplace.service.gov.uk" target="_blank" class="govuk-link">help@digitalmarketplace.service.gov.uk</a>.</span>Please tell us what format you need. It will help us if you say what assistive technology you use.</p>
 </div>

--- a/app/templates/search/_opportunity_data.html
+++ b/app/templates/search/_opportunity_data.html
@@ -18,5 +18,5 @@
     "headingTag": 'p',
     "thumbnailSize": "small"
   })}}
-  <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-3">If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <span class="govuk-!-display-block govuk-!-margin-top-1 govuk-!-margin-bottom-2"><a href="mailto:help@digitalmarketplace.service.gov.uk" target="_blank" class="govuk-link">help@digitalmarketplace.service.gov.uk</a>.</span>Please tell us what format you need. It will help us if you say what assistive technology you use.</p>
+  <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-3">If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <span class="govuk-!-display-block govuk-!-margin-top-1 govuk-!-margin-bottom-2"><a href="mailto:info@crowncommercial.gov.uk" target="_blank" class="govuk-link">info@crowncommercial.gov.uk</a>.</span>Please tell us what format you need. It will help us if you say what assistive technology you use.</p>
 </div>

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -80,9 +80,16 @@
     <ul class="govuk-list">
     {% for document in service.meta.documents %}
       <li class="govuk-!-margin-bottom-2">
-        <a href="{{ document.url }}" class="govuk-link">
-          {{ document.name }} ({{ document.extension }})
-        </a>
+        {{dmAttachment({
+          "link": {
+            "classes": "govuk-!-font-size-16",
+            "href": document.url,
+            "text": document.name
+          },
+          "contentType": document.extension | upper,
+          "headingTag": 'p',
+          "thumbnailSize": "small"
+        })}}
       </li>
     {% endfor %}
     </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2055,8 +2055,8 @@
       "from": "github:alphagov/digitalmarketplace-frameworks#v17.17.10"
     },
     "digitalmarketplace-govuk-frontend": {
-      "version": "github:alphagov/digitalmarketplace-govuk-frontend#497d6f82d4493b772db84d00af3805742ec03998",
-      "from": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r4"
+      "version": "github:alphagov/digitalmarketplace-govuk-frontend#e008bfad4286de2ffb0200869538f345398a76d8",
+      "from": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release--govuk-frontend-v3-r5"
     },
     "dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "del": "^5.1.0",
     "digitalmarketplace-frameworks": "github:alphagov/digitalmarketplace-frameworks#v17.17.10",
-    "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release-v3.0.0-govuk-frontend-3-r4",
+    "digitalmarketplace-govuk-frontend": "github:alphagov/digitalmarketplace-govuk-frontend#pre-release--govuk-frontend-v3-r5",
     "govuk-frontend": "^3.9.1",
     "gulp": "^4.0.2",
     "gulp-filelog": "0.4.1",

--- a/tests/main/views/test_marketplace.py
+++ b/tests/main/views/test_marketplace.py
@@ -1564,7 +1564,7 @@ class TestCatalogueOfBriefsPage(APIClientMixin, BaseApplicationTest):
         header = document.xpath("//h2[@id='opportunity-data-header']")[0].text
         description = document.xpath("//p[@id='opportunity-data-description']")[0].text
         expected_desc = "Download data buyers have provided about closed opportunities. Some data may be missing."
-        link = document.xpath("//a[normalize-space(text())='Download data (CSV)']")[0].values()
+        link = document.xpath("//a[normalize-space(text())='Download data']")[0].values()
         expected_link = (
             "https://assets.digitalmarketplace.service.gov.uk"
             + f"/digital-outcomes-and-specialists{expected_url_slug_suffix}/communications/data/opportunity-data.csv"

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -76,7 +76,7 @@ class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
         ]
 
         doc_hrefs = [a.get('href') for a in document.xpath(
-            '//div[@id="meta"]//ul[contains(@class, "govuk-list")]//li/a')]
+            '//div[@id="meta"]//ul[contains(@class, "govuk-list")]//li/section[@class="dm-attachment"]//p/a')]
 
         print(str(doc_hrefs))
 


### PR DESCRIPTION
https://trello.com/c/tUd7Ck2w/275-5-replace-document-links-with-attachment-component-in-frontend-apps

## DOS Search page
### Before
![Screenshot 2020-12-01 at 13 30 26](https://user-images.githubusercontent.com/22524634/100749269-59f54500-33dc-11eb-9632-83adcb5dddc0.png)
### After
![Screenshot 2020-12-02 at 10 30 46](https://user-images.githubusercontent.com/22524634/100861295-8915c000-3489-11eb-9311-1a9386575e40.png)

## Service page
### Before
![Screenshot 2020-12-01 at 09 42 32](https://user-images.githubusercontent.com/22524634/100749378-80b37b80-33dc-11eb-9556-c0b5bec8f7f8.png)
![Screenshot 2020-12-01 at 09 41 42](https://user-images.githubusercontent.com/22524634/100749441-92951e80-33dc-11eb-99e4-43a6d06448aa.png)

### After
![Screenshot 2020-12-01 at 09 42 52](https://user-images.githubusercontent.com/22524634/100749396-85782f80-33dc-11eb-8f16-102ede13f2f5.png)
![Screenshot 2020-12-01 at 09 42 01](https://user-images.githubusercontent.com/22524634/100749421-8c06a700-33dc-11eb-93d7-1727c754fae6.png)

