### PR TITLE
Add message on how to request alternative formats of service documents

### DIFF
--- a/app/templates/_service_documents.html
+++ b/app/templates/_service_documents.html
@@ -1,0 +1,18 @@
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+<ul class="govuk-list">
+{% for document in service.meta.documents %}
+  <li class="gouk-!-margin-bottom-2">
+    {{dmAttachment({
+      "link": {
+        "classes": "govuk-!-font-size-16",
+        "href": document.url,
+        "text": document.name
+      },
+      "contentType": document.extension | upper,
+      "headingTag": 'p',
+      "thumbnailSize": "small"
+    })}}
+  </li>
+{% endfor %}
+</ul>

--- a/app/templates/_service_documents.html
+++ b/app/templates/_service_documents.html
@@ -16,3 +16,15 @@
   </li>
 {% endfor %}
 </ul>
+
+{% set alternativeFormatHtml %}
+  If you use assistive technology (such as a screen reader) and need versions of these documents in a more accessible format,
+  email the supplier at <a href="mailto:{{ service.meta.contact.email }}" target="_blank" class="govuk-link">{{ service.meta.contact.email }}</a>.
+  Tell them what format you need. It will help if you say what assistive technology you use.
+{% endset %}
+
+{{ govukDetails({
+  "classes": "govuk-!-font-size-16",
+  "summaryText": "Request an accessible format",
+  "html": alternativeFormatHtml
+}) }}

--- a/app/templates/_service_meta.html
+++ b/app/templates/_service_meta.html
@@ -17,22 +17,7 @@
   {% endfor %}
   </ul>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Service documents</h2>
-  <ul class="govuk-list govuk-body-s">
-  {% for document in service.meta.documents %}
-    <li class="gouk-!-margin-bottom-2">
-      {{dmAttachment({
-        "link": {
-          "classes": "govuk-!-font-size-16",
-          "href": document.url,
-          "text": document.name
-        },
-        "contentType": document.extension | upper,
-        "headingTag": 'p',
-        "thumbnailSize": "small"
-      })}}
-    </li>
-  {% endfor %}
-  </ul>
+  {% include "_service_documents.html" %}
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Framework</h2>
   <p class="govuk-body-s">{{ service.frameworkName }}</p>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-padding-top-1">Service ID</h2>

--- a/app/templates/service.html
+++ b/app/templates/service.html
@@ -76,23 +76,10 @@
 <div class="govuk-grid-row" id="service-attributes">
   <div class="govuk-grid-column-full">
     {% include '_service_attributes.html' %}
+
     <h2 class="govuk-heading-m app-summary-list-heading" id="service-documents">Service documents</h2>
-    <ul class="govuk-list">
-    {% for document in service.meta.documents %}
-      <li class="govuk-!-margin-bottom-2">
-        {{dmAttachment({
-          "link": {
-            "classes": "govuk-!-font-size-16",
-            "href": document.url,
-            "text": document.name
-          },
-          "contentType": document.extension | upper,
-          "headingTag": 'p',
-          "thumbnailSize": "small"
-        })}}
-      </li>
-    {% endfor %}
-    </ul>
+    {% include "_service_documents.html" %}
+
   </div>
 </div>
 


### PR DESCRIPTION
We want users to know who to send requests for accessible versions of service documents to, this commit adds a piece of content with guidance after all the documents. Users should direct their requests to suppliers, and suppliers should always have a public contact email address, so we use that.

We could have had this as part of the alternativeFormatHtml for each attachment component, but we thought that would have been too repetitive.