### PR TITLE
Fix details list on briefs search page

### DIFF
--- a/app/templates/search/_briefs_results.html
+++ b/app/templates/search/_briefs_results.html
@@ -5,11 +5,11 @@
             <a class="govuk-link" href="{{ url_for('.get_brief_by_id', framework_family=framework_family, brief_id=brief.id) }}">{{ brief.title }}</a>
         </h2>
 
-        <ul>
-            <li class="govuk-!-font-weight-bold">
+        <ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0">
+            <li class="govuk-!-font-weight-bold govuk-!-font-size-16 govuk-!-margin-bottom-0">
                 <span class="govuk-visually-hidden">Organisation: </span>{{ brief.organisation }}
             </li>
-            <li class="govuk-!-font-weight-bold">
+            <li class="govuk-!-font-weight-bold govuk-!-font-size-16">
                 <span class="govuk-visually-hidden">Location: </span>{{ brief.location }}
             </li>
         </ul>


### PR DESCRIPTION
This list should have some classes on it to make it conform to how it appeared before.

![Screenshot 2020-12-02 at 15 25 39](https://user-images.githubusercontent.com/22524634/100892837-a743e600-34b2-11eb-9875-5e2f5e627a17.png)
