### PR TITLE
Add accessible format request text to service page

### DIFF
--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -9,6 +9,7 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}

--- a/app/templates/_service_documents.html
+++ b/app/templates/_service_documents.html
@@ -1,0 +1,21 @@
+<ul class="govuk-list govuk-body-s">
+{% for document in service.meta.documents %}
+    <li class="gouk-!-margin-bottom-2">
+        {{dmAttachment({
+        "link": {
+            "classes": "govuk-!-font-size-16",
+            "href": document.url,
+            "text": document.name
+        },
+        "contentType": document.extension | upper,
+        "headingTag": 'p',
+        "thumbnailSize": "small"
+        })}}
+    </li>
+{% endfor %}
+</ul>
+{{ govukDetails({
+"classes": "govuk-!-font-size-16",
+"summaryText": "Request an accessible format",
+"html": 'If you use assistive technology (such as a screen reader) and need a version of these documents in a more accessible format, please email <a href="mailto:info@crowncommercial.gov.uk" target="_blank" class="govuk-link">info@crowncommercial.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.'
+})}}

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -17,30 +17,7 @@
   {% endfor %}
   </ul>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Service documents</h2>
-  <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-3">
-    
-  </p>
-  <ul class="govuk-list govuk-body-s">
-  {% for document in service.meta.documents %}
-    <li class="gouk-!-margin-bottom-2">
-      {{dmAttachment({
-        "link": {
-          "classes": "govuk-!-font-size-16",
-          "href": document.url,
-          "text": document.name
-        },
-        "contentType": document.extension | upper,
-        "headingTag": 'p',
-        "thumbnailSize": "small"
-      })}}
-    </li>
-  {% endfor %}
-  </ul>
-  {{ govukDetails({
-    "classes": "govuk-!-font-size-16",
-    "summaryText": "Request an accessible format",
-    "html": 'If you use assistive technology (such as a screen reader) and need a version of these documents in a more accessible format, please email <span class="govuk-!-display-block govuk-!-margin-top-1 govuk-!-margin-bottom-2"><a href="mailto:info@crowncommercial.gov.uk" target="_blank" class="govuk-link">info@crowncommercial.gov.uk</a>.</span>Please tell us what format you need. It will help us if you say what assistive technology you use.'
-  })}}
+  {% include '_service_documents.html' %}
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Framework</h2>
   <p class="govuk-body-s">{{ service.frameworkName }}</p>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Service ID</h2>

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -17,6 +17,9 @@
   {% endfor %}
   </ul>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Service documents</h2>
+  <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-3">
+    
+  </p>
   <ul class="govuk-list govuk-body-s">
   {% for document in service.meta.documents %}
     <li class="gouk-!-margin-bottom-2">
@@ -33,6 +36,11 @@
     </li>
   {% endfor %}
   </ul>
+  {{ govukDetails({
+    "classes": "govuk-!-font-size-16",
+    "summaryText": "Request an accessible format",
+    "html": 'If you use assistive technology (such as a screen reader) and need a version of these documents in a more accessible format, please email <span class="govuk-!-display-block govuk-!-margin-top-1 govuk-!-margin-bottom-2"><a href="mailto:info@crowncommercial.gov.uk" target="_blank" class="govuk-link">info@crowncommercial.gov.uk</a>.</span>Please tell us what format you need. It will help us if you say what assistive technology you use.'
+  })}}
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Framework</h2>
   <p class="govuk-body-s">{{ service.frameworkName }}</p>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Service ID</h2>

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -76,6 +76,10 @@
 <div class="govuk-grid-row" id="service-attributes">
   <div class="govuk-grid-column-full">
     {% include '_service_attributes.html' %}
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m app-summary-list-heading" id="service-documents">Service documents</h2>
     <ul class="govuk-list">
     {% for document in service.meta.documents %}
@@ -93,6 +97,11 @@
       </li>
     {% endfor %}
     </ul>
+    {{ govukDetails({
+      "classes": "govuk-!-font-size-16",
+      "summaryText": "Request an accessible format",
+      "html": 'If you use assistive technology (such as a screen reader) and need a version of these documents in a more accessible format, please email <a href="mailto:info@crowncommercial.gov.uk" target="_blank" class="govuk-link">info@crowncommercial.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.'
+    })}}
   </div>
 </div>
 

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -81,27 +81,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m app-summary-list-heading" id="service-documents">Service documents</h2>
-    <ul class="govuk-list">
-    {% for document in service.meta.documents %}
-      <li class="govuk-!-margin-bottom-2">
-        {{dmAttachment({
-          "link": {
-            "classes": "govuk-!-font-size-16",
-            "href": document.url,
-            "text": document.name
-          },
-          "contentType": document.extension | upper,
-          "headingTag": 'p',
-          "thumbnailSize": "small"
-        })}}
-      </li>
-    {% endfor %}
-    </ul>
-    {{ govukDetails({
-      "classes": "govuk-!-font-size-16",
-      "summaryText": "Request an accessible format",
-      "html": 'If you use assistive technology (such as a screen reader) and need a version of these documents in a more accessible format, please email <a href="mailto:info@crowncommercial.gov.uk" target="_blank" class="govuk-link">info@crowncommercial.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.'
-    })}}
+    {% include '_service_documents.html' %}
   </div>
 </div>
 


### PR DESCRIPTION
https://trello.com/c/tUd7Ck2w/275-5-replace-document-links-with-attachment-component-in-frontend-apps

Adds details on how to request accessible versions of the documents on the service page.

## Before

![Screenshot 2020-12-03 at 12 17 25](https://user-images.githubusercontent.com/22524634/101017198-acac3980-3561-11eb-8799-67515de2b9fe.png)

![Screenshot 2020-12-03 at 12 17 37](https://user-images.githubusercontent.com/22524634/101017208-b0d85700-3561-11eb-80df-03962c419486.png)


## After
![Screenshot 2020-12-03 at 12 17 45](https://user-images.githubusercontent.com/22524634/101017156-a027e100-3561-11eb-90b6-63a43b6ea70d.png)

![Screenshot 2020-12-03 at 12 13 11](https://user-images.githubusercontent.com/22524634/101017184-a7e78580-3561-11eb-8b80-33f6e5dcfec8.png)
