### PR TITLE
Fix error summary link for choose a category page

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -135,7 +135,7 @@ def choose_lot(framework_family):
         else:
             errors["lot"] = {
                 "input_name": "lot",
-                "href": "#input-lot-1",
+                "href": "#input-lot",
                 "question": "Choose a category",
                 "message": "Select a category to start your search",
             }


### PR DESCRIPTION
govuk-frontend 3 does not have `-1` appended to the id for the first input element in a radios component.