### PR TITLE
Show 404s for deleted services

### DIFF
--- a/app/main/views/g_cloud.py
+++ b/app/main/views/g_cloud.py
@@ -180,6 +180,8 @@ def get_service_by_id(service_id):
             abort(404, "Service ID '{}' can not be found".format(service_id))
         if service['services']['frameworkStatus'] not in ("live", "expired"):
             abort(404, "Service ID '{}' can not be found".format(service_id))
+        if service['services']['status'] == 'deleted':
+            abort(404, "Service ID '{}' can not be found".format(service_id))
 
         service_data = service['services']
         framework_slug = service_data['frameworkSlug']

--- a/tests/main/views/test_services.py
+++ b/tests/main/views/test_services.py
@@ -321,3 +321,11 @@ class TestServicePage(DataAPIClientMixin, BaseApplicationTest):
             heading.strip() for heading in attribute_headings]
 
         assert 'Certifications' not in attribute_headings
+
+    def test_deleted_service_causes_404(self):
+        self.service["services"]["status"] = "deleted"
+        self.data_api_client.get_service.return_value = self.service
+
+        service_id = self.service['services']['id']
+        res = self.client.get(f'/g-cloud/services/{service_id}')
+        assert res.status_code == 404


### PR DESCRIPTION
In order to support a supplier's request to be removed completely from G-Cloud we are adding a new service status - `deleted`.

The URL for a service with `deleted` status should return a 404. This is different from the behaviour of `disabled` status, which still shows the service information at that URL but with a banner stating the service is unavailable.

https://trello.com/c/qqL3sqWV/2182-remove-supplier-92526-from-g-cloud