### PR TITLE
Fix HTML typos

### DIFF
--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -11,7 +11,7 @@
 
 <h2 id="clarification-questions" class="govuk-heading-m app-summary-list-heading">Questions asked by suppliers</h2>
 {% if brief.clarificationQuestions is undefined or brief.clarificationQuestions|length == 0 %} 
-<p class="summary-item-no-content">No questions have been answered yet</p>
+<p class="govuk-body">No questions have been answered yet</p>
 {% else %}
 {{ govukSummaryList({
     "rows": brief.clarificationQuestions, 
@@ -29,5 +29,5 @@
     {% endif %}
   </a>
 {% elif brief.status == 'live' %}
-  The deadline for asking questions about this opportunity was {{ brief.clarificationQuestionsClosedAt|dateformat }}.
+  <p class="govuk-body">The deadline for asking questions about this opportunity was {{ brief.clarificationQuestionsClosedAt|dateformat }}.</p>
 {% endif %}

--- a/app/templates/_brief_q_and_a.html
+++ b/app/templates/_brief_q_and_a.html
@@ -1,12 +1,15 @@
 {% if brief.status == 'live' and not brief.clarificationQuestionsAreClosed and brief.questionAndAnswerSessionDetails %}
   <h2 id="question-and-answer-session" class="govuk-heading-m">Question and answer session</h2>
-  <a class="govuk-link govuk-!-display-inline-block govuk-!-margin-bottom-6" href="/suppliers/opportunities/{{ brief.id }}/question-and-answer-session">
-    {% if current_user.is_authenticated and current_user.role == 'supplier' %}
-      View question and answer session details
-    {% else %}
-      Log in to view question and answer session details
-    {% endif %}
-  </a>
+
+  <p class="govuk-body">
+    <a class="govuk-link govuk-!-margin-bottom-6" href="/suppliers/opportunities/{{ brief.id }}/question-and-answer-session">
+      {% if current_user.is_authenticated and current_user.role == 'supplier' %}
+        View question and answer session details
+      {% else %}
+        Log in to view question and answer session details
+      {% endif %}
+    </a>
+  </p>
 {% endif %}
 
 <h2 id="clarification-questions" class="govuk-heading-m app-summary-list-heading">Questions asked by suppliers</h2>
@@ -21,13 +24,15 @@
 {% endif %}
 
 {% if brief.status == 'live' and not brief.clarificationQuestionsAreClosed %}
-  <a class="govuk-link" href="/suppliers/opportunities/{{ brief.id }}/ask-a-question">
-    {% if current_user.is_authenticated and current_user.role == 'supplier' %}
-      Ask a question
-    {% else %}
-      Log in to ask a question
-    {% endif %}
-  </a>
+  <p class="govuk-body">
+    <a class="govuk-link" href="/suppliers/opportunities/{{ brief.id }}/ask-a-question">
+      {% if current_user.is_authenticated and current_user.role == 'supplier' %}
+        Ask a question
+      {% else %}
+        Log in to ask a question
+      {% endif %}
+    </a>
+  </p>
 {% elif brief.status == 'live' %}
   <p class="govuk-body">The deadline for asking questions about this opportunity was {{ brief.clarificationQuestionsClosedAt|dateformat }}.</p>
 {% endif %}

--- a/app/templates/search/_opportunity_data.html
+++ b/app/templates/search/_opportunity_data.html
@@ -1,6 +1,6 @@
 <div>
   <h2 class="govuk-heading-s" id="opportunity-data-header">Opportunity data</h2>
-  <p class="govuk-body" id="opportunity-data-description">Download data buyers have provided about closed opportunities. Some data may be missing.<p>
+  <p class="govuk-body" id="opportunity-data-description">Download data buyers have provided about closed opportunities. Some data may be missing.</p>
   {{dmAttachment({
     "link": {
       "classes": "govuk-!-font-size-19",


### PR DESCRIPTION
Two small HTML typos I found:

- close p tag
- add p tag with formatting to message on brief page

### Screenshots

#### Before

<img width="699" alt="Screenshot 2021-01-08 at 12 59 54" src="https://user-images.githubusercontent.com/503614/104024791-9413ec80-51bb-11eb-85d6-4ed4a67b3eab.png">

#### After

<img width="764" alt="Screenshot 2021-01-08 at 14 12 07" src="https://user-images.githubusercontent.com/503614/104024776-8f4f3880-51bb-11eb-9000-4c0a2622aa0d.png">
