### PR TITLE
Add more detailed error messages for date inputs

### DIFF
--- a/app/main/forms/direct_award_forms.py
+++ b/app/main/forms/direct_award_forms.py
@@ -9,7 +9,7 @@ from dmutils.forms.fields import (
     DMStripWhitespaceStringField,
     DMRadioField,
 )
-from dmutils.forms.validators import GreaterThan
+from dmutils.forms.validators import DateValidator, GreaterThan
 
 from decimal import Decimal
 
@@ -82,20 +82,16 @@ class TellUsAboutContractForm(FlaskForm):
 
     start_date = DMDateField(
         "Start date",
-        id="input-start_date-day",
         validators=[
-            InputRequired("Enter the start date"),
-            DataRequired("Enter the full start date of your contract"),
+            DateValidator("the start date"),
         ],
     )
 
     end_date = DMDateField(
         "End date",
-        id="input-end_date-day",
         validators=[
-            InputRequired("Enter the end date"),
-            DataRequired("Enter the full end date of your contract"),
-            GreaterThan("start_date", "Your end date must be later than the start date."),
+            DateValidator("the end date"),
+            GreaterThan("start_date", "End date must be after the start date"),
         ],
     )
 

--- a/app/templates/direct-award/tell-us-about-contract.html
+++ b/app/templates/direct-award/tell-us-about-contract.html
@@ -55,17 +55,17 @@
           "errorMessage": errors.start_date.errorMessage if errors.start_date.errorMessage,
           "items": [
             {
-              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if errors.start_date.errorMessage),
+              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if form.start_date.day.errors),
               "name": "day",
               "value": form.start_date.value['start_date-day'] if form.start_date.value['start_date-day']
             },
             {
-              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if errors.start_date.errorMessage),
+              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if form.start_date.month.errors),
               "name": "month",
               "value": form.start_date.value['start_date-month'] if form.start_date.value['start_date-month']
             },
             {
-              "classes": "govuk-input--width-4" ~ (' govuk-input--error' if errors.start_date.errorMessage),
+              "classes": "govuk-input--width-4" ~ (' govuk-input--error' if form.start_date.year.errors),
               "name": "year",
               "value": form.start_date.value['start_date-year'] if form.start_date.value['start_date-year']
             }
@@ -87,17 +87,17 @@
           "errorMessage": errors.end_date.errorMessage if errors.end_date.errorMessage,
           "items": [
             {
-              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if errors.end_date.errorMessage),
+              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if form.end_date.day.errors),
               "name": "day",
               "value": form.end_date.value['end_date-day'] if form.end_date.value['end_date-day']
             },
             {
-              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if errors.end_date.errorMessage),
+              "classes": "govuk-input--width-2" ~ (' govuk-input--error' if form.end_date.month.errors),
               "name": "month",
               "value": form.end_date.value['end_date-month'] if form.end_date.value['end_date-month']
             },
             {
-              "classes": "govuk-input--width-4" ~ (' govuk-input--error' if errors.end_date.errorMessage),
+              "classes": "govuk-input--width-4" ~ (' govuk-input--error' if form.end_date.year.errors),
               "name": "year",
               "value": form.end_date.value['end_date-year'] if form.end_date.value['end_date-year']
             }

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ Flask-WTF==0.14.3
 itsdangerous==1.1.0
 lxml==4.6.1
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@56.1.0#egg=digitalmarketplace-utils==56.1.0
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.2#egg=digitalmarketplace-content-loader==7.26.2
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1
 git+https://github.com/alphagov/govuk-frontend-jinja.git@v0.5.6-alpha#egg=govuk-frontend-jinja==0.5.6-alpha

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ cryptography==3.2.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-apiclient.git@21.4.1#egg=digitalmarketplace-apiclient==21.4.1  # via -r requirements.in
 git+https://github.com/alphagov/digitalmarketplace-content-loader.git@7.26.2#egg=digitalmarketplace-content-loader==7.26.2  # via -r requirements.in
-git+https://github.com/alphagov/digitalmarketplace-utils.git@56.0.0#egg=digitalmarketplace-utils==56.0.0  # via -r requirements.in, digitalmarketplace-content-loader
+git+https://github.com/alphagov/digitalmarketplace-utils.git@56.1.0#egg=digitalmarketplace-utils==56.1.0  # via -r requirements.in, digitalmarketplace-content-loader
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 flask-gzip==0.2           # via digitalmarketplace-utils


### PR DESCRIPTION
Ticket: https://trello.com/c/Ex9qw68e/184-3-more-granular-date-error-messages

Requires alphagov/digitalmarketplace-utils#590.