### PR TITLE
Cache framework description

### DIFF
--- a/app/main/helpers/framework_helpers.py
+++ b/app/main/helpers/framework_helpers.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from flask import abort
 
 from dmapiclient import HTTPError
@@ -34,6 +36,7 @@ def get_lots_by_slug(framework_data):
     return {lot['slug']: lot for lot in framework_data['lots']}
 
 
+@lru_cache()
 def get_framework_description(data_api_client, framework_family):
     frameworks = data_api_client.find_frameworks().get('frameworks')
     framework = get_latest_live_framework(frameworks, framework_family)


### PR DESCRIPTION
Trello: https://trello.com/c/wW4w1XQZ

We call this function very frequently - once per page for many pages. It will only ever return one of three outputs: the G-Cloud description, the DOS description, or an empty string. The description changes very infrequently. So we can improve performance significantly by caching the output of this function.

This will be useful because a scraper currently tries to scrape 1500-2000 supplier pages very quickly once every 2 hours. We want to improve the performance of the scraped pages so that we can restore the rate limits to their old higher value.

From my testing, this reduces the time taken to respond to `/g-cloud/supplier/<supplier_id>` by 32% (from 111 ms to 76 ms).

Once we've merged this, there's one more API call I think we may be able to cache, and then I'll try raising the rate limit.