### PR TITLE
labs are renamed to studios

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -189,7 +189,7 @@
           <strong>
             <a class="govuk-link"
                href="{{ url_for('external.studios_start_page', framework_slug=dos_slug) }}">
-              Find a user research lab
+              Find a user research studio
             </a>
           </strong>
           <p class="govuk-body">


### PR DESCRIPTION
https://trello.com/c/ohDPcudm/606-1-change-dos-page-title-user-research-studios
We want to rename user research labs to studios to reflect the current name of the lot.