### PR TITLE
bump docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-frontend:9.6.1
+FROM digitalmarketplace/base-frontend:10.0.0


### PR DESCRIPTION
https://trello.com/c/0BmkYFSD/907-3-node-10-is-eol-april-2021-upgrade-node-to-v14